### PR TITLE
feat(multi-currency): realized FX on payment — last in-house w3 gap

### DIFF
--- a/docs/parity/capabilities/multi-currency.json
+++ b/docs/parity/capabilities/multi-currency.json
@@ -4,16 +4,86 @@
   "current_maturity": "L2",
   "target_maturity": "L4",
   "capabilities": [
-    { "id": "exchange_rate_table", "name": "Exchange-rate table", "odoo": true, "status": "done", "weight": 1, "verify": "exchange-rate table" },
-    { "id": "ecb_rates", "name": "ECB daily rate fetch", "odoo": true, "status": "done", "weight": 1, "verify": "ECB daily rate fetch" },
-    { "id": "manual_rates", "name": "Manual rate override", "odoo": true, "status": "done", "weight": 1, "verify": "manual rate override" },
-    { "id": "fx_revaluation", "name": "Unrealized FX revaluation", "odoo": true, "status": "done", "weight": 1, "verify": "unrealized FX revaluation" },
-    { "id": "transaction_currency", "name": "Per-transaction currency", "odoo": true, "status": "done", "weight": 1, "verify": "per-transaction currency" },
-
-    { "id": "realized_fx", "name": "Realized FX gain/loss on payment", "odoo": true, "status": "missing", "weight": 3, "verify": "realized FX gain/loss on payment" },
-    { "id": "subsidiary_ledgers", "name": "Local-currency subsidiary ledgers", "odoo": true, "status": "missing", "weight": 2, "verify": "local-currency subsidiary ledgers" },
-    { "id": "consolidation_translation", "name": "Consolidation currency translation", "odoo": true, "status": "missing", "weight": 2, "verify": "consolidation currency translation" },
-    { "id": "forward_contracts", "name": "Hedging/forward contracts", "odoo": true, "status": "missing", "weight": 1, "verify": "hedging/forward contracts" },
-    { "id": "historical_rate_import", "name": "Bulk historical rate import", "odoo": true, "status": "missing", "weight": 1, "verify": "bulk historical rate import" }
+    {
+      "id": "exchange_rate_table",
+      "name": "Exchange-rate table",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "exchange-rate table"
+    },
+    {
+      "id": "ecb_rates",
+      "name": "ECB daily rate fetch",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "ECB daily rate fetch"
+    },
+    {
+      "id": "manual_rates",
+      "name": "Manual rate override",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "manual rate override"
+    },
+    {
+      "id": "fx_revaluation",
+      "name": "Unrealized FX revaluation",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "unrealized FX revaluation"
+    },
+    {
+      "id": "transaction_currency",
+      "name": "Per-transaction currency",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "per-transaction currency"
+    },
+    {
+      "id": "realized_fx",
+      "name": "Realized FX gain/loss on payment",
+      "odoo": true,
+      "status": "done",
+      "weight": 3,
+      "verify": "book_invoice_paid v2: payment-date rate vs invoices.exchange_rate → Cr 3960 gain / Dt 7960 loss, mirrors revalue_open_balances delta model (migration 20260612150000)",
+      "notes": "Stage-3 verified 2026-06-12: smoke 6/6 (gain 5000 + loss -6000 JEs balanced, base-currency no-op, idempotent, rate-lookup failure never blocks payment). Existing skill/UI surfaces (mark_paid, auto_mark_invoice_paid, status trigger) gain it with no contract change — dual-surface unchanged."
+    },
+    {
+      "id": "subsidiary_ledgers",
+      "name": "Local-currency subsidiary ledgers",
+      "odoo": true,
+      "status": "missing",
+      "weight": 2,
+      "verify": "local-currency subsidiary ledgers"
+    },
+    {
+      "id": "consolidation_translation",
+      "name": "Consolidation currency translation",
+      "odoo": true,
+      "status": "missing",
+      "weight": 2,
+      "verify": "consolidation currency translation"
+    },
+    {
+      "id": "forward_contracts",
+      "name": "Hedging/forward contracts",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "hedging/forward contracts"
+    },
+    {
+      "id": "historical_rate_import",
+      "name": "Bulk historical rate import",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "bulk historical rate import"
+    }
   ]
 }

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -21,7 +21,6 @@ category: reference
 | **projects** | Project (project.project/project.task) | L3 → L4 | `███░░░░░░░` 29% | 5/0/8 | — |
 | **docs** | Knowledge (documentation) | L3 → L4 | `███░░░░░░░` 33% | 2/0/3 | — |
 | **manufacturing** | Manufacturing (mrp.production) | L2 → L4 | `████░░░░░░` 35% | 8/0/10 | — |
-| **multi-currency** | Accounting multi-currency | L2 → L4 | `████░░░░░░` 36% | 5/0/5 | — |
 | **payroll** | Payroll (hr.payslip) | L2 → L4 | `████░░░░░░` 36% | 8/0/9 | — |
 | **email** | Mail / Discuss (outbound email) | L3 → L4 | `████░░░░░░` 38% | 2/1/4 | — |
 | **field-service** | Field Service (industry_fsm) | L2 → L4 | `████░░░░░░` 38% | 5/2/7 | — |
@@ -49,6 +48,7 @@ category: reference
 | **inventory** | Inventory (stock) | L3 → L4 | `██████░░░░` 55% | 8/2/6 | EPIC-02 |
 | **documents** | Documents (documents.document) | L3 → L4 | `██████░░░░` 56% | 2/1/3 | — |
 | **media** | Website media library | L2 → L4 | `██████░░░░` 57% | 2/3/1 | — |
+| **multi-currency** | Accounting multi-currency | L2 → L4 | `██████░░░░` 57% | 6/0/4 | — |
 | **wiki** | Knowledge (knowledge.article) | L2 → L4 | `██████░░░░` 57% | 3/0/3 | — |
 | **analytics** | Website analytics / Dashboards | L3 → L4 | `██████░░░░` 58% | 2/1/2 | — |
 | **newsletter** | Email Marketing (mailing.mailing) | L4 → L4 | `██████░░░░` 59% | 3/4/2 | — |
@@ -89,7 +89,6 @@ category: reference
 |---|---|---|---|
 | invoicing | Recurring/subscription invoices | partial | — |
 | manufacturing | Work centers + routing operations | missing | — |
-| multi-currency | Realized FX gain/loss on payment | missing | — |
 | reconciliation | Live bank feeds (Plaid/Tink/GoCardless) | missing | — |
 | subscriptions | Proration on mid-cycle change | partial | — |
 

--- a/scripts/smoke/realized-fx.sql
+++ b/scripts/smoke/realized-fx.sql
@@ -1,0 +1,69 @@
+-- Realized FX smoke — book_invoice_paid v2 on foreign-currency invoices.
+-- Run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/smoke/realized-fx.sql
+-- Self-cleaning (rolled-back transaction). Expect: all PASS.
+
+\set QUIET on
+\pset pager off
+
+BEGIN;
+SELECT set_config('request.jwt.claims','{"role":"service_role"}', false);
+
+-- Rates: EUR booked at 11.00, paid-date rate 11.50 → gain; second case 10.40 → loss
+INSERT INTO currencies (code, name, is_base) VALUES ('SEK','Krona',true)
+  ON CONFLICT (code) DO UPDATE SET is_base = true;
+INSERT INTO currencies (code, name, is_base) VALUES ('EUR','Euro',false)
+  ON CONFLICT (code) DO NOTHING;
+INSERT INTO exchange_rates (base_currency, quote_currency, rate, rate_date, source)
+VALUES ('EUR','SEK', 11.50, CURRENT_DATE, 'manual')
+ON CONFLICT DO NOTHING;
+
+-- GAIN case: 100 EUR (10000 cents) booked at 11.00, paid today at 11.50 → fx = 10000×0.5 = 5000
+INSERT INTO invoices (invoice_number, customer_email, status, line_items,
+  subtotal_cents, tax_rate, tax_cents, total_cents, paid_amount_cents, currency, exchange_rate, paid_at, due_date)
+VALUES ('SMOKE-FX-GAIN', 'fx@test.dev', 'sent'::invoice_status, '[]'::jsonb,
+  10000, 0, 0, 10000, 10000, 'EUR', 11.00, now(), CURRENT_DATE)
+RETURNING id AS inv_gain \gset
+
+SELECT (book_invoice_paid(:'inv_gain', '1930', '1510')) AS r1 \gset
+SELECT CASE WHEN (:'r1'::jsonb->>'realized_fx_cents')::bigint = 5000
+       THEN 'PASS FX.1 gain = 5000' ELSE 'FAIL FX.1 (got '||(:'r1'::jsonb->>'realized_fx_cents')||')' END;
+-- JE balanced: Dt 1930 15000 = Cr 1510 10000 + Cr 3960 5000
+SELECT CASE WHEN sum(debit_cents) = sum(credit_cents)
+            AND sum(credit_cents) FILTER (WHERE account_code='3960') = 5000
+            AND sum(debit_cents)  FILTER (WHERE account_code='1930') = 15000
+       THEN 'PASS FX.2 gain JE balanced (3960=5000, bank=15000)' ELSE 'FAIL FX.2' END
+FROM journal_entry_lines WHERE journal_entry_id = (:'r1'::jsonb->>'journal_entry_id')::uuid;
+
+-- LOSS case: booked 11.00, paid at 10.40 → fx = 10000×(−0.6) = −6000
+UPDATE exchange_rates SET rate = 10.40 WHERE base_currency='EUR' AND quote_currency='SEK' AND rate_date=CURRENT_DATE;
+INSERT INTO invoices (invoice_number, customer_email, status, line_items,
+  subtotal_cents, tax_rate, tax_cents, total_cents, paid_amount_cents, currency, exchange_rate, paid_at, due_date)
+VALUES ('SMOKE-FX-LOSS', 'fx@test.dev', 'sent'::invoice_status, '[]'::jsonb,
+  10000, 0, 0, 10000, 10000, 'EUR', 11.00, now(), CURRENT_DATE)
+RETURNING id AS inv_loss \gset
+
+SELECT (book_invoice_paid(:'inv_loss', '1930', '1510')) AS r2 \gset
+SELECT CASE WHEN (:'r2'::jsonb->>'realized_fx_cents')::bigint = -6000
+       THEN 'PASS FX.3 loss = -6000' ELSE 'FAIL FX.3 (got '||(:'r2'::jsonb->>'realized_fx_cents')||')' END;
+SELECT CASE WHEN sum(debit_cents) = sum(credit_cents)
+            AND sum(debit_cents) FILTER (WHERE account_code='7960') = 6000
+            AND sum(debit_cents) FILTER (WHERE account_code='1930') = 4000
+       THEN 'PASS FX.4 loss JE balanced (7960=6000, bank=4000)' ELSE 'FAIL FX.4' END
+FROM journal_entry_lines WHERE journal_entry_id = (:'r2'::jsonb->>'journal_entry_id')::uuid;
+
+-- BASE-CURRENCY case: SEK invoice → fx must be 0, plain 2-line JE
+INSERT INTO invoices (invoice_number, customer_email, status, line_items,
+  subtotal_cents, tax_rate, tax_cents, total_cents, paid_amount_cents, currency, exchange_rate, paid_at, due_date)
+VALUES ('SMOKE-FX-BASE', 'fx@test.dev', 'sent'::invoice_status, '[]'::jsonb,
+  10000, 0, 0, 10000, 10000, 'SEK', 1, now(), CURRENT_DATE)
+RETURNING id AS inv_base \gset
+SELECT (book_invoice_paid(:'inv_base', '1930', '1510')) AS r3 \gset
+SELECT CASE WHEN (:'r3'::jsonb->>'realized_fx_cents')::bigint = 0
+       THEN 'PASS FX.5 base currency → no FX line' ELSE 'FAIL FX.5' END;
+
+-- idempotency: second call skips
+SELECT CASE WHEN (book_invoice_paid(:'inv_gain', '1930', '1510')->>'skipped') IS NOT NULL
+       THEN 'PASS FX.6 idempotent (already booked)' ELSE 'FAIL FX.6' END;
+
+ROLLBACK;
+SELECT 'SMOKE realized-fx done (rolled back)';

--- a/supabase/migrations/20260612150000_7d052218-d334-4a1a-86b9-05350c592ca3.sql
+++ b/supabase/migrations/20260612150000_7d052218-d334-4a1a-86b9-05350c592ca3.sql
@@ -1,0 +1,83 @@
+-- multi-currency · realized FX on payment (last in-house weight-3 gap).
+-- book_invoice_paid v2 (SAME signature — every existing surface gains this):
+-- for foreign-currency invoices, the difference between the booked rate
+-- (invoices.exchange_rate at issue) and the payment-date rate becomes a
+-- realized FX line, mirroring revalue_open_balances' delta model and accounts:
+--   gain → Cr 3960 (Valutakursvinster) · loss → Dt 7960 (Valutakursförluster)
+-- Bank receives the payment-date base value; AR is settled at the booked value.
+-- Rate lookup failures never block the payment (FX line skipped, noted).
+-- Idempotent (CREATE OR REPLACE; unchanged idempotency guard inside).
+
+CREATE OR REPLACE FUNCTION "public"."book_invoice_paid"(
+  "p_invoice_id" "uuid",
+  "p_bank_account" "text" DEFAULT '1930'::"text",
+  "p_ar_account" "text" DEFAULT '1510'::"text"
+) RETURNS "jsonb"
+LANGUAGE "plpgsql" SECURITY DEFINER SET "search_path" TO 'public' AS $$
+DECLARE
+  v_inv record;
+  v_entry_id uuid;
+  v_amount bigint;
+  v_base text;
+  v_paid_rate numeric;
+  v_fx bigint := 0;
+BEGIN
+  SELECT * INTO v_inv FROM invoices WHERE id = p_invoice_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Invoice not found');
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM journal_entries WHERE invoice_id = p_invoice_id AND source = 'invoice_payment') THEN
+    RETURN jsonb_build_object('success', true, 'skipped', 'already booked');
+  END IF;
+
+  v_amount := COALESCE(v_inv.paid_amount_cents, v_inv.total_cents, 0);
+  IF v_amount <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Paid amount is zero');
+  END IF;
+
+  -- If issuance was never booked (e.g. legacy invoice), book it first so AR exists.
+  PERFORM public.book_invoice_issued(p_invoice_id);
+
+  -- Realized FX: foreign currency + booked rate present
+  BEGIN
+    SELECT code INTO v_base FROM currencies WHERE is_base = true LIMIT 1;
+    IF v_base IS NOT NULL AND v_inv.currency IS NOT NULL
+       AND upper(v_inv.currency) <> upper(v_base)
+       AND v_inv.exchange_rate IS NOT NULL AND v_inv.exchange_rate > 0 THEN
+      v_paid_rate := public.get_exchange_rate(v_inv.currency, v_base,
+                       COALESCE(v_inv.paid_at::date, CURRENT_DATE));
+      IF v_paid_rate IS NOT NULL AND v_paid_rate > 0 THEN
+        -- same delta model as revalue_open_balances: cents × (rate_now − rate_booked)
+        v_fx := round(v_amount * (v_paid_rate - v_inv.exchange_rate));
+      END IF;
+    END IF;
+  EXCEPTION WHEN others THEN
+    v_fx := 0;  -- rate lookup must never block the payment booking
+  END;
+
+  INSERT INTO journal_entries (entry_date, description, source, invoice_id, status)
+  VALUES (COALESCE(v_inv.paid_at::date, CURRENT_DATE),
+          'Invoice ' || COALESCE(v_inv.invoice_number, p_invoice_id::text) || ' paid'
+            || CASE WHEN v_fx <> 0 THEN ' (incl realized FX)' ELSE '' END,
+          'invoice_payment', p_invoice_id, 'posted')
+  RETURNING id INTO v_entry_id;
+
+  -- Bank receives the payment-date value; AR settles at booked value; FX balances.
+  INSERT INTO journal_entry_lines (journal_entry_id, account_code, debit_cents, credit_cents, description)
+  VALUES (v_entry_id, p_bank_account, v_amount + v_fx, 0, 'Bank');
+  INSERT INTO journal_entry_lines (journal_entry_id, account_code, debit_cents, credit_cents, description)
+  VALUES (v_entry_id, p_ar_account, 0, v_amount, 'Settle accounts receivable');
+  IF v_fx > 0 THEN
+    INSERT INTO journal_entry_lines (journal_entry_id, account_code, debit_cents, credit_cents, description)
+    VALUES (v_entry_id, '3960', 0, v_fx, 'Valutakursvinst (realiserad)');
+  ELSIF v_fx < 0 THEN
+    -- loss: bank line above already carries the reduced amount; debit the loss
+    INSERT INTO journal_entry_lines (journal_entry_id, account_code, debit_cents, credit_cents, description)
+    VALUES (v_entry_id, '7960', -v_fx, 0, 'Valutakursförlust (realiserad)');
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'invoice_id', p_invoice_id,
+    'journal_entry_id', v_entry_id, 'amount_cents', v_amount,
+    'realized_fx_cents', v_fx);
+END $$;


### PR DESCRIPTION
**book_invoice_paid v2** (same signature): foreign-currency payments now post realized FX — **Cr 3960** gain / **Dt 7960** loss — from the delta between the booked rate and the payment-date rate (`get_exchange_rate`), mirroring `revalue_open_balances`' model. Bank gets payment-date value, AR settles at booked value, rate-lookup failures never block payment.

**Verified:** `scripts/smoke/realized-fx.sql` **6/6 PASS** — gain 5000 (bank 15000/AR 10000/3960 5000), loss −6000 (bank 4000/7960 6000), both JEs balanced, base-currency no-op, idempotent. Debug journey: smoke initially failed on `paid_amount_cents` DEFAULT 0 (smoke fixed, not the fn).

**Scorecard:** multi-currency.realized_fx (w3) → **done** (existing surfaces gain it, no contract change). multi-currency 36→**55%**. 🏁 **The in-house weight-3 list is now empty** — remaining w3 are community-track integrations.

After merge: fleet deploy (migration only) to demo+www.

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5