### PR TITLE
fix: update Anthropic model IDs to Claude 4 family

### DIFF
--- a/src/hooks/useIntegrations.tsx
+++ b/src/hooks/useIntegrations.tsx
@@ -170,7 +170,7 @@ export const defaultIntegrationsSettings: IntegrationsSettings = {
     docsUrl: 'https://console.anthropic.com/settings/keys',
     docsLabel: 'Get API key',
     config: {
-      model: 'claude-sonnet-4-20250514',
+      model: 'claude-sonnet-4-6',
     },
   },
   local_llm: {

--- a/supabase/functions/shared/ai-models.ts
+++ b/supabase/functions/shared/ai-models.ts
@@ -22,10 +22,10 @@ export const AI_MODELS = {
 
   // Anthropic
   anthropic: {
-    default: 'claude-sonnet-4-20250514',
-    chat: 'claude-sonnet-4-20250514',
-    fast: 'claude-3-5-haiku-20241022',
-    pro: 'claude-opus-4-20250514',
+    default: 'claude-sonnet-4-6',
+    chat: 'claude-sonnet-4-6',
+    fast: 'claude-haiku-4-5-20251001',
+    pro: 'claude-opus-4-6',
   },
 
   // Local LLM (user-configurable)

--- a/supabase/functions/test-ai-connection/index.ts
+++ b/supabase/functions/test-ai-connection/index.ts
@@ -263,7 +263,7 @@ serve(async (req) => {
           JSON.stringify({
             success: false,
             provider: 'anthropic',
-            error: `API returned ${response.status}: ${response.statusText}`
+            error: `API returned ${response.status}: ${errorData}`
           }),
           { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );


### PR DESCRIPTION
## Summary

- Updates `ai-models.ts` to use current Claude 4 model IDs — old names caused 400 Bad Request on Test Connection
- Improves error reporting in `test-ai-connection` to surface the actual Anthropic response body
- Updates default model in `useIntegrations.tsx`

| Before | After |
|---|---|
| `claude-3-5-haiku-20241022` | `claude-haiku-4-5-20251001` |
| `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
| `claude-opus-4-20250514` | `claude-opus-4-6` |

## Deploy

```bash
supabase functions deploy test-ai-connection --no-verify-jwt --project-ref <ref>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)