### PR TITLE
feat(pricelists): tiered quantity pricing

### DIFF
--- a/docs/parity/capabilities/pricelists.json
+++ b/docs/parity/capabilities/pricelists.json
@@ -4,18 +4,102 @@
   "current_maturity": "L3",
   "target_maturity": "L4",
   "capabilities": [
-    { "id": "versioned", "name": "Versioned pricelists", "odoo": true, "status": "done", "weight": 1, "verify": "versioned pricelist records" },
-    { "id": "per_customer_period", "name": "Per customer/period", "odoo": true, "status": "done", "weight": 1, "verify": "pricelist scoped per customer/period" },
-    { "id": "priority_validity", "name": "Priority + validity dates", "odoo": true, "status": "done", "weight": 1, "verify": "priority and validity date fields" },
-    { "id": "fixed_or_discount", "name": "Fixed price or discount %", "odoo": true, "status": "done", "weight": 1, "verify": "fixed price or discount % rule type" },
-    { "id": "price_resolution", "name": "Best-price resolution RPC", "odoo": true, "status": "done", "weight": 1, "verify": "best-price resolution RPC" },
-
-    { "id": "tiered_quantity", "name": "Tiered quantity discounts", "odoo": true, "status": "missing", "weight": 2, "verify": "quantity-tier discount rules" },
-    { "id": "dynamic_pricing", "name": "Time-based dynamic pricing", "odoo": true, "status": "missing", "weight": 1, "verify": "time-based dynamic pricing rules" },
-    { "id": "segment_pricing", "name": "Customer-segment/country pricing", "odoo": true, "status": "missing", "weight": 1, "verify": "segment/country-based pricing rules" },
-    { "id": "supplier_pricelists", "name": "Supplier/vendor pricelists", "odoo": true, "status": "missing", "weight": 1, "verify": "supplier/vendor pricelist records" },
-    { "id": "formula_pricing", "name": "Formula (cost+margin) pricing", "odoo": true, "status": "missing", "weight": 1, "verify": "cost+margin formula pricing rule" },
-    { "id": "pos_subscription_application", "name": "Apply to POS/subscriptions", "odoo": true, "status": "missing", "weight": 1, "verify": "pricelist applied to POS and subscriptions" },
-    { "id": "version_history", "name": "Pricelist version history", "odoo": true, "status": "missing", "weight": 1, "verify": "pricelist version history records" }
+    {
+      "id": "versioned",
+      "name": "Versioned pricelists",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "versioned pricelist records"
+    },
+    {
+      "id": "per_customer_period",
+      "name": "Per customer/period",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "pricelist scoped per customer/period"
+    },
+    {
+      "id": "priority_validity",
+      "name": "Priority + validity dates",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "priority and validity date fields"
+    },
+    {
+      "id": "fixed_or_discount",
+      "name": "Fixed price or discount %",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "fixed price or discount % rule type"
+    },
+    {
+      "id": "price_resolution",
+      "name": "Best-price resolution RPC",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "best-price resolution RPC"
+    },
+    {
+      "id": "tiered_quantity",
+      "name": "Tiered quantity discounts",
+      "odoo": true,
+      "status": "partial",
+      "weight": 2,
+      "verify": "multiple pricelist_items.min_quantity tiers per product; resolve_pricelist_price picks the deepest qualifying break (ORDER BY specificity, qty_break DESC) (migration 20260613020000)",
+      "notes": "Built + scratch-Postgres verified 2026-06-13 (qty 5\u219210000, 12\u21929000@10%, 80\u21927500@25%). Reused current ambiguity-fixed fn (avoided regressing the price_cents bug). Pending: tier-row admin UI affordance + Stage-3 before done."
+    },
+    {
+      "id": "dynamic_pricing",
+      "name": "Time-based dynamic pricing",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "time-based dynamic pricing rules"
+    },
+    {
+      "id": "segment_pricing",
+      "name": "Customer-segment/country pricing",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "segment/country-based pricing rules"
+    },
+    {
+      "id": "supplier_pricelists",
+      "name": "Supplier/vendor pricelists",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "supplier/vendor pricelist records"
+    },
+    {
+      "id": "formula_pricing",
+      "name": "Formula (cost+margin) pricing",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "cost+margin formula pricing rule"
+    },
+    {
+      "id": "pos_subscription_application",
+      "name": "Apply to POS/subscriptions",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "pricelist applied to POS and subscriptions"
+    },
+    {
+      "id": "version_history",
+      "name": "Pricelist version history",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "pricelist version history records"
+    }
   ]
 }

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -21,7 +21,6 @@ category: reference
 | **payroll** | Payroll (hr.payslip) | L2 → L4 | `████░░░░░░` 36% | 8/0/9 | — |
 | **email** | Mail / Discuss (outbound email) | L3 → L4 | `████░░░░░░` 38% | 2/1/4 | — |
 | **field-service** | Field Service (industry_fsm) | L2 → L4 | `████░░░░░░` 38% | 5/2/7 | — |
-| **pricelists** | Sales pricelists (product.pricelist) | L3 → L4 | `████░░░░░░` 38% | 5/0/7 | — |
 | **forms** | Website forms | L4 → L4 | `████░░░░░░` 39% | 1/3/3 | — |
 | **pos** | Point of Sale (pos.order) | L3 → L4 | `████░░░░░░` 39% | 7/0/9 | — |
 | **booking** | Appointments (calendar.appointment) | L3 → L4 | `████░░░░░░` 41% | 9/0/10 | — |
@@ -34,6 +33,7 @@ category: reference
 | **reconciliation** | Accounting bank reconciliation | L3 → L4 | `████░░░░░░` 44% | 7/0/6 | — |
 | **timesheets** | Timesheets (account.analytic.line) | L3 → L4 | `████░░░░░░` 44% | 7/0/7 | — |
 | **accounting** | Accounting (account.move, account.account) | L3 → L4 | `█████░░░░░` 45% | 8/1/7 | — |
+| **pricelists** | Sales pricelists (product.pricelist) | L3 → L4 | `█████░░░░░` 46% | 5/1/6 | — |
 | **expenses** | Expenses (hr.expense) | L4 → L4 | `█████░░░░░` 47% | 8/0/7 | — |
 | **invoicing** | Invoicing (account.move) | L4 → L4 | `█████░░░░░` 47% | 7/1/6 | — |
 | **subscriptions** | Subscriptions (sale.subscription) | L3 → L4 | `█████░░░░░` 47% | 7/0/7 | — |

--- a/supabase/migrations/20260613020000_2fe9cbca-c811-4aca-b9a6-916024fd220d.sql
+++ b/supabase/migrations/20260613020000_2fe9cbca-c811-4aca-b9a6-916024fd220d.sql
@@ -1,0 +1,58 @@
+-- Pricelists: tiered quantity pricing (docs/parity/capabilities/pricelists.json#tiered_quantity).
+-- The data model already supports quantity breaks (pricelist_items.min_quantity) and
+-- resolve_pricelist_price already filters p_quantity >= min_quantity — but when several
+-- tiers qualify (e.g. min 1 AND min 10 for qty 20) the tie-break ignored the break size,
+-- so the wrong tier could win. Fix: among equally-specific candidates, prefer the
+-- HIGHEST qualifying min_quantity (the deepest applicable quantity break).
+--
+-- Based on the CURRENT (ambiguity-fixed) definition from migration 20260610104500 —
+-- products column stays qualified as pr.price_cents. Only the candidates CTE gains
+-- qty_break and the ORDER BY gains a tie-break. Idempotent CREATE OR REPLACE.
+
+CREATE OR REPLACE FUNCTION public.resolve_pricelist_price(
+  p_product_id uuid,
+  p_lead_id uuid DEFAULT NULL::uuid,
+  p_company_id uuid DEFAULT NULL::uuid,
+  p_quantity numeric DEFAULT 1,
+  p_at date DEFAULT CURRENT_DATE,
+  p_currency text DEFAULT 'SEK'::text
+)
+RETURNS TABLE(price_cents integer, pricelist_id uuid, pricelist_name text, source text)
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE v_base_price integer;
+BEGIN
+  SELECT COALESCE(pr.price_cents, 0) INTO v_base_price FROM public.products pr WHERE pr.id = p_product_id;
+  RETURN QUERY
+  WITH candidates AS (
+    SELECT pl.id, pl.name,
+      CASE WHEN pli.fixed_price_cents IS NOT NULL THEN pli.fixed_price_cents
+           WHEN pli.discount_pct IS NOT NULL THEN GREATEST(0, ROUND(v_base_price * (1 - pli.discount_pct/100.0))::int)
+           ELSE v_base_price END AS resolved_price,
+      pli.min_quantity AS qty_break,
+      (CASE WHEN pl.lead_id = p_lead_id THEN 1000 ELSE 0 END
+       + CASE WHEN pl.company_id = p_company_id THEN 500 ELSE 0 END
+       + CASE WHEN pli.product_id = p_product_id THEN 100 ELSE 0 END
+       - pl.priority) AS specificity
+    FROM public.pricelists pl
+    JOIN public.pricelist_items pli ON pli.pricelist_id = pl.id
+    WHERE pl.is_active AND pl.currency = p_currency
+      AND (pl.valid_from IS NULL OR pl.valid_from <= p_at)
+      AND (pl.valid_until IS NULL OR pl.valid_until >= p_at)
+      AND (pli.product_id = p_product_id OR pli.product_id IS NULL)
+      AND p_quantity >= pli.min_quantity
+      AND ((pl.lead_id IS NULL AND pl.company_id IS NULL)
+        OR (p_lead_id IS NOT NULL AND pl.lead_id = p_lead_id)
+        OR (p_company_id IS NOT NULL AND pl.company_id = p_company_id))
+  )
+  SELECT resolved_price, id, name, 'pricelist'::text
+  FROM candidates
+  -- most specific match first; within that, the deepest qualifying quantity break
+  ORDER BY specificity DESC, qty_break DESC
+  LIMIT 1;
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT v_base_price, NULL::uuid, NULL::text, 'product_base'::text;
+  END IF;
+END; $function$;


### PR DESCRIPTION
## pricelists — tiered quantity pricing

`pricelists.tiered_quantity` (weight 2): 38% → **46%**.

### What
`resolve_pricelist_price` already filtered `p_quantity >= pli.min_quantity`, but when several tiers qualified for the same product (e.g. breaks at 1 / 10 / 50 for qty 80) the tie-break only ranked by `specificity` — so the wrong tier could win. Now: `ORDER BY specificity DESC, qty_break DESC` → among equally-specific candidates, the **deepest qualifying quantity break** wins. Multiple `pricelist_items` rows with different `min_quantity` now behave as proper quantity breaks.

### Verify-loop catch
The naïve approach (edit the baseline definition) would have **re-introduced the `price_cents is ambiguous` regression** (fixed earlier in #23df463). Running it on scratch Postgres surfaced the error immediately; the migration is rebuilt on the **current** ambiguity-fixed definition (qualified `pr.price_cents`), adding only `qty_break` + the tie-break.

### Verified (Stage 2, scratch Postgres)
Tiers 0% / 10%@10 / 25%@50 on a 10000 product:
- qty 5 → **10000**, qty 12 → **9000**, qty 80 → **7500**
- migration idempotent; vitest (full) + `parity:check` green

### Scorecard
`pricelists.tiered_quantity`: `missing → partial` (resolution verified; tier-row admin UI affordance + Stage-3 runtime verification pending before `done`).

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_