### PR TITLE
feat(field-service): deduct parts stock on service-order completion

### DIFF
--- a/docs/parity/capabilities/field-service.json
+++ b/docs/parity/capabilities/field-service.json
@@ -4,20 +4,120 @@
   "current_maturity": "L2",
   "target_maturity": "L4",
   "capabilities": [
-    { "id": "order_lifecycle", "name": "Service-order lifecycle", "odoo": true, "status": "done", "weight": 1, "verify": "Service-order status lifecycle supported" },
-    { "id": "visit_scheduling", "name": "Visit scheduling", "odoo": true, "status": "done", "weight": 1, "verify": "Visit scheduling with dates" },
-    { "id": "line_items", "name": "Labor/material/expense lines", "odoo": true, "status": "done", "weight": 1, "verify": "Labor/material/expense line items on order" },
-    { "id": "order_number", "name": "Auto order number", "odoo": true, "status": "done", "weight": 1, "verify": "Auto-generated order number" },
-    { "id": "completion_event", "name": "Completion→invoice event", "odoo": true, "status": "done", "weight": 1, "verify": "Completion fires invoice event" },
-
-    { "id": "technician_availability", "name": "Technician availability check", "odoo": true, "status": "missing", "weight": 2, "verify": "Technician availability check before scheduling" },
-    { "id": "signature_proof", "name": "Signature/photo proof", "odoo": true, "status": "partial", "weight": 2, "verify": "Signature/photo capture as proof of service", "notes": "service_visits has signature_url + signed_at columns, but no skill/handler/UI writes them — schema only, no capture flow." },
-    { "id": "parts_inventory_deduction", "name": "Material stock deduction", "odoo": true, "status": "missing", "weight": 2, "verify": "Material lines deduct from stock" },
-    { "id": "visit_time_tracking", "name": "Actual visit time tracking", "odoo": true, "status": "partial", "weight": 1, "verify": "Actual on-site visit time tracked", "notes": "service_visits has actual_start + actual_end columns, but no skill/handler/UI writes them — schema only, no clock-in/out flow." },
-    { "id": "sla_targets", "name": "Service SLA targets", "odoo": true, "status": "missing", "weight": 1, "verify": "Service SLA targets on orders" },
-    { "id": "service_packages", "name": "Service package templates", "odoo": true, "status": "missing", "weight": 1, "verify": "Reusable service package templates" },
-    { "id": "recurring_orders", "name": "Recurring service orders", "odoo": true, "status": "missing", "weight": 1, "verify": "Recurring service order generation" },
-    { "id": "territory_routing", "name": "Territory/route optimization", "odoo": true, "status": "missing", "weight": 1, "verify": "Territory/route optimization for visits" },
-    { "id": "contract_linking", "name": "Service contract linking", "odoo": true, "status": "missing", "weight": 1, "verify": "Orders link to service contracts" }
+    {
+      "id": "order_lifecycle",
+      "name": "Service-order lifecycle",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "Service-order status lifecycle supported"
+    },
+    {
+      "id": "visit_scheduling",
+      "name": "Visit scheduling",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "Visit scheduling with dates"
+    },
+    {
+      "id": "line_items",
+      "name": "Labor/material/expense lines",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "Labor/material/expense line items on order"
+    },
+    {
+      "id": "order_number",
+      "name": "Auto order number",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "Auto-generated order number"
+    },
+    {
+      "id": "completion_event",
+      "name": "Completion\u2192invoice event",
+      "odoo": true,
+      "status": "done",
+      "weight": 1,
+      "verify": "Completion fires invoice event"
+    },
+    {
+      "id": "technician_availability",
+      "name": "Technician availability check",
+      "odoo": true,
+      "status": "missing",
+      "weight": 2,
+      "verify": "Technician availability check before scheduling"
+    },
+    {
+      "id": "signature_proof",
+      "name": "Signature/photo proof",
+      "odoo": true,
+      "status": "partial",
+      "weight": 2,
+      "verify": "Signature/photo capture as proof of service",
+      "notes": "service_visits has signature_url + signed_at columns, but no skill/handler/UI writes them \u2014 schema only, no capture flow."
+    },
+    {
+      "id": "parts_inventory_deduction",
+      "name": "Material stock deduction",
+      "odoo": true,
+      "status": "partial",
+      "weight": 2,
+      "verify": "emit_service_order_event trigger emits stock.movement (negative qty) per material line on completion (migration 20260614010000); stock module listener decrements",
+      "notes": "Built + scratch-Postgres verified 2026-06-14: completing an order emits one stock.movement per material line (-2, -5), labor lines none, no double-deduct on re-save. Pending: Stage-3 runtime verify (listener decrements quant) before done."
+    },
+    {
+      "id": "visit_time_tracking",
+      "name": "Actual visit time tracking",
+      "odoo": true,
+      "status": "partial",
+      "weight": 1,
+      "verify": "Actual on-site visit time tracked",
+      "notes": "service_visits has actual_start + actual_end columns, but no skill/handler/UI writes them \u2014 schema only, no clock-in/out flow."
+    },
+    {
+      "id": "sla_targets",
+      "name": "Service SLA targets",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "Service SLA targets on orders"
+    },
+    {
+      "id": "service_packages",
+      "name": "Service package templates",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "Reusable service package templates"
+    },
+    {
+      "id": "recurring_orders",
+      "name": "Recurring service orders",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "Recurring service order generation"
+    },
+    {
+      "id": "territory_routing",
+      "name": "Territory/route optimization",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "Territory/route optimization for visits"
+    },
+    {
+      "id": "contract_linking",
+      "name": "Service contract linking",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "Orders link to service contracts"
+    }
   ]
 }

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -18,13 +18,13 @@ category: reference
 | **shipping** | Inventory → Delivery/Shipping connectors | L2 → L4 | `███░░░░░░░` 31% | 4/2/9 | — |
 | **docs** | Knowledge (documentation) | L3 → L4 | `███░░░░░░░` 33% | 2/0/3 | — |
 | **email** | Mail / Discuss (outbound email) | L3 → L4 | `████░░░░░░` 38% | 2/1/4 | — |
-| **field-service** | Field Service (industry_fsm) | L2 → L4 | `████░░░░░░` 38% | 5/2/7 | — |
 | **forms** | Website forms | L4 → L4 | `████░░░░░░` 39% | 1/3/3 | — |
 | **booking** | Appointments (calendar.appointment) | L3 → L4 | `████░░░░░░` 41% | 9/0/10 | — |
 | **projects** | Project (project.project/project.task) | L3 → L4 | `████░░░░░░` 41% | 5/2/6 | — |
 | **sla** | Helpdesk SLA policies | L3 → L4 | `████░░░░░░` 41% | 7/0/8 | — |
 | **chat** | Livechat + chatbot | L3 → L4 | `████░░░░░░` 42% | 0/4/1 | — |
 | **global-blocks** | Website building blocks/snippets | L3 → L4 | `████░░░░░░` 42% | 0/3/1 | — |
+| **field-service** | Field Service (industry_fsm) | L2 → L4 | `████░░░░░░` 44% | 5/3/6 | — |
 | **fixed-assets** | Accounting → Assets | L3 → L4 | `████░░░░░░` 44% | 7/0/7 | — |
 | **pos** | Point of Sale (pos.order) | L3 → L4 | `████░░░░░░` 44% | 7/2/7 | — |
 | **quotes** | Sales (sale.order quotation) | L3 → L4 | `████░░░░░░` 44% | 8/0/8 | — |

--- a/supabase/migrations/20260614010000_f2f146cc-d61c-437b-ae06-c21236f751ea.sql
+++ b/supabase/migrations/20260614010000_f2f146cc-d61c-437b-ae06-c21236f751ea.sql
@@ -1,0 +1,56 @@
+-- Field Service: parts inventory deduction
+-- (docs/parity/capabilities/field-service.json#parts_inventory_deduction).
+-- When a service order is completed, its MATERIAL lines should draw stock down —
+-- today they don't. Extend the existing emit_service_order_event trigger so that,
+-- on completion, every material line with a product_id emits a stock.movement event
+-- (negative quantity), the same channel POS uses. The stock module's listener does
+-- the actual quant decrement. All prior behavior (created/completed/scheduled
+-- events) is preserved. Idempotent CREATE OR REPLACE.
+
+CREATE OR REPLACE FUNCTION "public"."emit_service_order_event"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_line RECORD;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    PERFORM public.emit_platform_event('service_order.created',
+      jsonb_build_object('id', NEW.id, 'order_number', NEW.order_number, 'customer_name', NEW.customer_name, 'priority', NEW.priority),
+      'service_orders');
+  ELSIF TG_OP = 'UPDATE' AND NEW.status IS DISTINCT FROM OLD.status THEN
+    IF NEW.status = 'completed' THEN
+      PERFORM public.emit_platform_event('service_order.completed',
+        jsonb_build_object('id', NEW.id, 'order_number', NEW.order_number, 'customer_name', NEW.customer_name, 'customer_email', NEW.customer_email, 'total_amount', NEW.total_amount),
+        'service_orders');
+      -- Deduct consumed parts: one stock.movement per material line with a product.
+      -- Only on the unfulfilled→completed transition (status changed to completed),
+      -- so re-saving a completed order does not double-deduct.
+      FOR v_line IN
+        SELECT product_id, quantity, description
+        FROM public.service_order_lines
+        WHERE service_order_id = NEW.id AND kind = 'material' AND product_id IS NOT NULL
+      LOOP
+        PERFORM public.emit_platform_event(
+          'stock.movement',
+          jsonb_build_object(
+            'product_id', v_line.product_id,
+            'quantity', -(v_line.quantity),
+            'reason', 'field_service',
+            'reference_type', 'service_order',
+            'reference_id', NEW.id,
+            'description', v_line.description
+          ),
+          'service_orders');
+      END LOOP;
+    ELSIF NEW.status = 'scheduled' THEN
+      PERFORM public.emit_platform_event('service_order.scheduled',
+        jsonb_build_object('id', NEW.id, 'order_number', NEW.order_number, 'scheduled_start', NEW.scheduled_start),
+        'service_orders');
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION "public"."emit_service_order_event"() OWNER TO "postgres";


### PR DESCRIPTION
## field-service — deduct parts stock on completion

`field-service.parts_inventory_deduction` (weight 2): 38% → **44%**.

### What
Completing a service order now draws down stock for its **material** lines — previously they didn't move inventory. Extends the existing `emit_service_order_event` trigger: on the `→completed` transition, each `service_order_lines` row with `kind='material'` and a `product_id` emits a `stock.movement` event (negative quantity) on the same channel POS uses; the stock module's listener performs the quant decrement.

- Labor / expense lines are untouched.
- Guarded by the status-change condition, so re-saving an already-completed order does **not** re-emit → no double-deduct.
- All prior events (created / completed / scheduled) preserved.

### Verified (Stage 2, scratch Postgres)
- complete an order with 2 material lines (qty 2, 5) + 1 labor line → exactly **2** `stock.movement` events with `quantity` −2 and −5, `reason=field_service`; labor produced none
- re-save the completed order (no status change) → **no** new stock.movement (still 2)
- migration idempotent; vitest (full) + `parity:check` green

### Scorecard
`field-service.parts_inventory_deduction`: `missing → partial` (emission verified; Stage-3 runtime confirmation that the listener decrements the quant pending before `done`).

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_