### PR TITLE
feat(forms): file upload fields (private bucket + signed-URL downloads) — 56%→67%

### DIFF
--- a/docs/parity/capabilities/forms.json
+++ b/docs/parity/capabilities/forms.json
@@ -9,7 +9,7 @@
     { "id": "spam_protection", "name": "Spam protection", "odoo": true, "status": "done", "weight": 1, "verify": "honeypot field (off-screen) + 800ms time-trap in FormBlock.tsx — bot submissions dropped silently; build-verified" },
     { "id": "notifications", "name": "Submission notifications", "odoo": true, "status": "missing", "weight": 1, "verify": "no notification skill or UI; only the form.submitted webhook event for automations" },
     { "id": "custom_fields", "name": "Custom field types", "odoo": true, "status": "done", "weight": 1, "verify": "text/email/phone/textarea/checkbox + select/radio/date/number in FormBlockEditor (options UI) and FormBlock public render; build-verified", "notes": "Added select/radio (with options), date, number field types." },
-    { "id": "file_uploads", "name": "File upload fields", "odoo": true, "status": "missing", "weight": 1, "verify": "no file field type in FormBlockEditor" },
+    { "id": "file_uploads", "name": "File upload fields", "odoo": true, "status": "done", "weight": 1, "verify": "file field type (accept + max-size settings) in FormBlockEditor; FormBlock uploads to private form-uploads bucket on submit; FormSubmissionsPage signed-URL downloads. Verified on demo: anon upload OK, anon read denied (private), bucket RLS applied", "notes": "Private 10MB bucket + RLS (anon insert, admin read/delete). Recruiting/CV pipeline (extract-pdf-text→parse-resume) is the natural follow-on." },
     { "id": "submissions_admin", "name": "Submission management (list/get/stats/delete)", "odoo": true, "status": "done", "weight": 1, "verify": "manage_form_submissions skill; FormSubmissionsPage.tsx", "notes": "Added: full submission admin on both surfaces." }
   ]
 }

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -42,7 +42,6 @@ category: reference
 | **reconciliation** | Accounting bank reconciliation | L3 → L4 | `█████░░░░░` 53% | 7/2/4 | — |
 | **recruitment** | Recruitment (hr.applicant) | L3 → L4 | `█████░░░░░` 53% | 9/0/7 | — |
 | **documents** | Documents (documents.document) | L3 → L4 | `██████░░░░` 56% | 2/1/3 | — |
-| **forms** | Website forms | L4 → L4 | `██████░░░░` 56% | 3/2/2 | — |
 | **media** | Website media library | L2 → L4 | `██████░░░░` 57% | 2/3/1 | — |
 | **multi-currency** | Accounting multi-currency | L2 → L4 | `██████░░░░` 57% | 6/0/4 | — |
 | **wiki** | Knowledge (knowledge.article) | L2 → L4 | `██████░░░░` 57% | 3/0/3 | — |
@@ -56,6 +55,7 @@ category: reference
 | **inventory** | Inventory (stock) | L3 → L4 | `██████░░░░` 64% | 9/2/5 | — |
 | **surveys** | Surveys (survey.survey) | L2 → L4 | `██████░░░░` 64% | 2/4/0 | — |
 | **maintenance** | Maintenance (maintenance.equipment / maintenance.request) | L3 → L4 | `███████░░░` 65% | 3/1/3 | — |
+| **forms** | Website forms | L4 → L4 | `███████░░░` 67% | 4/2/1 | — |
 | **returns** | Inventory returns / RMA | L2 → L4 | `███████░░░` 69% | 9/0/4 | — |
 | **pages** | Website (website.page) | L4 → L4 | `███████░░░` 70% | 5/0/3 | — |
 | **kb** | Knowledge / Helpdesk KB | L3 → L4 | `███████░░░` 71% | 3/2/1 | — |

--- a/src/components/admin/blocks/FormBlockEditor.tsx
+++ b/src/components/admin/blocks/FormBlockEditor.tsx
@@ -45,6 +45,7 @@ import {
   CircleDot,
   Calendar,
   Hash,
+  Paperclip,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -64,6 +65,7 @@ const FIELD_TYPE_OPTIONS: { value: FormFieldType; label: string; icon: React.Rea
   { value: 'radio', label: 'Radio', icon: <CircleDot className="h-4 w-4" /> },
   { value: 'date', label: 'Date', icon: <Calendar className="h-4 w-4" /> },
   { value: 'number', label: 'Number', icon: <Hash className="h-4 w-4" /> },
+  { value: 'file', label: 'File', icon: <Paperclip className="h-4 w-4" /> },
 ];
 
 const CHOICE_TYPES: FormFieldType[] = ['select', 'radio'];
@@ -189,7 +191,7 @@ function SortableFieldItem({ field, onUpdate, onDelete, isExpanded, onToggleExpa
             />
           </div>
 
-          {field.type !== 'checkbox' && !CHOICE_TYPES.includes(field.type) && (
+          {field.type !== 'checkbox' && !CHOICE_TYPES.includes(field.type) && field.type !== 'file' && (
             <div className="space-y-1.5">
               <Label className="text-xs">Placeholder</Label>
               <Input
@@ -197,6 +199,28 @@ function SortableFieldItem({ field, onUpdate, onDelete, isExpanded, onToggleExpa
                 onChange={(e) => onUpdate({ placeholder: e.target.value })}
                 placeholder="Placeholder text"
               />
+            </div>
+          )}
+
+          {field.type === 'file' && (
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label className="text-xs">Accepted types</Label>
+                <Input
+                  value={field.accept || ''}
+                  onChange={(e) => onUpdate({ accept: e.target.value })}
+                  placeholder=".pdf,.docx"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">Max size (MB)</Label>
+                <Input
+                  type="number"
+                  value={field.maxSizeMB ?? ''}
+                  onChange={(e) => onUpdate({ maxSizeMB: e.target.value ? Number(e.target.value) : undefined })}
+                  placeholder="10"
+                />
+              </div>
             </div>
           )}
 

--- a/src/components/public/blocks/FormBlock.tsx
+++ b/src/components/public/blocks/FormBlock.tsx
@@ -31,6 +31,7 @@ interface FormBlockProps {
 
 export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
   const [formData, setFormData] = useState<Record<string, string | boolean>>({});
+  const [files, setFiles] = useState<Record<string, File>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -81,6 +82,18 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
     // Validate all fields
     const newErrors: Record<string, string> = {};
     data.fields.forEach(field => {
+      if (field.type === 'file') {
+        const file = files[field.id];
+        if (field.required && !file) {
+          newErrors[field.id] = 'Please attach a file';
+        } else if (file) {
+          const maxBytes = (field.maxSizeMB ?? 10) * 1024 * 1024;
+          if (file.size > maxBytes) {
+            newErrors[field.id] = `File must be under ${field.maxSizeMB ?? 10} MB`;
+          }
+        }
+        return;
+      }
       const error = validateField(field, formData[field.id] || '');
       if (error) {
         newErrors[field.id] = error;
@@ -96,11 +109,30 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
     setErrors({});
 
     try {
+      // Upload any file fields to the private bucket; store {path,name} in the submission.
+      const uploadedFiles: Record<string, { path: string; name: string }> = {};
+      for (const field of data.fields) {
+        if (field.type !== 'file') continue;
+        const file = files[field.id];
+        if (!file) continue;
+        const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+        const path = `${blockId}/${Date.now()}-${safeName}`;
+        const { error: upErr } = await supabase.storage
+          .from('form-uploads')
+          .upload(path, file, { cacheControl: '3600', upsert: false, contentType: file.type || undefined });
+        if (upErr) throw upErr;
+        uploadedFiles[field.id] = { path, name: file.name };
+      }
+
       // Build submission data with field labels
       const submissionData: Record<string, Json> = {};
       data.fields.forEach(field => {
-        submissionData[field.label] = formData[field.id] !== undefined 
-          ? formData[field.id] 
+        if (field.type === 'file') {
+          submissionData[field.label] = uploadedFiles[field.id] ?? null;
+          return;
+        }
+        submissionData[field.label] = formData[field.id] !== undefined
+          ? formData[field.id]
           : (field.type === 'checkbox' ? false : '');
       });
 
@@ -148,6 +180,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
 
       setIsSubmitted(true);
       setFormData({});
+      setFiles({});
     } catch (error) {
       logger.error('Form submission error:', error);
       toast({
@@ -263,6 +296,40 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
                 </div>
               ))}
             </RadioGroup>
+            {error && <p className="text-xs text-destructive">{error}</p>}
+          </div>
+        );
+
+      case 'file':
+        return (
+          <div key={field.id} className={fieldClasses}>
+            <Label htmlFor={field.id}>
+              {field.label}
+              {field.required && <span className="text-destructive ml-1">*</span>}
+            </Label>
+            <Input
+              id={field.id}
+              type="file"
+              accept={field.accept || undefined}
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                setFiles((prev) => {
+                  const next = { ...prev };
+                  if (f) next[field.id] = f;
+                  else delete next[field.id];
+                  return next;
+                });
+                if (errors[field.id]) {
+                  setErrors((prev) => {
+                    const n = { ...prev };
+                    delete n[field.id];
+                    return n;
+                  });
+                }
+              }}
+              className={cn('cursor-pointer', error && 'border-destructive')}
+            />
+            {field.accept && <p className="text-xs text-muted-foreground">Accepted: {field.accept}</p>}
             {error && <p className="text-xs text-destructive">{error}</p>}
           </div>
         );

--- a/src/pages/admin/FormSubmissionsPage.tsx
+++ b/src/pages/admin/FormSubmissionsPage.tsx
@@ -53,6 +53,34 @@ interface FormSubmission {
   page?: { title: string; slug: string } | null;
 }
 
+/** A file-upload field value persisted by FormBlock: { path, name }. */
+function isFileValue(v: unknown): v is { path: string; name: string } {
+  return (
+    !!v && typeof v === 'object' && 'path' in v &&
+    typeof (v as { path: unknown }).path === 'string'
+  );
+}
+
+/** Renders an uploaded file as a download link, generating a short-lived signed URL on click. */
+function FileDownloadLink({ file }: { file: { path: string; name: string } }) {
+  const [loading, setLoading] = useState(false);
+  const open = async () => {
+    setLoading(true);
+    const { data, error } = await supabase.storage
+      .from('form-uploads')
+      .createSignedUrl(file.path, 120);
+    setLoading(false);
+    if (!error && data?.signedUrl) {
+      window.open(data.signedUrl, '_blank', 'noopener,noreferrer');
+    }
+  };
+  return (
+    <Button variant="link" size="sm" className="h-auto p-0" onClick={open} disabled={loading}>
+      {loading ? 'Preparing…' : file.name || 'Download file'}
+    </Button>
+  );
+}
+
 export default function FormSubmissionsPage() {
   const queryClient = useQueryClient();
   const [searchQuery, setSearchQuery] = useState('');
@@ -357,7 +385,7 @@ export default function FormSubmissionsPage() {
                         {key.replace(/_/g, ' ')}
                       </span>
                       <span className="font-medium text-right max-w-[60%] break-words">
-                        {formatDisplayValue(value)}
+                        {isFileValue(value) ? <FileDownloadLink file={value} /> : formatDisplayValue(value)}
                       </span>
                     </div>
                   ))}

--- a/src/types/cms.ts
+++ b/src/types/cms.ts
@@ -175,7 +175,8 @@ export type FormFieldType =
   | 'select'
   | 'radio'
   | 'date'
-  | 'number';
+  | 'number'
+  | 'file';
 
 export interface FormField {
   id: string;
@@ -186,6 +187,10 @@ export interface FormField {
   width: 'full' | 'half';
   /** Choices for 'select' and 'radio' fields. */
   options?: string[];
+  /** Accept attribute for 'file' fields, e.g. ".pdf,.docx". */
+  accept?: string;
+  /** Client-side max size hint for 'file' fields (the bucket enforces 10 MB server-side). */
+  maxSizeMB?: number;
 }
 
 export interface FormBlockData {

--- a/supabase/migrations/20260615181508_d251a0e7-6992-48ef-87d3-4e5e4db3be3b.sql
+++ b/supabase/migrations/20260615181508_d251a0e7-6992-48ef-87d3-4e5e4db3be3b.sql
@@ -1,0 +1,40 @@
+-- Forms file uploads — private storage bucket + RLS for the `file` form field type.
+--
+-- Public visitors (anon) submit forms, so they must be able to UPLOAD into the bucket,
+-- but only admins may READ/DELETE the files (downloads use admin-generated signed URLs).
+-- Bucket is private with a 10 MB cap and a doc/image mime allowlist (CV-friendly).
+--
+-- Idempotent: ON CONFLICT / DROP POLICY IF EXISTS.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'form-uploads', 'form-uploads', false, 10485760,
+  ARRAY[
+    'application/pdf',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'image/png', 'image/jpeg', 'image/webp', 'text/plain'
+  ]
+)
+ON CONFLICT (id) DO UPDATE
+  SET file_size_limit = EXCLUDED.file_size_limit,
+      allowed_mime_types = EXCLUDED.allowed_mime_types,
+      public = EXCLUDED.public;
+
+-- anon + authenticated may upload into this bucket (public form submissions).
+DROP POLICY IF EXISTS "form-uploads insert" ON storage.objects;
+CREATE POLICY "form-uploads insert" ON storage.objects
+  FOR INSERT TO anon, authenticated
+  WITH CHECK (bucket_id = 'form-uploads');
+
+-- only admins may read the files (signed URLs are generated admin-side).
+DROP POLICY IF EXISTS "form-uploads admin read" ON storage.objects;
+CREATE POLICY "form-uploads admin read" ON storage.objects
+  FOR SELECT TO authenticated
+  USING (bucket_id = 'form-uploads' AND public.has_role(auth.uid(), 'admin'::public.app_role));
+
+-- only admins may delete uploaded files.
+DROP POLICY IF EXISTS "form-uploads admin delete" ON storage.objects;
+CREATE POLICY "form-uploads admin delete" ON storage.objects
+  FOR DELETE TO authenticated
+  USING (bucket_id = 'form-uploads' AND public.has_role(auth.uid(), 'admin'::public.app_role));


### PR DESCRIPTION
forms `file_uploads` cap → **done**. A `file` field type that uploads to a private bucket on submit; admins download via signed URLs.

## What
- **migration**: `form-uploads` bucket (private, 10 MB, doc/image mime allowlist) + `storage.objects` RLS — **anon INSERT**, **admin SELECT/DELETE**
- `cms.ts`: `file` field type + `accept` / `maxSizeMB`
- `FormBlockEditor`: file in palette + accepted-types & max-size settings
- `FormBlock`: file input, client-side size check, upload-on-submit, stores `{path,name}`
- `FormSubmissionsPage`: signed-URL download link for file values

## Verification (verification-loop)
Migration applied to **demo**; then through the real runtime:
- ✅ anon **upload** → HTTP 200, object created
- ✅ anon **read** → HTTP 400 (private; admin-only SELECT)
- ✅ bucket + 3 RLS policies present
- ✅ `eslint` + `tsc` + **production build** clean

**forms 56% → 67%** (4 done / 2 partial / 1 missing). Per-field opt-in, so forms without a file field are unaffected.

## Follow-ons
- **Recruiting/CV pipeline**: application-form CV → `extract-pdf-text` → `parse-resume` → recruitment candidate (the self-hosted-CV value)
- `notifications` (last missing cap) + `manage_form` agent skill surface (flips `builder` / `submissions_to_leads`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)