### PR TITLE
docs(parity): handbook + workspace-chat → differentiators (owner decision)

### DIFF
--- a/docs/parity/capabilities/handbook.json
+++ b/docs/parity/capabilities/handbook.json
@@ -1,43 +1,33 @@
 {
   "module": "handbook",
-  "odoo_app": "Knowledge (internal handbook)",
+  "odoo_app": "none (FlowWink differentiator)",
   "current_maturity": "L2",
-  "target_maturity": "L4",
+  "target_maturity": "L3",
   "capabilities": [
     {
-      "id": "section_crud",
-      "name": "Section/page CRUD",
-      "odoo": true,
-      "status": "missing",
+      "id": "github_sync",
+      "name": "GitHub-synced handbook content",
+      "odoo": false,
+      "status": "done",
       "weight": 2,
-      "verify": "handbook_search is read-only; admin HandbookPage.tsx only syncs chapters from GitHub (useSyncHandbook)",
-      "notes": "Benchmark mismatch found 2026-06-12: handbook_chapters is GitHub-SYNCED read-only content (repo/sha/synced_at) — local CRUD would fight the sync. Owner decision pending: keep read-only (re-benchmark like workspace-chat) or build local authoring."
-    },
-    {
-      "id": "publishing",
-      "name": "Publish workflow",
-      "odoo": true,
-      "status": "missing",
-      "weight": 1,
-      "verify": "no publish/draft state on handbook chapters; everything synced is live",
-      "notes": "Benchmark mismatch found 2026-06-12: handbook_chapters is GitHub-SYNCED read-only content (repo/sha/synced_at) — local CRUD would fight the sync. Owner decision pending: keep read-only (re-benchmark like workspace-chat) or build local authoring."
+      "verify": "handbook_chapters (repo_owner/sha/synced_at) + github-content-sync edge fn",
+      "notes": "The Agentic Handbook (clawable) synced into the app. Read-only by design — the repo is the source of truth. Owner confirmed 2026-06-12: unique module, not an Odoo Knowledge clone."
     },
     {
       "id": "search",
-      "name": "Search",
-      "odoo": true,
+      "name": "Search + slug fetch",
+      "odoo": false,
       "status": "done",
       "weight": 1,
-      "verify": "handbook_search skill (module:handbook, slug fetch + ILIKE search over handbook_chapters) + public handbook UI",
-      "notes": "Verified 2026-06-12: handler fetches by slug and searches content."
+      "verify": "handbook_search skill (module:handbook) + public handbook UI"
     },
     {
-      "id": "acknowledgement",
-      "name": "Employee read-acknowledgement",
+      "id": "agent_surface",
+      "name": "Agent-readable handbook (MCP)",
       "odoo": false,
-      "status": "missing",
+      "status": "done",
       "weight": 1,
-      "verify": "no acknowledgement skill, table, or UI"
+      "verify": "handbook_search exposed over MCP — agents can cite the handbook"
     }
   ]
 }

--- a/docs/parity/capabilities/workspace-chat.json
+++ b/docs/parity/capabilities/workspace-chat.json
@@ -1,15 +1,26 @@
 {
   "module": "workspace-chat",
-  "odoo_app": "Discuss (mail.channel)",
-  "current_maturity": "L3",
-  "target_maturity": "L4",
+  "odoo_app": "none (FlowWink differentiator)",
+  "current_maturity": "L2",
+  "target_maturity": "L3",
   "capabilities": [
-    { "id": "channels", "name": "Channels", "odoo": true, "status": "missing", "weight": 2, "verify": "no channel concept; module is Cowork Chat (AI sessions via useWorkspaceSessions), exposes no skills" },
-    { "id": "direct_messages", "name": "Direct messages", "odoo": true, "status": "missing", "weight": 1, "verify": "no user-to-user DM skill or UI; chat is user-to-AI only" },
-    { "id": "mentions", "name": "@mentions", "odoo": true, "status": "missing", "weight": 1, "verify": "no mention handling in WorkspaceChatPage or hooks" },
-    { "id": "threads", "name": "Threaded replies", "odoo": true, "status": "missing", "weight": 1, "verify": "sessions are linear AI conversations (useWorkspaceSessions), no threaded replies" },
-    { "id": "file_sharing", "name": "File sharing", "odoo": true, "status": "partial", "weight": 1, "verify": "WorkspaceChatPage attachment upload (AttachmentChip, 20MB/5 files)", "notes": "Skill surface missing: workspace-chat-module deliberately exposes no skills (skills: [])" },
-    { "id": "search", "name": "Message search", "odoo": true, "status": "missing", "weight": 1, "verify": "no message-search UI or skill; only RAG search over workspace data, not chat messages" },
-    { "id": "rag_chat", "name": "AI workspace chat (RAG/CAG with citations)", "odoo": false, "status": "partial", "weight": 1, "verify": "WorkspaceChatPage + useWorkspaceChat + CitationsDrawer; blended workspace/model/web modes", "notes": "Added capability. No skill surface — module intentionally exposes no skills (read-only internal chat)" }
+    {
+      "id": "rag_chat",
+      "name": "AI RAG chat over workspace context",
+      "odoo": false,
+      "status": "done",
+      "weight": 2,
+      "verify": "Cowork Chat UI + workspace-chat edge fn (RAG over workspace data)",
+      "notes": "Owner confirmed 2026-06-12: unique module — an AI interface to your own data, NOT a Discuss/Slack clone. Previous Discuss-benchmark (channels/DM/threads) removed as a category error."
+    },
+    {
+      "id": "agent_post",
+      "name": "Agent can post/answer in cowork chat (optional)",
+      "odoo": false,
+      "status": "missing",
+      "weight": 1,
+      "verify": "a skill surface for the chat (cf. post_to_river)",
+      "notes": "Optional future: dual-surface for the chat itself, so FlowPilot/external agents can participate. Not a parity gap."
+    }
   ]
 }

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -9,15 +9,13 @@ category: reference
 > **GENERATED FILE.** Run `bun run scripts/parity-report.ts` to refresh.
 > Edit `docs/parity/capabilities/<module>.json` to change scores.
 
-**Benchmarked modules:** 54  ·  **Mean parity:** 53%  ·  **Differentiators (no Odoo benchmark):** 8  ·  **Unscored:** 0
+**Benchmarked modules:** 52  ·  **Mean parity:** 55%  ·  **Differentiators (no Odoo benchmark):** 10  ·  **Unscored:** 0
 
 ## Scored modules
 
 | Module | Odoo app | Maturity → target | Parity | Done/Partial/Missing | Open epics |
 |---|---|---|---|---|---|
-| **workspace-chat** | Discuss (mail.channel) | L3 → L4 | `█░░░░░░░░░` 7% | 0/1/5 | — |
 | **shipping** | Inventory → Delivery/Shipping connectors | L2 → L4 | `██░░░░░░░░` 22% | 4/0/11 | — |
-| **handbook** | Knowledge (internal handbook) | L2 → L4 | `███░░░░░░░` 25% | 1/0/2 | — |
 | **projects** | Project (project.project/project.task) | L3 → L4 | `███░░░░░░░` 29% | 5/0/8 | — |
 | **docs** | Knowledge (documentation) | L3 → L4 | `███░░░░░░░` 33% | 2/0/3 | — |
 | **manufacturing** | Manufacturing (mrp.production) | L2 → L4 | `████░░░░░░` 35% | 8/0/10 | — |
@@ -80,8 +78,10 @@ category: reference
 | **developer** | none (FlowWink differentiator) | 4 |
 | **federation** | none (FlowWink differentiator) | 8 |
 | **flowpilot** | none (FlowWink differentiator) | 7 |
+| **handbook** | none (FlowWink differentiator) | 3 |
 | **river** | none (FlowWink differentiator) | 5 |
 | **site-migration** | none (FlowWink differentiator) | 4 |
+| **workspace-chat** | none (FlowWink differentiator) | 2 |
 
 ## Foundational gaps (weight 3, still open)
 


### PR DESCRIPTION
Owner confirmed both are unique FlowWink modules (not Odoo-inspired). The S0 benchmark against Knowledge/Discuss was a category error — re-scored as differentiators per the program's own rule (`odoo:false` = documented, excluded from the denominator). Benchmarked 54→52, differentiators 8→10, **mean 53→55%**. Optional future noted: an agent skill surface for cowork chat.

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5