### PR TITLE
docs(parity): docs L3→L4 — 3 caps verified & done (33%→100%)

### DIFF
--- a/docs/parity/capabilities/docs.json
+++ b/docs/parity/capabilities/docs.json
@@ -1,13 +1,13 @@
 {
   "module": "docs",
   "odoo_app": "Knowledge (documentation)",
-  "current_maturity": "L3",
+  "current_maturity": "L4",
   "target_maturity": "L4",
   "capabilities": [
-    { "id": "doc_crud", "name": "Doc page CRUD", "odoo": true, "status": "missing", "weight": 2, "verify": "docs_search is read-only; DocsAdminPage.tsx only syncs from GitHub (useSyncDocs)", "notes": "Content is authored in the GitHub repo, not in-app; no CRUD skill or editor." },
+    { "id": "doc_crud", "name": "Doc page CRUD", "odoo": true, "status": "done", "weight": 2, "verify": "manage_docs_page RPC (create/update/delete) verified end-to-end on real Postgres (demo) + live via agent-execute on flowwink.com; DocsAdminPage Authoring tab + useManageDocsPage", "notes": "In-app authoring alongside GitHub sync (source=app); sync only touches source=github rows." },
     { "id": "structure_nav", "name": "Structured navigation/TOC", "odoo": true, "status": "done", "weight": 1, "verify": "docs_search category browse param; DocsSidebar.tsx category tree on DocsLandingPage.tsx" },
     { "id": "search", "name": "Search", "odoo": true, "status": "done", "weight": 1, "verify": "docs_search skill (scope both); search input in DocsSidebar.tsx" },
-    { "id": "public_private", "name": "Public/private visibility", "odoo": true, "status": "missing", "weight": 1, "verify": "no visibility/is_published flag for docs pages; all synced docs are public" },
-    { "id": "versioning", "name": "Versioning", "odoo": true, "status": "missing", "weight": 1, "verify": "no in-app version history; history lives only in upstream git" }
+    { "id": "public_private", "name": "Public/private visibility", "odoo": true, "status": "done", "weight": 1, "verify": "is_published col + RLS read policy (anon sees only published) + docs_search is_published filter; draft create (is_published=false) verified on demo + live via agent-execute" },
+    { "id": "versioning", "name": "Versioning", "odoo": true, "status": "done", "weight": 1, "verify": "docs_page_versions + transactional snapshot in manage_docs_page; update→snapshot and restore_version→rollback(+snapshot) verified on real Postgres; DocsAuthoring version-history UI" }
   ]
 }

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -9,14 +9,13 @@ category: reference
 > **GENERATED FILE.** Run `bun run scripts/parity-report.ts` to refresh.
 > Edit `docs/parity/capabilities/<module>.json` to change scores.
 
-**Benchmarked modules:** 53  ·  **Mean parity:** 57%  ·  **Differentiators (no Odoo benchmark):** 10  ·  **Unscored:** 0
+**Benchmarked modules:** 53  ·  **Mean parity:** 58%  ·  **Differentiators (no Odoo benchmark):** 10  ·  **Unscored:** 0
 
 ## Scored modules
 
 | Module | Odoo app | Maturity → target | Parity | Done/Partial/Missing | Open epics |
 |---|---|---|---|---|---|
 | **shipping** | Inventory → Delivery/Shipping connectors | L2 → L4 | `███░░░░░░░` 31% | 4/2/9 | — |
-| **docs** | Knowledge (documentation) | L3 → L4 | `███░░░░░░░` 33% | 2/0/3 | — |
 | **email** | Mail / Discuss (outbound email) | L3 → L4 | `████░░░░░░` 38% | 2/1/4 | — |
 | **forms** | Website forms | L4 → L4 | `████░░░░░░` 39% | 1/3/3 | — |
 | **projects** | Project (project.project/project.task) | L3 → L4 | `████░░░░░░` 41% | 5/2/6 | — |
@@ -67,6 +66,7 @@ category: reference
 | **companies** | Contacts (res.partner companies) | L4 → L4 | `█████████░` 93% | 11/0/1 | — |
 | **approvals** | Approvals + studio approval rules | L3 → L4 | `██████████` 100% | 9/0/0 | — |
 | **customer360** | Contacts 360 view (partner timeline) | L3 → L4 | `██████████` 100% | 2/0/0 | — |
+| **docs** | Knowledge (documentation) | L4 → L4 | `██████████` 100% | 5/0/0 | — |
 | **sales-intelligence** | CRM lead scoring (partial counterpart) | L4 → L4 | `██████████` 100% | 1/0/0 | — |
 
 ## Differentiators (no Odoo counterpart — excluded from the mean)


### PR DESCRIPTION
Flips the docs module's three open caps to `done` after live verification (feature shipped in #69):

| cap | verification |
|-----|--------------|
| `doc_crud` | manage_docs_page RPC end-to-end (demo Postgres) + **live agent-execute** create/delete on flowwink.com |
| `public_private` | is_published col + RLS read policy + docs_search filter; draft create verified |
| `versioning` | docs_page_versions transactional snapshot; update→snapshot, restore→rollback(+snapshot) verified |

**docs: 33% → 100%** (5/5). Mean fleet parity 57% → 58%. `current_maturity` L3 → L4.

Deploy already done on the FlowWink pair: migration live-applied + `sync:skills` + `agent-execute` deployed to flowwink.com + demo. autoversio (fork) / liteit (customer) intentionally not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)