### PR TITLE
feat: add Anthropic to Test Connection

### DIFF
--- a/src/pages/admin/IntegrationsStatusPage.tsx
+++ b/src/pages/admin/IntegrationsStatusPage.tsx
@@ -101,13 +101,13 @@ function getCredentialBadge(hasCredential: boolean, requiresSecret: boolean) {
 }
 
 // Test AI Connection Button Component
-function TestAIConnectionButton({ 
-  provider, 
-  hasKey, 
-  isEnabled 
-}: { 
-  provider: 'openai' | 'gemini'; 
-  hasKey: boolean; 
+function TestAIConnectionButton({
+  provider,
+  hasKey,
+  isEnabled
+}: {
+  provider: 'openai' | 'gemini' | 'anthropic';
+  hasKey: boolean;
   isEnabled: boolean;
 }) {
   const [isTesting, setIsTesting] = useState(false);
@@ -127,7 +127,8 @@ function TestAIConnectionButton({
       }
 
       if (data?.success) {
-        toast.success(`${provider === 'openai' ? 'OpenAI' : 'Gemini'} connection verified! Model: ${data.model}`);
+        const name = provider === 'openai' ? 'OpenAI' : provider === 'gemini' ? 'Gemini' : 'Anthropic';
+        toast.success(`${name} connection verified! Model: ${data.model}`);
       } else {
         toast.error(`Test failed: ${data?.error || 'Unknown error'}`);
       }
@@ -868,7 +869,7 @@ export default function IntegrationsStatusPage() {
                         <CardContent className="pt-0 space-y-3">
                           {/* Actions */}
                           <div className="flex items-center gap-2 flex-wrap" onClick={(e) => e.stopPropagation()}>
-                            {(key === 'openai' || key === 'gemini') && (
+                            {(key === 'openai' || key === 'gemini' || key === 'anthropic') && (
                               <TestAIConnectionButton provider={key} hasKey={hasKey} isEnabled={isEnabled} />
                             )}
                             {(key === 'local_llm' || key === 'n8n') && (

--- a/supabase/functions/test-ai-connection/index.ts
+++ b/supabase/functions/test-ai-connection/index.ts
@@ -233,9 +233,52 @@ serve(async (req) => {
         );
       }
 
+    } else if (provider === 'anthropic') {
+      const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+      if (!apiKey) {
+        return new Response(
+          JSON.stringify({ success: false, provider: 'anthropic', error: 'ANTHROPIC_API_KEY not configured' }),
+          { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const response = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: AI_MODELS.anthropic.fast,
+          messages: [{ role: 'user', content: 'Say "OK"' }],
+          max_tokens: 5,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        console.error('Anthropic API error:', response.status, errorData);
+        return new Response(
+          JSON.stringify({
+            success: false,
+            provider: 'anthropic',
+            error: `API returned ${response.status}: ${response.statusText}`
+          }),
+          { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const data = await response.json();
+      result = {
+        success: true,
+        provider: 'anthropic',
+        model: data.model || AI_MODELS.anthropic.default
+      };
+
     } else {
       return new Response(
-        JSON.stringify({ success: false, error: 'Invalid provider. Use "openai", "gemini", "local_llm", or "n8n".' }),
+        JSON.stringify({ success: false, error: 'Invalid provider. Use "openai", "gemini", "anthropic", "local_llm", or "n8n".' }),
         { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }


### PR DESCRIPTION
## Summary

- Adds `anthropic` provider to `test-ai-connection` edge function — pings Anthropic API with `claude-3-5-haiku` (cheap/fast) to verify the key works
- Extends `TestAIConnectionButton` type to accept `'anthropic'`
- Shows Test Connection button on the Anthropic integration card when key is configured and enabled

## Deploy

After merge, redeploy the edge function:
```bash
supabase functions deploy test-ai-connection --no-verify-jwt --project-ref <ref>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)