### PR TITLE
Add full CMS autonomy skills and block-level manipulation

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "vite-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 8080
+    },
+    {
+      "name": "vite-preview",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "preview"],
+      "port": 4173
+    }
+  ]
+}

--- a/docs/OPENCLAW-LAW.md
+++ b/docs/OPENCLAW-LAW.md
@@ -155,23 +155,54 @@ All agent surfaces (interactive, autonomous, visitor chat) MUST share the same r
 
 FlowAgent interacts with platform modules through registered skills:
 
+### CMS & Content (Full Autonomy)
+
 | Module | Skills | Handler | Scope |
 |--------|--------|---------|-------|
+| **Pages** | `manage_page`, `manage_page_blocks` | `module:pages` | internal |
 | **Blog** | `write_blog_post` | `module:blog` | internal |
+| **Knowledge Base** | `manage_kb_article` | `module:kb` | internal |
+| **Global Elements** | `manage_global_blocks` | `module:globalElements` | internal |
+| **Media** | `manage_media` | `module:media` | internal |
+
+### CRM & Sales
+
+| Module | Skills | Handler | Scope |
+|--------|--------|---------|-------|
 | **CRM/Leads** | `add_lead`, `qualify_lead` | `module:crm`, `edge:qualify-lead` | both, internal |
-| **Companies** | `enrich_company` | `edge:enrich-company` | internal |
-| **Booking** | `book_appointment` | `module:booking` | both |
+| **Companies** | `manage_company`, `enrich_company` | `module:companies`, `edge:enrich-company` | internal |
+| **Deals** | `manage_deal` | `module:deals` | internal |
+| **Forms** | `manage_form_submissions` | `module:forms` | internal |
+
+### Communication
+
+| Module | Skills | Handler | Scope |
+|--------|--------|---------|-------|
 | **Newsletter** | `send_newsletter`, `execute_newsletter_send` | `module:newsletter`, `edge:newsletter-send` | internal |
-| **Analytics** | `analyze_analytics`, `weekly_business_digest` | `db:page_views`, `edge:business-digest` | internal |
+| **Webinars** | `manage_webinar` | `module:webinars` | internal |
+| **Email** | `scan_gmail_inbox` | `edge:gmail-inbox-scan` | internal |
+
+### Commerce
+
+| Module | Skills | Handler | Scope |
+|--------|--------|---------|-------|
+| **Products** | `manage_product` | `module:products` | internal |
+| **Orders** | `lookup_order` | `module:orders` | both |
+| **Booking** | `book_appointment` | `module:booking` | both |
+
+### Intelligence & Research
+
+| Module | Skills | Handler | Scope |
+|--------|--------|---------|-------|
+| **Analytics** | `analyze_analytics`, `weekly_business_digest`, `seo_audit_page`, `kb_gap_analysis` | `db:page_views`, `edge:business-digest`, `module:analytics` | internal |
 | **Content Pipeline** | `research_content`, `generate_content_proposal` | `edge:research-content`, `edge:generate-content-proposal` | internal |
 | **Sales Intelligence** | `prospect_research`, `prospect_fit_analysis` | `edge:prospect-research`, `edge:prospect-fit-analysis` | internal |
 | **Web Research** | `search_web`, `scrape_url` | `edge:web-search`, `edge:web-scrape` | internal |
-| **Email** | `scan_gmail_inbox` | `edge:gmail-inbox-scan` | internal |
-| **Scheduling** | `publish_scheduled_content` | `edge:publish-scheduled-pages` | internal |
-| **Orders** | `lookup_order` | `module:orders` | both |
-| **Learning** | `learn_from_data` | `edge:flowpilot-learn` | internal |
 | **Browser** | `browser_fetch` | `edge:browser-fetch` | internal |
+| **Scheduling** | `publish_scheduled_content` | `edge:publish-scheduled-pages` | internal |
+| **Learning** | `learn_from_data` | `edge:flowpilot-learn` | internal |
 | **Objectives** | `create_objective` | `module:objectives` | internal |
+| **Resume** | `manage_consultant_profile`, `match_consultant` | `module:resume` | internal |
 
 ### Integration-Aware Skills
 
@@ -204,6 +235,9 @@ Skills that use external providers document their provider strategy in `instruct
 - **Prompt Compiler** — `buildSystemPrompt(mode)` shared across heartbeat/operate/chat surfaces
 - **Vector Memory** — `pgvector` with 768-dim embeddings, semantic search via `search_memories_semantic()` RPC
 - **Context Pruning** — `pruneConversationHistory()` with AI-powered summarization of old messages
+- **Full CMS Autonomy** — Block-level manipulation, page lifecycle, KB articles, global elements, deals, products, companies, forms, webinars (28+ registered skills)
+- **Page Rollback** — Version history with rollback capability via `manage_page`
+- **Auto Module Activation** — Modules auto-enable when FlowPilot uses them
 
 ### ⚠️ Partially Implemented
 | Gap | OpenClaw Has | FlowWink Status | Priority |
@@ -223,8 +257,8 @@ Skills that use external providers document their provider strategy in `instruct
 ## 6. Recommended Next Steps (Priority Order)
 
 1. **Skill Packs** — Allow templates to include pre-configured skill sets (e.g., "E-commerce Pack" adds order tracking, inventory check, cart recovery skills).
-
-4. **Skill Packs** — Allow templates to include pre-configured skill sets (e.g., "E-commerce Pack" adds order tracking, inventory check, cart recovery skills).
+2. **A2A Protocol** — Implement `@a2a:agent-name` for multi-agent delegation.
+3. **Workflow DAGs** — Multi-step automation chains with conditional branching.
 
 ---
 
@@ -256,4 +290,4 @@ Skills that use external providers document their provider strategy in `instruct
 
 ---
 
-*This document supersedes all previous architectural descriptions. Updated: 2026-03-11.*
+*This document supersedes all previous architectural descriptions. Updated: 2026-03-12.*

--- a/docs/flowpilot.md
+++ b/docs/flowpilot.md
@@ -352,51 +352,68 @@ FlowAgent can modify its own behavior:
 
 ---
 
-## 5. Complete Skill Inventory (19 Default Skills)
+## 5. Complete Skill Inventory (28+ Default Skills)
 
-### Content & Research
+### CMS & Content (Full Autonomy)
 
 | Skill | Handler | Scope | Approval | Description |
 |-------|---------|-------|----------|-------------|
-| `write_blog_post` | `module:blog` | internal | ❌ | Create draft blog post with title, topic, tone |
+| `manage_page` | `module:pages` | internal | ❌ | Full page lifecycle: create, update, publish, archive, delete, rollback |
+| `manage_page_blocks` | `module:pages` | internal | ❌ | Block manipulation: add, update, remove, reorder, duplicate, toggle visibility |
+| `manage_global_blocks` | `module:globalElements` | internal | ❌ | Header, footer, sidebar management |
+| `manage_kb_article` | `module:kb` | internal | ❌ | KB article CRUD: create, update, publish, list |
+| `write_blog_post` | `module:blog` | internal | ❌ | Create draft blog post with AI content generation |
+| `publish_scheduled_content` | `edge:publish-scheduled-pages` | internal | ❌ | Auto-publish pages/posts past scheduled date |
+
+### Content Research & Pipeline
+
+| Skill | Handler | Scope | Approval | Description |
+|-------|---------|-------|----------|-------------|
 | `research_content` | `edge:research-content` | internal | ❌ | Deep AI topic research — angles, hooks, competitive landscape |
 | `generate_content_proposal` | `edge:generate-content-proposal` | internal | ✅ | Multi-channel content generation (blog, newsletter, LinkedIn, X) |
-| `publish_scheduled_content` | `edge:publish-scheduled-pages` | internal | ❌ | Auto-publish pages/posts past their scheduled date |
-| `search_web` | `edge:firecrawl-search` | internal | ❌ | Web search for research and content ideas |
+| `search_web` | `edge:web-search` | internal | ❌ | Web search (Jina free / Firecrawl paid) |
+| `scrape_url` | `edge:web-scrape` | internal | ❌ | URL scraping (Jina free / Firecrawl paid) |
 
-### CRM & Sales Intelligence
+### CRM & Sales
 
 | Skill | Handler | Scope | Approval | Description |
 |-------|---------|-------|----------|-------------|
 | `add_lead` | `module:crm` | both | ❌ | Add lead to CRM from any source |
-| `qualify_lead` | `edge:qualify-lead` | internal | ❌ | AI lead scoring — analyzes activities, company data, engagement |
-| `enrich_company` | `edge:enrich-company` | internal | ❌ | Domain-based company enrichment via Firecrawl + AI |
-| `prospect_research` | `edge:prospect-research` | internal | ❌ | Company research + Hunter.io contact discovery |
-| `prospect_fit_analysis` | `edge:prospect-fit-analysis` | internal | ❌ | AI prospect-company fit scoring against ICP |
+| `qualify_lead` | `edge:qualify-lead` | internal | ❌ | AI lead scoring |
+| `manage_company` | `module:companies` | internal | ❌ | Company CRUD |
+| `enrich_company` | `edge:enrich-company` | internal | ❌ | Domain-based company enrichment |
+| `manage_deal` | `module:deals` | internal | ❌ | Sales pipeline: create, update, move stage |
+| `manage_form_submissions` | `module:forms` | internal | ❌ | Form submission access and stats |
+| `prospect_research` | `edge:prospect-research` | internal | ❌ | Company research + contact discovery |
+| `prospect_fit_analysis` | `edge:prospect-fit-analysis` | internal | ❌ | AI prospect-company fit scoring |
 
 ### Communication
 
 | Skill | Handler | Scope | Approval | Description |
 |-------|---------|-------|----------|-------------|
 | `send_newsletter` | `module:newsletter` | internal | ✅ | Create newsletter draft or schedule |
-| `execute_newsletter_send` | `edge:newsletter-send` | internal | ✅ | Actually send newsletter to subscribers via Resend |
-| `scan_gmail_inbox` | `edge:gmail-inbox-scan` | internal | ❌ | Scan Gmail for business signals (leads, inquiries) |
+| `execute_newsletter_send` | `edge:newsletter-send` | internal | ✅ | Send newsletter via Resend |
+| `manage_webinar` | `module:webinars` | internal | ❌ | Webinar CRUD with platform integration |
+| `scan_gmail_inbox` | `edge:gmail-inbox-scan` | internal | ❌ | Scan Gmail for business signals |
 
-### Operations
+### Commerce & Operations
 
 | Skill | Handler | Scope | Approval | Description |
 |-------|---------|-------|----------|-------------|
+| `manage_product` | `module:products` | internal | ❌ | Product catalog CRUD |
+| `lookup_order` | `module:orders` | both | ❌ | Order lookup by ID or email |
 | `book_appointment` | `module:booking` | both | ❌ | Create booking for customer |
-| `lookup_order` | `module:orders` | both | ❌ | Look up order by ID or email |
-| `create_objective` | `module:objectives` | internal | ❌ | Create high-level goal for autonomous operation |
+| `create_objective` | `module:objectives` | internal | ❌ | Create high-level goal |
 
 ### Analytics & Learning
 
 | Skill | Handler | Scope | Approval | Description |
 |-------|---------|-------|----------|-------------|
-| `analyze_analytics` | `db:page_views` | internal | ❌ | Page view analytics by period |
-| `weekly_business_digest` | `edge:business-digest` | internal | ❌ | Cross-module business summary (views, leads, bookings, orders) |
-| `learn_from_data` | `edge:flowpilot-learn` | internal | ❌ | Distill platform data into persistent memory insights |
+| `analyze_analytics` | `db:page_views` | internal | ❌ | Page view analytics |
+| `seo_audit_page` | `module:analytics` | internal | ❌ | SEO audit for any page/post |
+| `kb_gap_analysis` | `module:analytics` | internal | ❌ | KB coverage gap analysis |
+| `weekly_business_digest` | `edge:business-digest` | internal | ❌ | Cross-module business summary |
+| `learn_from_data` | `edge:flowpilot-learn` | internal | ❌ | Distill platform data into memory |
 
 ### Objective Progress Auto-Tracking
 
@@ -555,15 +572,22 @@ error_message → if failed
 
 | Capability | Status |
 |-----------|--------|
-| Skill Engine | ✅ 100% |
-| Persistent Memory | ✅ 100% |
+| Skill Engine (28+ skills) | ✅ 100% |
+| Persistent Memory (pgvector) | ✅ 100% |
 | Objectives & Plan Decomposition | ✅ 100% |
 | Priority Scoring | ✅ 100% |
 | Self-Healing | ✅ 100% |
+| Prompt Compiler | ✅ 100% |
+| Context Pruning | ✅ 100% |
+| CMS Content Autonomy (pages, blocks, KB, global) | ✅ 100% |
+| CRM Autonomy (leads, companies, deals, forms) | ✅ 100% |
+| Commerce Autonomy (products, orders, bookings) | ✅ 100% |
+| Communication (newsletter, webinars, gmail) | ✅ 95% |
 | Signal Automations | ✅ 95% |
 | Signal Ingest (External) | ✅ 90% |
 | Self-Evolution (soul, skill_instruct, propose_objective) | ✅ 90% |
-| Proactive Goal Setting | ✅ 85% |
+| Proactive Goal Setting | ✅ 90% |
+| Provider Routing (free-first) | ✅ 90% |
 | Multi-Agent Orchestration (A2A) | 🔧 40% |
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "react-helmet-async": "^2.0.5",
         "react-hook-form": "^7.61.1",
         "react-image-crop": "^11.0.10",
+        "react-markdown": "^10.1.0",
         "react-resizable-panels": "^2.1.9",
         "react-router-dom": "^6.30.1",
         "recharts": "^2.15.4",
@@ -4042,6 +4043,15 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4053,6 +4063,24 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -4077,10 +4105,25 @@
         "@types/mdurl": "^2"
       }
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -4122,6 +4165,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -4447,6 +4496,12 @@
         "react-dom": ">=17.0.0"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.11.0.tgz",
@@ -4741,6 +4796,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4865,6 +4930,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -4889,6 +4964,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -4997,6 +5112,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -5264,6 +5389,19 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5276,7 +5414,6 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5286,6 +5423,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -5631,6 +5781,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -5664,6 +5824,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5905,6 +6071,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -5915,6 +6121,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -6010,6 +6226,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/input-otp": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
@@ -6036,6 +6258,30 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-binary-path": {
@@ -6065,6 +6311,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6086,6 +6342,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6093,6 +6359,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -6320,6 +6598,16 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -6829,6 +7117,159 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
@@ -6849,6 +7290,448 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -7077,6 +7960,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -7390,6 +8298,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/prosemirror-changeset": {
       "version": "2.3.1",
@@ -7714,6 +8632,33 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
@@ -7949,6 +8894,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -8165,6 +9143,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -8184,6 +9172,20 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-indent": {
@@ -8216,6 +9218,24 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -8447,6 +9467,26 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -8534,6 +9574,93 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -8645,6 +9772,34 @@
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/victory-vendor": {
@@ -9480,6 +10635,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/supabase/functions/agent-execute/index.ts
+++ b/supabase/functions/agent-execute/index.ts
@@ -262,6 +262,13 @@ const MODULE_HANDLER_TO_SETTING: Record<string, string> = {
   products: 'products',
   media: 'media',
   resume: 'resume',
+  pages: 'pages',
+  kb: 'knowledgeBase',
+  globalElements: 'globalElements',
+  deals: 'deals',
+  companies: 'companies',
+  forms: 'forms',
+  webinars: 'webinars',
 };
 
 async function autoActivateModule(
@@ -546,6 +553,38 @@ async function executeModuleAction(
       return await executeResumeAction(supabase, skillName, args);
     }
 
+    case 'pages': {
+      return await executePagesAction(supabase, skillName, args);
+    }
+
+    case 'kb': {
+      return await executeKbAction(supabase, skillName, args);
+    }
+
+    case 'globalElements': {
+      return await executeGlobalBlocksAction(supabase, skillName, args);
+    }
+
+    case 'deals': {
+      return await executeDealsAction(supabase, skillName, args);
+    }
+
+    case 'products': {
+      return await executeProductsAction(supabase, skillName, args);
+    }
+
+    case 'companies': {
+      return await executeCompaniesAction(supabase, skillName, args);
+    }
+
+    case 'forms': {
+      return await executeFormsAction(supabase, skillName, args);
+    }
+
+    case 'webinars': {
+      return await executeWebinarsAction(supabase, skillName, args);
+    }
+
     default:
       return { error: `Unknown module: ${moduleName}` };
   }
@@ -612,6 +651,648 @@ async function executeResumeAction(
     default:
       return { error: `Unknown resume skill: ${skillName}` };
   }
+}
+
+// =============================================================================
+// Pages module — full page lifecycle + block manipulation
+// =============================================================================
+
+async function executePagesAction(
+  supabase: SupabaseClient,
+  skillName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  switch (skillName) {
+    case 'manage_page': {
+      const { action = 'list', page_id, slug, title, status, meta, blocks } = args as any;
+
+      if (action === 'list') {
+        let query = supabase.from('pages')
+          .select('id, title, slug, status, menu_order, created_at, updated_at')
+          .is('deleted_at', null)
+          .order('updated_at', { ascending: false })
+          .limit(50);
+        if (status) query = query.eq('status', status);
+        const { data, error } = await query;
+        if (error) throw new Error(`List pages failed: ${error.message}`);
+        return { pages: data || [] };
+      }
+
+      if (action === 'get') {
+        let query = supabase.from('pages')
+          .select('id, title, slug, status, content_json, meta_json, menu_order, created_at, updated_at');
+        if (page_id) query = query.eq('id', page_id);
+        else if (slug) query = query.eq('slug', slug);
+        else throw new Error('page_id or slug required');
+        const { data, error } = await query.is('deleted_at', null).single();
+        if (error) throw new Error(`Get page failed: ${error.message}`);
+        const blockSummary = (data.content_json as any[] || []).map((b: any, i: number) => ({
+          index: i, id: b.id, type: b.type, hidden: b.hidden || false,
+        }));
+        return { ...data, block_count: blockSummary.length, block_summary: blockSummary };
+      }
+
+      if (action === 'create') {
+        if (!title) throw new Error('title is required');
+        const pageSlug = slug || title.toLowerCase().replace(/[^a-z0-9åäö]+/g, '-').replace(/(^-|-$)/g, '');
+        const { data, error } = await supabase.from('pages').insert({
+          title,
+          slug: pageSlug,
+          status: 'draft',
+          content_json: blocks || [],
+          meta_json: meta || {},
+        }).select('id, title, slug, status').single();
+        if (error) throw new Error(`Create page failed: ${error.message}`);
+        return { page_id: data.id, slug: data.slug, title: data.title, status: 'draft' };
+      }
+
+      if (action === 'update' && page_id) {
+        const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+        if (title !== undefined) updates.title = title;
+        if (slug !== undefined) updates.slug = slug;
+        if (meta !== undefined) updates.meta_json = meta;
+        if (blocks !== undefined) updates.content_json = blocks;
+        const { data, error } = await supabase.from('pages')
+          .update(updates).eq('id', page_id).select('id, title, slug, status').single();
+        if (error) throw new Error(`Update page failed: ${error.message}`);
+        return { page_id: data.id, status: 'updated' };
+      }
+
+      if (action === 'publish' && page_id) {
+        // Save version before publishing
+        const { data: current } = await supabase.from('pages')
+          .select('title, content_json, meta_json').eq('id', page_id).single();
+        if (current) {
+          await supabase.from('page_versions').insert({
+            page_id, title: current.title,
+            content_json: current.content_json, meta_json: current.meta_json,
+          });
+        }
+        const { data, error } = await supabase.from('pages')
+          .update({ status: 'published', updated_at: new Date().toISOString() })
+          .eq('id', page_id).select('id, title, slug, status').single();
+        if (error) throw new Error(`Publish failed: ${error.message}`);
+        return { page_id: data.id, slug: data.slug, status: 'published' };
+      }
+
+      if (action === 'archive' && page_id) {
+        const { data, error } = await supabase.from('pages')
+          .update({ status: 'archived', updated_at: new Date().toISOString() })
+          .eq('id', page_id).select('id, title, status').single();
+        if (error) throw new Error(`Archive failed: ${error.message}`);
+        return { page_id: data.id, status: 'archived' };
+      }
+
+      if (action === 'delete' && page_id) {
+        const { error } = await supabase.from('pages')
+          .update({ deleted_at: new Date().toISOString() })
+          .eq('id', page_id);
+        if (error) throw new Error(`Delete failed: ${error.message}`);
+        return { page_id, status: 'deleted' };
+      }
+
+      if (action === 'rollback' && page_id) {
+        const { version_id } = args as any;
+        let query = supabase.from('page_versions')
+          .select('id, title, content_json, meta_json, created_at')
+          .eq('page_id', page_id)
+          .order('created_at', { ascending: false });
+        if (version_id) query = query.eq('id', version_id);
+        const { data: version } = await query.limit(1).single();
+        if (!version) throw new Error('No version found to rollback to');
+        // Save current state as new version before rollback
+        const { data: current } = await supabase.from('pages')
+          .select('title, content_json, meta_json').eq('id', page_id).single();
+        if (current) {
+          await supabase.from('page_versions').insert({
+            page_id, title: current.title,
+            content_json: current.content_json, meta_json: current.meta_json,
+          });
+        }
+        await supabase.from('pages').update({
+          title: version.title, content_json: version.content_json,
+          meta_json: version.meta_json, updated_at: new Date().toISOString(),
+        }).eq('id', page_id);
+        return { page_id, rolled_back_to: version.id, version_date: version.created_at };
+      }
+
+      return { error: `Unknown page action: ${action}` };
+    }
+
+    case 'manage_page_blocks': {
+      const { action = 'list', page_id } = args as any;
+      if (!page_id) throw new Error('page_id is required');
+
+      // Fetch current page blocks
+      const { data: page, error: fetchErr } = await supabase.from('pages')
+        .select('id, content_json').eq('id', page_id).is('deleted_at', null).single();
+      if (fetchErr || !page) throw new Error(`Page not found: ${page_id}`);
+
+      const blocks = (page.content_json as any[]) || [];
+
+      if (action === 'list') {
+        return {
+          page_id,
+          block_count: blocks.length,
+          blocks: blocks.map((b: any, i: number) => ({
+            index: i, id: b.id, type: b.type, hidden: b.hidden || false,
+            has_data: !!b.data && Object.keys(b.data).length > 0,
+          })),
+        };
+      }
+
+      if (action === 'add') {
+        const { block_type, block_data = {}, position } = args as any;
+        if (!block_type) throw new Error('block_type is required');
+        const newBlock = {
+          id: crypto.randomUUID(),
+          type: block_type,
+          data: block_data,
+          spacing: {},
+          animation: { type: 'fade-up' },
+        };
+        const pos = position !== undefined ? Math.min(position, blocks.length) : blocks.length;
+        blocks.splice(pos, 0, newBlock);
+        await supabase.from('pages')
+          .update({ content_json: blocks, updated_at: new Date().toISOString() })
+          .eq('id', page_id);
+        return { page_id, block_id: newBlock.id, type: block_type, position: pos, total_blocks: blocks.length };
+      }
+
+      if (action === 'update') {
+        const { block_id, block_data } = args as any;
+        if (!block_id || !block_data) throw new Error('block_id and block_data required');
+        const idx = blocks.findIndex((b: any) => b.id === block_id);
+        if (idx === -1) throw new Error(`Block not found: ${block_id}`);
+        blocks[idx] = { ...blocks[idx], data: { ...blocks[idx].data, ...block_data } };
+        await supabase.from('pages')
+          .update({ content_json: blocks, updated_at: new Date().toISOString() })
+          .eq('id', page_id);
+        return { page_id, block_id, type: blocks[idx].type, status: 'updated' };
+      }
+
+      if (action === 'remove') {
+        const { block_id } = args as any;
+        if (!block_id) throw new Error('block_id is required');
+        const idx = blocks.findIndex((b: any) => b.id === block_id);
+        if (idx === -1) throw new Error(`Block not found: ${block_id}`);
+        const removed = blocks.splice(idx, 1)[0];
+        await supabase.from('pages')
+          .update({ content_json: blocks, updated_at: new Date().toISOString() })
+          .eq('id', page_id);
+        return { page_id, removed_block_id: removed.id, removed_type: removed.type, remaining_blocks: blocks.length };
+      }
+
+      if (action === 'reorder') {
+        const { block_ids } = args as any;
+        if (!Array.isArray(block_ids)) throw new Error('block_ids array is required');
+        const reordered: any[] = [];
+        for (const bid of block_ids) {
+          const block = blocks.find((b: any) => b.id === bid);
+          if (block) reordered.push(block);
+        }
+        // Append any blocks not in the reorder list at the end
+        for (const b of blocks) {
+          if (!block_ids.includes(b.id)) reordered.push(b);
+        }
+        await supabase.from('pages')
+          .update({ content_json: reordered, updated_at: new Date().toISOString() })
+          .eq('id', page_id);
+        return { page_id, new_order: reordered.map((b: any) => b.id), total_blocks: reordered.length };
+      }
+
+      if (action === 'toggle_visibility') {
+        const { block_id } = args as any;
+        if (!block_id) throw new Error('block_id is required');
+        const idx = blocks.findIndex((b: any) => b.id === block_id);
+        if (idx === -1) throw new Error(`Block not found: ${block_id}`);
+        blocks[idx].hidden = !blocks[idx].hidden;
+        await supabase.from('pages')
+          .update({ content_json: blocks, updated_at: new Date().toISOString() })
+          .eq('id', page_id);
+        return { page_id, block_id, hidden: blocks[idx].hidden };
+      }
+
+      if (action === 'duplicate') {
+        const { block_id } = args as any;
+        if (!block_id) throw new Error('block_id is required');
+        const idx = blocks.findIndex((b: any) => b.id === block_id);
+        if (idx === -1) throw new Error(`Block not found: ${block_id}`);
+        const clone = JSON.parse(JSON.stringify(blocks[idx]));
+        clone.id = crypto.randomUUID();
+        blocks.splice(idx + 1, 0, clone);
+        await supabase.from('pages')
+          .update({ content_json: blocks, updated_at: new Date().toISOString() })
+          .eq('id', page_id);
+        return { page_id, original_block_id: block_id, new_block_id: clone.id, position: idx + 1 };
+      }
+
+      return { error: `Unknown block action: ${action}` };
+    }
+
+    default:
+      return { error: `Unknown pages skill: ${skillName}` };
+  }
+}
+
+// =============================================================================
+// Knowledge Base module handlers
+// =============================================================================
+
+async function executeKbAction(
+  supabase: SupabaseClient,
+  skillName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const { action = 'list' } = args as any;
+
+  if (action === 'list') {
+    const { category, is_published } = args as any;
+    let query = supabase.from('kb_articles')
+      .select('id, title, slug, question, category, is_published, is_featured, views_count, helpful_count, not_helpful_count, created_at, updated_at')
+      .order('updated_at', { ascending: false }).limit(50);
+    if (category) query = query.eq('category', category);
+    if (is_published !== undefined) query = query.eq('is_published', is_published);
+    const { data, error } = await query;
+    if (error) throw new Error(`List KB articles failed: ${error.message}`);
+    return { articles: data || [] };
+  }
+
+  if (action === 'get') {
+    const { article_id, slug } = args as any;
+    let query = supabase.from('kb_articles')
+      .select('*');
+    if (article_id) query = query.eq('id', article_id);
+    else if (slug) query = query.eq('slug', slug);
+    else throw new Error('article_id or slug required');
+    const { data, error } = await query.single();
+    if (error) throw new Error(`Get KB article failed: ${error.message}`);
+    return data;
+  }
+
+  if (action === 'create') {
+    const { title, question, answer, category = 'general', include_in_chat = true, is_featured = false, content } = args as any;
+    if (!title || !question) throw new Error('title and question are required');
+    const articleSlug = title.toLowerCase().replace(/[^a-z0-9åäö]+/g, '-').replace(/(^-|-$)/g, '');
+
+    // Convert markdown answer to Tiptap if needed
+    let answerContent = answer;
+    if (typeof answer === 'string' && !content) {
+      answerContent = answer;
+    }
+
+    const { data, error } = await supabase.from('kb_articles').insert({
+      title, question, answer: answerContent || '',
+      slug: articleSlug, category,
+      include_in_chat, is_featured,
+      is_published: false,
+      content_json: content || null,
+    }).select('id, title, slug, category, is_published').single();
+    if (error) throw new Error(`Create KB article failed: ${error.message}`);
+    return { article_id: data.id, slug: data.slug, title: data.title, status: 'draft' };
+  }
+
+  if (action === 'update') {
+    const { article_id, ...updateData } = args as any;
+    if (!article_id) throw new Error('article_id is required');
+    delete updateData.action;
+    const { data, error } = await supabase.from('kb_articles')
+      .update({ ...updateData, updated_at: new Date().toISOString() })
+      .eq('id', article_id).select('id, title, is_published').single();
+    if (error) throw new Error(`Update KB article failed: ${error.message}`);
+    return { article_id: data.id, title: data.title, status: 'updated' };
+  }
+
+  if (action === 'publish') {
+    const { article_id } = args as any;
+    if (!article_id) throw new Error('article_id is required');
+    const { data, error } = await supabase.from('kb_articles')
+      .update({ is_published: true, updated_at: new Date().toISOString() })
+      .eq('id', article_id).select('id, title, slug').single();
+    if (error) throw new Error(`Publish failed: ${error.message}`);
+    return { article_id: data.id, slug: data.slug, status: 'published' };
+  }
+
+  if (action === 'unpublish') {
+    const { article_id } = args as any;
+    if (!article_id) throw new Error('article_id is required');
+    const { data, error } = await supabase.from('kb_articles')
+      .update({ is_published: false, updated_at: new Date().toISOString() })
+      .eq('id', article_id).select('id, title').single();
+    if (error) throw new Error(`Unpublish failed: ${error.message}`);
+    return { article_id: data.id, status: 'unpublished' };
+  }
+
+  return { error: `Unknown KB action: ${action}` };
+}
+
+// =============================================================================
+// Global Blocks module handlers
+// =============================================================================
+
+async function executeGlobalBlocksAction(
+  supabase: SupabaseClient,
+  _skillName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const { action = 'list', slot, block_data } = args as any;
+
+  if (action === 'list') {
+    const { data, error } = await supabase.from('global_blocks')
+      .select('id, slot, type, data, is_active, updated_at');
+    if (error) throw new Error(`List global blocks failed: ${error.message}`);
+    return { global_blocks: data || [] };
+  }
+
+  if (action === 'get' && slot) {
+    const { data, error } = await supabase.from('global_blocks')
+      .select('*').eq('slot', slot).maybeSingle();
+    if (error) throw new Error(`Get global block failed: ${error.message}`);
+    return data || { slot, exists: false };
+  }
+
+  if (action === 'update' && slot) {
+    if (!block_data) throw new Error('block_data is required');
+    const { data: existing } = await supabase.from('global_blocks')
+      .select('id, data').eq('slot', slot).maybeSingle();
+
+    if (existing) {
+      const mergedData = { ...existing.data, ...block_data };
+      const { data, error } = await supabase.from('global_blocks')
+        .update({ data: mergedData, updated_at: new Date().toISOString() })
+        .eq('id', existing.id).select('id, slot, type').single();
+      if (error) throw new Error(`Update global block failed: ${error.message}`);
+      return { id: data.id, slot: data.slot, status: 'updated' };
+    } else {
+      const { block_type = slot === 'header' ? 'header' : 'footer' } = args as any;
+      const { data, error } = await supabase.from('global_blocks').insert({
+        slot, type: block_type, data: block_data, is_active: true,
+      }).select('id, slot, type').single();
+      if (error) throw new Error(`Create global block failed: ${error.message}`);
+      return { id: data.id, slot: data.slot, status: 'created' };
+    }
+  }
+
+  if (action === 'toggle' && slot) {
+    const { data: existing } = await supabase.from('global_blocks')
+      .select('id, is_active').eq('slot', slot).single();
+    if (!existing) throw new Error(`No global block in slot: ${slot}`);
+    const { data, error } = await supabase.from('global_blocks')
+      .update({ is_active: !existing.is_active, updated_at: new Date().toISOString() })
+      .eq('id', existing.id).select('id, slot, is_active').single();
+    if (error) throw new Error(`Toggle failed: ${error.message}`);
+    return { id: data.id, slot: data.slot, is_active: data.is_active };
+  }
+
+  return { error: `Unknown global blocks action: ${action}` };
+}
+
+// =============================================================================
+// Deals module handlers
+// =============================================================================
+
+async function executeDealsAction(
+  supabase: SupabaseClient,
+  _skillName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const { action = 'list' } = args as any;
+
+  if (action === 'list') {
+    const { stage, lead_id } = args as any;
+    let query = supabase.from('deals')
+      .select('id, title, value_cents, currency, stage, lead_id, company_id, expected_close_date, created_at, updated_at')
+      .order('updated_at', { ascending: false }).limit(50);
+    if (stage) query = query.eq('stage', stage);
+    if (lead_id) query = query.eq('lead_id', lead_id);
+    const { data, error } = await query;
+    if (error) throw new Error(`List deals failed: ${error.message}`);
+    return { deals: data || [] };
+  }
+
+  if (action === 'create') {
+    const { title, value_cents, currency = 'SEK', stage = 'proposal', lead_id, company_id, expected_close_date } = args as any;
+    if (!title) throw new Error('title is required');
+    const { data, error } = await supabase.from('deals').insert({
+      title, value_cents, currency, stage, lead_id, company_id, expected_close_date,
+    }).select('id, title, stage, value_cents').single();
+    if (error) throw new Error(`Create deal failed: ${error.message}`);
+    return { deal_id: data.id, title: data.title, stage: data.stage, value_cents: data.value_cents };
+  }
+
+  if (action === 'update') {
+    const { deal_id, ...updateData } = args as any;
+    if (!deal_id) throw new Error('deal_id is required');
+    delete updateData.action;
+    const { data, error } = await supabase.from('deals')
+      .update({ ...updateData, updated_at: new Date().toISOString() })
+      .eq('id', deal_id).select('id, title, stage').single();
+    if (error) throw new Error(`Update deal failed: ${error.message}`);
+    return { deal_id: data.id, title: data.title, stage: data.stage, status: 'updated' };
+  }
+
+  if (action === 'move_stage') {
+    const { deal_id, stage } = args as any;
+    if (!deal_id || !stage) throw new Error('deal_id and stage required');
+    const completed_at = ['closed_won', 'closed_lost'].includes(stage) ? new Date().toISOString() : null;
+    const { data, error } = await supabase.from('deals')
+      .update({ stage, completed_at, updated_at: new Date().toISOString() })
+      .eq('id', deal_id).select('id, title, stage').single();
+    if (error) throw new Error(`Move stage failed: ${error.message}`);
+    return { deal_id: data.id, title: data.title, new_stage: data.stage };
+  }
+
+  return { error: `Unknown deals action: ${action}` };
+}
+
+// =============================================================================
+// Products module handlers
+// =============================================================================
+
+async function executeProductsAction(
+  supabase: SupabaseClient,
+  _skillName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const { action = 'list' } = args as any;
+
+  if (action === 'list') {
+    const { is_active } = args as any;
+    let query = supabase.from('products')
+      .select('id, name, slug, description, price_cents, currency, type, is_active, created_at')
+      .order('created_at', { ascending: false }).limit(50);
+    if (is_active !== undefined) query = query.eq('is_active', is_active);
+    const { data, error } = await query;
+    if (error) throw new Error(`List products failed: ${error.message}`);
+    return { products: data || [] };
+  }
+
+  if (action === 'create') {
+    const { name, description, price_cents, currency = 'SEK', type = 'one_time', slug, image_url, stripe_price_id } = args as any;
+    if (!name || price_cents === undefined) throw new Error('name and price_cents required');
+    const productSlug = slug || name.toLowerCase().replace(/[^a-z0-9åäö]+/g, '-').replace(/(^-|-$)/g, '');
+    const { data, error } = await supabase.from('products').insert({
+      name, slug: productSlug, description, price_cents, currency, type,
+      image_url, stripe_price_id, is_active: true,
+    }).select('id, name, slug, price_cents').single();
+    if (error) throw new Error(`Create product failed: ${error.message}`);
+    return { product_id: data.id, name: data.name, slug: data.slug, price_cents: data.price_cents };
+  }
+
+  if (action === 'update') {
+    const { product_id, ...updateData } = args as any;
+    if (!product_id) throw new Error('product_id is required');
+    delete updateData.action;
+    const { data, error } = await supabase.from('products')
+      .update({ ...updateData, updated_at: new Date().toISOString() })
+      .eq('id', product_id).select('id, name, is_active').single();
+    if (error) throw new Error(`Update product failed: ${error.message}`);
+    return { product_id: data.id, name: data.name, status: 'updated' };
+  }
+
+  return { error: `Unknown products action: ${action}` };
+}
+
+// =============================================================================
+// Companies module handlers
+// =============================================================================
+
+async function executeCompaniesAction(
+  supabase: SupabaseClient,
+  _skillName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const { action = 'list' } = args as any;
+
+  if (action === 'list') {
+    const { data, error } = await supabase.from('companies')
+      .select('id, name, domain, industry, size, city, country, created_at')
+      .order('created_at', { ascending: false }).limit(50);
+    if (error) throw new Error(`List companies failed: ${error.message}`);
+    return { companies: data || [] };
+  }
+
+  if (action === 'create') {
+    const { name, domain, industry, size, city, country, website, description } = args as any;
+    if (!name) throw new Error('name is required');
+    const { data, error } = await supabase.from('companies').insert({
+      name, domain, industry, size, city, country, website, description,
+    }).select('id, name, domain').single();
+    if (error) throw new Error(`Create company failed: ${error.message}`);
+    return { company_id: data.id, name: data.name, domain: data.domain };
+  }
+
+  if (action === 'update') {
+    const { company_id, ...updateData } = args as any;
+    if (!company_id) throw new Error('company_id is required');
+    delete updateData.action;
+    const { data, error } = await supabase.from('companies')
+      .update({ ...updateData, updated_at: new Date().toISOString() })
+      .eq('id', company_id).select('id, name').single();
+    if (error) throw new Error(`Update company failed: ${error.message}`);
+    return { company_id: data.id, name: data.name, status: 'updated' };
+  }
+
+  return { error: `Unknown companies action: ${action}` };
+}
+
+// =============================================================================
+// Forms module handlers
+// =============================================================================
+
+async function executeFormsAction(
+  supabase: SupabaseClient,
+  _skillName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const { action = 'list' } = args as any;
+
+  if (action === 'list') {
+    const { data, error } = await supabase.from('form_submissions')
+      .select('id, form_name, data, page_slug, status, created_at')
+      .order('created_at', { ascending: false }).limit(50);
+    if (error) throw new Error(`List submissions failed: ${error.message}`);
+    return { submissions: data || [] };
+  }
+
+  if (action === 'get') {
+    const { submission_id } = args as any;
+    if (!submission_id) throw new Error('submission_id is required');
+    const { data, error } = await supabase.from('form_submissions')
+      .select('*').eq('id', submission_id).single();
+    if (error) throw new Error(`Get submission failed: ${error.message}`);
+    return data;
+  }
+
+  if (action === 'update_status') {
+    const { submission_id, status } = args as any;
+    if (!submission_id || !status) throw new Error('submission_id and status required');
+    const { data, error } = await supabase.from('form_submissions')
+      .update({ status }).eq('id', submission_id).select('id, status').single();
+    if (error) throw new Error(`Update status failed: ${error.message}`);
+    return { submission_id: data.id, status: data.status };
+  }
+
+  if (action === 'stats') {
+    const since = new Date();
+    since.setDate(since.getDate() - 30);
+    const { data, error } = await supabase.from('form_submissions')
+      .select('form_name, status, created_at')
+      .gte('created_at', since.toISOString());
+    if (error) throw new Error(`Form stats failed: ${error.message}`);
+    const submissions = data || [];
+    const byForm: Record<string, number> = {};
+    for (const s of submissions) {
+      byForm[s.form_name || 'unknown'] = (byForm[s.form_name || 'unknown'] || 0) + 1;
+    }
+    return { period_days: 30, total: submissions.length, by_form: byForm };
+  }
+
+  return { error: `Unknown forms action: ${action}` };
+}
+
+// =============================================================================
+// Webinars module handlers
+// =============================================================================
+
+async function executeWebinarsAction(
+  supabase: SupabaseClient,
+  _skillName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const { action = 'list' } = args as any;
+
+  if (action === 'list') {
+    const { data, error } = await supabase.from('webinars')
+      .select('id, title, description, scheduled_at, platform, meeting_url, status, max_attendees, created_at')
+      .order('scheduled_at', { ascending: false }).limit(50);
+    if (error) throw new Error(`List webinars failed: ${error.message}`);
+    return { webinars: data || [] };
+  }
+
+  if (action === 'create') {
+    const { title, description, scheduled_at, platform = 'google_meet', meeting_url, max_attendees } = args as any;
+    if (!title || !scheduled_at) throw new Error('title and scheduled_at required');
+    const { data, error } = await supabase.from('webinars').insert({
+      title, description, scheduled_at, platform, meeting_url,
+      max_attendees, status: 'upcoming',
+    }).select('id, title, scheduled_at, status').single();
+    if (error) throw new Error(`Create webinar failed: ${error.message}`);
+    return { webinar_id: data.id, title: data.title, scheduled_at: data.scheduled_at };
+  }
+
+  if (action === 'update') {
+    const { webinar_id, ...updateData } = args as any;
+    if (!webinar_id) throw new Error('webinar_id is required');
+    delete updateData.action;
+    const { data, error } = await supabase.from('webinars')
+      .update({ ...updateData, updated_at: new Date().toISOString() })
+      .eq('id', webinar_id).select('id, title, status').single();
+    if (error) throw new Error(`Update webinar failed: ${error.message}`);
+    return { webinar_id: data.id, title: data.title, status: 'updated' };
+  }
+
+  return { error: `Unknown webinars action: ${action}` };
 }
 
 async function executeDbAction(
@@ -991,17 +1672,30 @@ async function logActivity(
 
 // Maps skill names to objective keywords they contribute to
 const SKILL_OBJECTIVE_MAP: Record<string, string[]> = {
+  // Content & Pages
   write_blog_post: ['blog', 'content', 'publish', 'article'],
-  create_page_block: ['page', 'content', 'website'],
+  manage_page: ['page', 'content', 'website', 'publish', 'landing'],
+  manage_page_blocks: ['page', 'block', 'content', 'website', 'design', 'layout'],
+  manage_global_blocks: ['header', 'footer', 'navigation', 'branding', 'global'],
+  manage_kb_article: ['knowledge', 'support', 'faq', 'article', 'kb', 'help'],
+  // Communication
   send_newsletter: ['newsletter', 'email', 'subscriber', 'engagement'],
   execute_newsletter_send: ['newsletter', 'email', 'campaign', 'engagement'],
+  manage_webinar: ['webinar', 'event', 'presentation', 'training'],
+  // CRM & Sales
   add_lead: ['lead', 'crm', 'sales', 'pipeline'],
   qualify_lead: ['lead', 'qualify', 'score', 'crm', 'sales'],
   enrich_company: ['company', 'enrich', 'crm', 'data'],
+  manage_company: ['company', 'crm', 'account', 'client'],
+  manage_deal: ['deal', 'pipeline', 'sales', 'revenue', 'negotiation'],
   prospect_research: ['prospect', 'research', 'sales', 'lead'],
   prospect_fit_analysis: ['prospect', 'fit', 'sales', 'pipeline'],
+  // Commerce
+  manage_product: ['product', 'commerce', 'pricing', 'catalog', 'shop'],
+  manage_form_submissions: ['form', 'submission', 'lead', 'feedback'],
   create_campaign: ['campaign', 'marketing', 'engagement'],
   book_appointment: ['booking', 'appointment', 'calendar'],
+  // Analytics & Research
   analyze_analytics: ['analytics', 'traffic', 'performance', 'growth'],
   weekly_business_digest: ['digest', 'report', 'overview'],
   search_web: ['research', 'content'],
@@ -1012,8 +1706,10 @@ const SKILL_OBJECTIVE_MAP: Record<string, string[]> = {
   learn_from_data: ['learn', 'insight', 'analytics', 'performance'],
   seo_audit_page: ['seo', 'content', 'page', 'traffic', 'search', 'performance'],
   kb_gap_analysis: ['knowledge', 'support', 'chat', 'content', 'article', 'kb'],
+  // Resume & Talent
   manage_consultant_profile: ['resume', 'consultant', 'profile', 'talent'],
   match_consultant: ['resume', 'consultant', 'match', 'talent', 'recruitment'],
+  // Utilities
   extract_pdf_text: ['pdf', 'document', 'extract', 'content', 'resume', 'report', 'contract'],
   competitor_monitor: ['competitor', 'market', 'positioning', 'content', 'intelligence'],
   generate_social_post: ['social', 'linkedin', 'content', 'authority', 'engagement', 'repurpose'],

--- a/supabase/migrations/20260312000001_register_cms_autonomy_skills.sql
+++ b/supabase/migrations/20260312000001_register_cms_autonomy_skills.sql
@@ -1,0 +1,176 @@
+-- =============================================================================
+-- Register CMS Autonomy Skills — FlowPilot 9/10
+-- Adds block-level, page lifecycle, KB, global blocks, deals, products,
+-- companies, forms, and webinar skills for full CMS autonomy.
+-- =============================================================================
+
+-- 1. manage_page — Full page lifecycle
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.agent_skills WHERE name = 'manage_page') THEN
+    INSERT INTO public.agent_skills (name, description, handler, category, scope, requires_approval, enabled, instructions, tool_definition)
+    VALUES (
+      'manage_page',
+      'Create, update, publish, archive, delete, and rollback CMS pages. Full page lifecycle management.',
+      'module:pages',
+      'content',
+      'internal',
+      false,
+      true,
+      E'# Page Management\n\n## Actions\n- **list**: List all pages. Optional status filter (draft/published/archived).\n- **get**: Get page by page_id or slug. Returns block summary.\n- **create**: Create new page. Provide title (required), slug (auto-generated if omitted), blocks[], meta{}.\n- **update**: Update page_id with new title, slug, meta, or blocks.\n- **publish**: Publish a page (saves version first). Use after content is ready.\n- **archive**: Archive a page (removes from public but preserves).\n- **delete**: Soft-delete a page.\n- **rollback**: Rollback to previous version. Saves current state before reverting.\n\n## Block Format\nBlocks are objects: { id (auto), type (e.g. "hero", "text", "cta"), data: { ... }, spacing: {}, animation: { type: "fade-up" } }\n\n## When to Use\n- Use manage_page for page-level operations (create, publish, archive)\n- Use manage_page_blocks for block-level operations (add/update/remove blocks within a page)\n- Always get the page first to see current state before modifying',
+      '{"type":"function","function":{"name":"manage_page","description":"Manage CMS pages: create, update, publish, archive, delete, rollback.","parameters":{"type":"object","properties":{"action":{"type":"string","enum":["list","get","create","update","publish","archive","delete","rollback"],"description":"Operation to perform"},"page_id":{"type":"string","description":"Page UUID (for get/update/publish/archive/delete/rollback)"},"slug":{"type":"string","description":"Page slug (for get or create)"},"title":{"type":"string","description":"Page title (for create/update)"},"status":{"type":"string","enum":["draft","published","archived"],"description":"Filter for list action"},"meta":{"type":"object","description":"Page meta (description, ogImage, etc.)"},"blocks":{"type":"array","description":"Array of ContentBlock objects (for create/update)"},"version_id":{"type":"string","description":"Specific version to rollback to"}},"required":["action"]}}}'::jsonb
+    );
+  END IF;
+END $$;
+
+-- 2. manage_page_blocks — Block-level manipulation
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.agent_skills WHERE name = 'manage_page_blocks') THEN
+    INSERT INTO public.agent_skills (name, description, handler, category, scope, requires_approval, enabled, instructions, tool_definition)
+    VALUES (
+      'manage_page_blocks',
+      'Add, update, remove, reorder, duplicate, and toggle visibility of blocks within a page.',
+      'module:pages',
+      'content',
+      'internal',
+      false,
+      true,
+      E'# Block Manipulation\n\n## Actions\n- **list**: See all blocks on a page with their types and positions.\n- **add**: Add a new block. Specify block_type and block_data. Optional position (defaults to end).\n- **update**: Update block_data for an existing block_id. Merges with existing data.\n- **remove**: Remove a block by block_id.\n- **reorder**: Provide block_ids[] in desired order. Blocks not in list are appended.\n- **toggle_visibility**: Hide/show a block without removing it.\n- **duplicate**: Clone a block (placed right after original).\n\n## Block Types (48+)\nContent: hero, text, quote, two-column, info-box, accordion, article-grid\nMedia: image, gallery, youtube, embed, lottie\nInteractive: cta, contact, form, newsletter, chat, booking, smart-booking, popup, tabs\nCommerce: pricing, comparison, testimonials, team, logos, products, cart\nKB: kb-featured, kb-hub, kb-search, kb-accordion\nGlobal: header, footer, announcement-bar\nLayout: separator, marquee, countdown, bento-grid\n\n## Block Data Examples\n- hero: { title, subtitle, backgroundType: "image", imageUrl, buttons: [{text, url}] }\n- text: { content: { type: "doc", content: [...] } } (Tiptap JSON)\n- cta: { title, description, buttons: [{text, url, variant}] }\n- image: { src, alt, caption }\n- pricing: { tiers: [{name, price, features: [], cta}] }\n\n## Tips\n- Always list blocks first to see current state\n- Use Tiptap JSON for rich text (or simple strings for basic text)\n- Each block gets auto-generated id, fade-up animation, and empty spacing',
+      '{"type":"function","function":{"name":"manage_page_blocks","description":"Manipulate blocks within a CMS page: add, update, remove, reorder, duplicate, toggle visibility.","parameters":{"type":"object","properties":{"action":{"type":"string","enum":["list","add","update","remove","reorder","toggle_visibility","duplicate"],"description":"Block operation"},"page_id":{"type":"string","description":"Page UUID (required for all actions)"},"block_type":{"type":"string","description":"Block type for add action (e.g. hero, text, cta, image, pricing)"},"block_data":{"type":"object","description":"Block configuration data (for add/update)"},"block_id":{"type":"string","description":"Block UUID (for update/remove/toggle/duplicate)"},"block_ids":{"type":"array","items":{"type":"string"},"description":"Ordered block UUIDs (for reorder)"},"position":{"type":"number","description":"Insert position for add (0-based, defaults to end)"}},"required":["action","page_id"]}}}'::jsonb
+    );
+  END IF;
+END $$;
+
+-- 3. manage_kb_article — Knowledge Base CRUD
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.agent_skills WHERE name = 'manage_kb_article') THEN
+    INSERT INTO public.agent_skills (name, description, handler, category, scope, requires_approval, enabled, instructions, tool_definition)
+    VALUES (
+      'manage_kb_article',
+      'Create, update, publish, and manage Knowledge Base articles. Powers the AI chat context and public KB.',
+      'module:kb',
+      'content',
+      'internal',
+      false,
+      true,
+      E'# Knowledge Base Article Management\n\n## Actions\n- **list**: List articles. Filter by category or is_published.\n- **get**: Get full article by article_id or slug.\n- **create**: Create article with title, question, answer, category. Defaults to draft.\n- **update**: Update any field on an existing article.\n- **publish**: Make article public and available in chat context.\n- **unpublish**: Remove from public view.\n\n## Important Fields\n- title: Display title\n- question: The question this article answers (used for chat matching)\n- answer: The answer text (plain text or markdown)\n- category: Grouping category\n- include_in_chat: Whether AI chat can use this as context (default true)\n- is_featured: Show on KB landing page\n\n## When to Use\n- After kb_gap_analysis reveals uncovered questions\n- When users ask questions the chat can''t answer\n- To document new features or processes\n- Always set include_in_chat=true for articles that help the public chatbot',
+      '{"type":"function","function":{"name":"manage_kb_article","description":"Manage Knowledge Base articles: create, update, publish, list.","parameters":{"type":"object","properties":{"action":{"type":"string","enum":["list","get","create","update","publish","unpublish"],"description":"Operation to perform"},"article_id":{"type":"string","description":"Article UUID"},"slug":{"type":"string","description":"Article slug (for get)"},"title":{"type":"string","description":"Article title"},"question":{"type":"string","description":"The question this article answers"},"answer":{"type":"string","description":"Answer text (markdown supported)"},"category":{"type":"string","description":"Article category"},"include_in_chat":{"type":"boolean","description":"Include in AI chat context (default true)"},"is_featured":{"type":"boolean","description":"Feature on KB landing page"},"is_published":{"type":"boolean","description":"Filter for list action"}},"required":["action"]}}}'::jsonb
+    );
+  END IF;
+END $$;
+
+-- 4. manage_global_blocks — Header, Footer, Sidebar
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.agent_skills WHERE name = 'manage_global_blocks') THEN
+    INSERT INTO public.agent_skills (name, description, handler, category, scope, requires_approval, enabled, instructions, tool_definition)
+    VALUES (
+      'manage_global_blocks',
+      'Manage global site elements: header navigation, footer content, sidebar, and announcement bars.',
+      'module:globalElements',
+      'content',
+      'internal',
+      false,
+      true,
+      E'# Global Blocks Management\n\n## Actions\n- **list**: See all global blocks (header, footer, sidebar) and their active state.\n- **get**: Get full data for a specific slot.\n- **update**: Update block data for a slot. Merges with existing data.\n- **toggle**: Enable/disable a global block.\n\n## Slots\n- **header**: Site navigation (logo, nav items, sticky settings)\n- **footer**: Footer content (contact info, social links, legal links)\n- **sidebar**: Optional sidebar content\n\n## Header Data Example\n{ logoUrl, logoAlt, navItems: [{label, url}], sticky: true, transparent: false }\n\n## Footer Data Example\n{ companyName, email, phone, address, socialLinks: [{platform, url}], legalLinks: [{label, url}] }',
+      '{"type":"function","function":{"name":"manage_global_blocks","description":"Manage global site elements (header, footer, sidebar).","parameters":{"type":"object","properties":{"action":{"type":"string","enum":["list","get","update","toggle"],"description":"Operation to perform"},"slot":{"type":"string","enum":["header","footer","sidebar"],"description":"Global block slot"},"block_data":{"type":"object","description":"Block configuration data (for update)"},"block_type":{"type":"string","description":"Block type (for creating new slot)"}},"required":["action"]}}}'::jsonb
+    );
+  END IF;
+END $$;
+
+-- 5. manage_deal — Sales pipeline management
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.agent_skills WHERE name = 'manage_deal') THEN
+    INSERT INTO public.agent_skills (name, description, handler, category, scope, requires_approval, enabled, instructions, tool_definition)
+    VALUES (
+      'manage_deal',
+      'Create, update, and manage sales deals through pipeline stages (proposal → negotiation → closed).',
+      'module:deals',
+      'crm',
+      'internal',
+      false,
+      true,
+      E'# Deal Management\n\n## Actions\n- **list**: List deals. Filter by stage or lead_id.\n- **create**: Create deal with title, value_cents, stage, lead_id, company_id.\n- **update**: Update deal fields.\n- **move_stage**: Move deal to new pipeline stage.\n\n## Pipeline Stages\nproposal → negotiation → closed_won / closed_lost\n\n## When to Use\n- After qualifying a lead, create a deal\n- Track value in cents (e.g. 50000 = 500 SEK)\n- Link to lead_id and company_id for full CRM context',
+      '{"type":"function","function":{"name":"manage_deal","description":"Manage sales deals and pipeline stages.","parameters":{"type":"object","properties":{"action":{"type":"string","enum":["list","create","update","move_stage"],"description":"Operation"},"deal_id":{"type":"string","description":"Deal UUID"},"title":{"type":"string","description":"Deal title"},"value_cents":{"type":"number","description":"Deal value in cents"},"currency":{"type":"string","description":"Currency code (default SEK)"},"stage":{"type":"string","enum":["proposal","negotiation","closed_won","closed_lost"],"description":"Pipeline stage"},"lead_id":{"type":"string","description":"Associated lead UUID"},"company_id":{"type":"string","description":"Associated company UUID"},"expected_close_date":{"type":"string","description":"Expected close date (ISO)"}},"required":["action"]}}}'::jsonb
+    );
+  END IF;
+END $$;
+
+-- 6. manage_product — E-commerce product catalog
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.agent_skills WHERE name = 'manage_product') THEN
+    INSERT INTO public.agent_skills (name, description, handler, category, scope, requires_approval, enabled, instructions, tool_definition)
+    VALUES (
+      'manage_product',
+      'Create, update, and list e-commerce products with pricing and Stripe integration.',
+      'module:products',
+      'content',
+      'internal',
+      false,
+      true,
+      E'# Product Management\n\n## Actions\n- **list**: List products. Filter by is_active.\n- **create**: Create product with name, price_cents, currency, type.\n- **update**: Update product fields.\n\n## Types\n- one_time: Single purchase\n- recurring: Subscription\n\n## Pricing\nStore in cents: 9900 = 99.00 SEK',
+      '{"type":"function","function":{"name":"manage_product","description":"Manage e-commerce products.","parameters":{"type":"object","properties":{"action":{"type":"string","enum":["list","create","update"],"description":"Operation"},"product_id":{"type":"string","description":"Product UUID"},"name":{"type":"string","description":"Product name"},"description":{"type":"string","description":"Product description"},"price_cents":{"type":"number","description":"Price in cents"},"currency":{"type":"string","description":"Currency (default SEK)"},"type":{"type":"string","enum":["one_time","recurring"],"description":"Pricing type"},"is_active":{"type":"boolean","description":"Active status"}},"required":["action"]}}}'::jsonb
+    );
+  END IF;
+END $$;
+
+-- 7. manage_company — Company CRM
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.agent_skills WHERE name = 'manage_company') THEN
+    INSERT INTO public.agent_skills (name, description, handler, category, scope, requires_approval, enabled, instructions, tool_definition)
+    VALUES (
+      'manage_company',
+      'Create, update, and list companies in the CRM. Link to leads and deals.',
+      'module:companies',
+      'crm',
+      'internal',
+      false,
+      true,
+      E'# Company Management\n\n## Actions\n- **list**: List all companies.\n- **create**: Create company with name, domain, industry, size, location.\n- **update**: Update company fields.\n\n## Tips\n- Use enrich_company to auto-fill data from domain\n- Link companies to leads and deals for full CRM context',
+      '{"type":"function","function":{"name":"manage_company","description":"Manage CRM companies.","parameters":{"type":"object","properties":{"action":{"type":"string","enum":["list","create","update"],"description":"Operation"},"company_id":{"type":"string","description":"Company UUID"},"name":{"type":"string","description":"Company name"},"domain":{"type":"string","description":"Company domain"},"industry":{"type":"string","description":"Industry"},"size":{"type":"string","description":"Company size"},"city":{"type":"string","description":"City"},"country":{"type":"string","description":"Country"},"website":{"type":"string","description":"Website URL"},"description":{"type":"string","description":"Company description"}},"required":["action"]}}}'::jsonb
+    );
+  END IF;
+END $$;
+
+-- 8. manage_form_submissions — Form data access
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.agent_skills WHERE name = 'manage_form_submissions') THEN
+    INSERT INTO public.agent_skills (name, description, handler, category, scope, requires_approval, enabled, instructions, tool_definition)
+    VALUES (
+      'manage_form_submissions',
+      'List, view, and manage form submissions. Get stats on form performance.',
+      'module:forms',
+      'crm',
+      'internal',
+      false,
+      true,
+      E'# Form Submissions\n\n## Actions\n- **list**: List recent submissions (last 50).\n- **get**: Get full submission data by submission_id.\n- **update_status**: Update submission status.\n- **stats**: Get 30-day submission stats by form.',
+      '{"type":"function","function":{"name":"manage_form_submissions","description":"Manage form submissions and stats.","parameters":{"type":"object","properties":{"action":{"type":"string","enum":["list","get","update_status","stats"],"description":"Operation"},"submission_id":{"type":"string","description":"Submission UUID"},"status":{"type":"string","description":"New status (for update_status)"}},"required":["action"]}}}'::jsonb
+    );
+  END IF;
+END $$;
+
+-- 9. manage_webinar — Webinar management
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.agent_skills WHERE name = 'manage_webinar') THEN
+    INSERT INTO public.agent_skills (name, description, handler, category, scope, requires_approval, enabled, instructions, tool_definition)
+    VALUES (
+      'manage_webinar',
+      'Create, update, and list webinars with scheduling and platform integration.',
+      'module:webinars',
+      'communication',
+      'internal',
+      false,
+      true,
+      E'# Webinar Management\n\n## Actions\n- **list**: List all webinars.\n- **create**: Create webinar with title, scheduled_at, platform, meeting_url.\n- **update**: Update webinar fields.\n\n## Platforms\ngoogle_meet, zoom, teams',
+      '{"type":"function","function":{"name":"manage_webinar","description":"Manage webinars and events.","parameters":{"type":"object","properties":{"action":{"type":"string","enum":["list","create","update"],"description":"Operation"},"webinar_id":{"type":"string","description":"Webinar UUID"},"title":{"type":"string","description":"Webinar title"},"description":{"type":"string","description":"Description"},"scheduled_at":{"type":"string","description":"ISO datetime"},"platform":{"type":"string","enum":["google_meet","zoom","teams"],"description":"Meeting platform"},"meeting_url":{"type":"string","description":"Meeting URL"},"max_attendees":{"type":"number","description":"Max attendees"}},"required":["action"]}}}'::jsonb
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

- Add 9 new skills (`manage_page`, `manage_page_blocks`, `manage_kb_article`, `manage_global_blocks`, `manage_deal`, `manage_product`, `manage_company`, `manage_form_submissions`, `manage_webinar`) with rich OpenClaw-compliant instructions
- Implement 8 new module handlers in `agent-execute` for pages, KB, global elements, deals, products, companies, forms, and webinars
- Add block-level manipulation (add/update/remove/reorder/duplicate/toggle_visibility) and page rollback via version history
- Auto-activate modules when FlowPilot invokes them
- Updated `OPENCLAW-LAW.md` and `flowpilot.md` with categorized skill tables (28+ skills, ~9/10 autonomy)

## Test plan

- [ ] Run `supabase db push` to apply migration `20260312000001_register_cms_autonomy_skills.sql`
- [ ] Deploy updated edge function: `supabase functions deploy agent-execute`
- [ ] Verify new skills appear in FlowPilot skill registry
- [ ] Test block manipulation via FlowPilot: add/remove/reorder blocks on a page
- [ ] Test page rollback via `manage_page` with `rollback` action
- [ ] Test KB article CRUD via `manage_kb_article`
- [ ] Confirm modules auto-activate on first skill invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)