### PR TITLE
feat(recruitment): CV pipeline — application form → parsed candidate (self-hosted)

### DIFF
--- a/src/components/admin/blocks/FormBlockEditor.tsx
+++ b/src/components/admin/blocks/FormBlockEditor.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
 import {
   DndContext,
   closestCenter,
@@ -259,6 +261,21 @@ function SortableFieldItem({ field, onUpdate, onDelete, isExpanded, onToggleExpa
 export function FormBlockEditor({ data, onChange, isEditing }: FormBlockEditorProps) {
   const [expandedFieldId, setExpandedFieldId] = useState<string | null>(null);
 
+  // Job postings to optionally link this form to (turns it into an application form).
+  const { data: jobPostings = [] } = useQuery({
+    queryKey: ['form-job-postings'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('job_postings')
+        .select('id, title, status')
+        .neq('status', 'draft')
+        .order('title');
+      if (error) return [];
+      return (data || []) as { id: string; title: string; status: string }[];
+    },
+    enabled: isEditing,
+  });
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
@@ -514,6 +531,28 @@ export function FormBlockEditor({ data, onChange, isEditing }: FormBlockEditorPr
           />
           <p className="text-xs text-muted-foreground">
             Email this address on every submission. Leave blank to disable.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Job posting (optional)</Label>
+          <Select
+            value={data.jobPostingId || '__none__'}
+            onValueChange={(v) => updateField('jobPostingId', v === '__none__' ? undefined : v)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="None — regular form" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__none__">None — regular form</SelectItem>
+              {jobPostings.map((j) => (
+                <SelectItem key={j.id} value={j.id}>{j.title}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Link a job to make this an application form — a submitted CV (file field) is
+            parsed into a recruitment application.
           </p>
         </div>
 

--- a/src/components/public/blocks/FormBlock.tsx
+++ b/src/components/public/blocks/FormBlock.tsx
@@ -209,6 +209,33 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
         }
       }
 
+      // Job application — route the uploaded CV into the recruitment pipeline.
+      if (data.jobPostingId) {
+        const fileFieldId = data.fields.find((f) => f.type === 'file')?.id;
+        const cv = fileFieldId ? uploadedFiles[fileFieldId] : undefined;
+        if (cv) {
+          try {
+            await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/process-job-application`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY}`,
+                apikey: import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY,
+              },
+              body: JSON.stringify({
+                job_posting_id: data.jobPostingId,
+                storage_path: `form-uploads/${cv.path}`,
+                candidate_name: nameField ? (formData[nameField.id] as string) : undefined,
+                candidate_email: emailField ? (formData[emailField.id] as string) : undefined,
+                candidate_phone: phoneField ? (formData[phoneField.id] as string) : undefined,
+              }),
+            });
+          } catch (appErr) {
+            logger.error('process-job-application failed:', appErr);
+          }
+        }
+      }
+
       setIsSubmitted(true);
       setFormData({});
       setFiles({});

--- a/src/types/cms.ts
+++ b/src/types/cms.ts
@@ -203,6 +203,12 @@ export interface FormBlockData {
   variant: 'default' | 'card' | 'minimal';
   /** When set, each submission emails this address (submission notifications). */
   notifyEmail?: string;
+  /**
+   * When set, this form is a job application: on submit the uploaded CV (file field)
+   * is routed through process-job-application (extract-pdf-text → parse-resume →
+   * recruitment application) for the linked job posting.
+   */
+  jobPostingId?: string;
 }
 
 // Global block slot types

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -116,6 +116,9 @@ verify_jwt = false
 [functions.parse-resume]
 verify_jwt = false
 
+[functions.process-job-application]
+verify_jwt = false
+
 [functions.process-image]
 verify_jwt = false
 

--- a/supabase/functions/process-job-application/index.ts
+++ b/supabase/functions/process-job-application/index.ts
@@ -1,0 +1,105 @@
+// process-job-application — turns a website form submission with a CV upload into
+// a recruitment application. Chains the existing pieces:
+//   extract-pdf-text (CV in Storage → text) → parse-resume (text → profile)
+//   → INSERT applications (the AFTER-INSERT trigger then drives the recruitment pipeline).
+//
+// Best-effort enrichment: if extraction or parsing fails, the application is STILL
+// created from the form-provided name/email + resume_url, so no candidate is lost.
+// This is the self-hosted CV path — documents stay on the customer's own instance.
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { getServiceClient } from '../_shared/supabase-clients.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const {
+      job_posting_id,
+      storage_path,
+      candidate_name,
+      candidate_email,
+      candidate_phone,
+      cover_letter,
+    } = await req.json();
+
+    if (!job_posting_id) throw new Error('job_posting_id is required');
+    if (!storage_path) throw new Error('storage_path (uploaded CV) is required');
+
+    const supabase = getServiceClient();
+
+    // 1. Extract text from the uploaded CV (best-effort).
+    let resumeText = '';
+    try {
+      const { data: ext, error } = await supabase.functions.invoke('extract-pdf-text', {
+        body: { storage_path },
+      });
+      if (error) console.error('extract-pdf-text error:', error.message ?? error);
+      else if (ext?.success) resumeText = ext.text || '';
+    } catch (e) {
+      console.error('extract-pdf-text threw:', e);
+    }
+
+    // 2. Parse the resume into a structured profile (best-effort).
+    let profile: Record<string, unknown> = {};
+    if (resumeText && resumeText.length >= 20) {
+      try {
+        const { data: parsed, error } = await supabase.functions.invoke('parse-resume', {
+          body: { resume_text: resumeText },
+        });
+        if (error) console.error('parse-resume error:', error.message ?? error);
+        else if (parsed?.success) profile = parsed.profile || {};
+      } catch (e) {
+        console.error('parse-resume threw:', e);
+      }
+    }
+
+    // 3. Create the application — the candidate applied regardless of parse success.
+    const name = candidate_name || (profile.name as string) || 'Unknown applicant';
+    const email = candidate_email || (profile.email as string) || '';
+    if (!email) throw new Error('candidate_email is required (from the form or the parsed CV)');
+    const skills = Array.isArray(profile.skills) ? (profile.skills as string[]) : [];
+
+    const { data: app, error: insErr } = await supabase
+      .from('applications')
+      .insert({
+        job_posting_id,
+        candidate_name: name,
+        candidate_email: email,
+        candidate_phone: candidate_phone || (profile.phone as string) || null,
+        resume_url: storage_path,
+        cover_letter: cover_letter || null,
+        parsed_resume: profile,
+        detected_skills: skills,
+        ai_summary: (profile.summary as string) || null,
+        source: 'website_form',
+        stage: 'applied',
+      })
+      .select('id')
+      .single();
+    if (insErr) throw new Error(`Create application failed: ${insErr.message}`);
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        application_id: app.id,
+        parsed: Object.keys(profile).length > 0,
+        skills_detected: skills.length,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('process-job-application error:', message);
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});


### PR DESCRIPTION
The strategic follow-on to forms `file_uploads`: a form linked to a job posting becomes an **application form**, and the uploaded CV flows into recruitment — **all on the customer's own instance** (no third-party ATS; the self-hosted data-sovereignty value).

## Pipeline
`FormBlock` (CV upload, already private bucket) → **`process-job-application`** edge fn:
1. `extract-pdf-text` (CV in Storage → text)
2. `parse-resume` (text → `{name,email,phone,skills,summary,…}`)
3. `INSERT applications` (`source=website_form`, `stage=applied`, `resume_url`, `parsed_resume`, `detected_skills`) → the existing **AFTER-INSERT trigger** drives scoring/pipeline

**Best-effort enrichment:** if extract/parse fail, the application is still created from the form's name/email + resume_url — no candidate lost.

## Trigger
- `jobPostingId` on FormBlockData
- FormBlockEditor: a job-posting selector ("link a job → application form")
- FormBlock: fire-and-forget call on submit when linked + a CV is uploaded

## Verification (verification-loop)
Deployed to demo; full run:
- ✅ `process-job-application` → HTTP 200, application created (`source=website_form`, `stage=applied`, `resume_url` set)
- ✅ graceful degradation: non-PDF test file → no profile, **application still created**
- ✅ AFTER-INSERT trigger present (drives recruitment pipeline)
- ✅ `eslint` + `tsc` + **production build** clean

Full PDF→profile enrichment is best-effort (needs a real PDF + AI provider configured). Deploy: `process-job-application` fn + frontend (auto on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)