### PR TITLE
fix: suppress false positive validator warning for markdown content blocks

### DIFF
--- a/src/lib/template-validator.ts
+++ b/src/lib/template-validator.ts
@@ -354,7 +354,7 @@ function validateBlock(block: ContentBlock, path: string): ValidationResult {
   // Validate content format if present
   if (block.data?.content) {
     const content = block.data.content;
-    if (typeof content === 'string') {
+    if (typeof content === 'string' && block.data?.contentFormat !== 'markdown') {
       warnings.push({
         path: `${path}.data.content`,
         message: 'Content is a string - use Tiptap format or text() helper for better compatibility',


### PR DESCRIPTION
## Summary

Template validator was warning `Content is a string - use Tiptap format` on `two-column` blocks that explicitly declare `contentFormat: 'markdown'`. These are intentionally plain strings — markdown is a valid content format for that block type.

Fix: only warn when `contentFormat` is not `'markdown'`.

Affected template: `flowwink-platform.ts` (blocks `two-col-paradigm` and `agency-two-col`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)