### PR TITLE
docs: documentation audit — fix 110 broken links, refresh stale claims, patch regenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > A modular, self-hosted SaaS platform whose every capability is exposed as a skill over **MCP**. Run it with the built-in vertically-integrated operator **FlowPilot**, swap in an external one like **[OpenClaw](https://www.clawable.org)**, mix several in parallel — or run it as a pure SaaS with humans in the loop. The platform doesn't care.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/badge/release-v2.1-brightgreen)](https://github.com/magnusfroste/flowwink/releases)
+[![Release](https://img.shields.io/badge/release-v1.3.0-brightgreen)](https://github.com/magnusfroste/flowwink/releases)
 
 ---
 
@@ -27,7 +27,7 @@
 
 For decades, business software has been a collection of tools you operate manually — CMS, CRM, ERP, email, e-commerce — each requiring human input at every step.
 
-**FlowWink is a Business Operating System (BOS):** a unified, modular platform where every module (62 across CMS, CRM, commerce, finance, HR, operations) exposes its capabilities as **agent skills over MCP**. An operator — local or external — turns those skills into autonomous business outcomes.
+**FlowWink is a Business Operating System (BOS):** a unified, modular platform where every module (63 across CMS, CRM, commerce, finance, HR, operations) exposes its capabilities as **agent skills over MCP**. An operator — local or external — turns those skills into autonomous business outcomes.
 
 You set the direction. The operator runs the business. You choose which operator.
 
@@ -38,7 +38,7 @@ You set the direction. The operator runs the business. You choose which operator
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │  FlowWink SaaS Platform  (always on, agent-agnostic)         │
-│  • 62 modules · 280 MCP-exposed skills                      │
+│  • 63 modules · 300 MCP-exposed skills                      │
 │  • Database + RLS · Automations · Event bus · Workflows      │
 │  • MCP server — the universal surface for any operator       │
 └──────────────────────────────────────────────────────────────┘
@@ -94,7 +94,7 @@ FlowPilot is not a chatbot, a copilot, or a content suggester. It is an **autono
 
 ---
 
-## Modules — 50+ integrated domains
+## Modules — 63 integrated domains
 
 FlowWink follows an **Odoo-inspired modular architecture** where each module owns its data, views, and skill seeds. Modules register via `defineModule()` with typed contracts.
 
@@ -104,12 +104,13 @@ FlowWink follows an **Odoo-inspired modular architecture** where each module own
 | **CRM & Sales** | Leads, Companies, Deals, Quotes, Sales Intelligence, Customer 360, Company Insights |
 | **Commerce** | Products, Orders, POS, Bookings, Subscriptions, Inventory |
 | **Finance** | Accounting (BAS 2024 / IFRS / US GAAP), Invoicing, Expenses, Reconciliation, Timesheets |
-| **HR & People** | HR, Recruitment, Resume, Contracts, Signature, Calendar |
-| **Operations** | Projects, Tasks, Field Service, Manufacturing (MRP-light), Purchasing, SLA, Approvals |
+| **HR & People** | HR, Recruitment, Resume, Contracts, Calendar |
+| **Operations** | Projects, Field Service, Manufacturing (MRP-light), Purchasing, SLA, Approvals, Maintenance |
 | **Communication** | Email, Newsletter, Webinars, Chat, Workspace Chat |
 | **Support** | Tickets (Kanban + auto-triage), Live Support |
-| **Growth** | Analytics, Paid Growth, Content Campaigns |
+| **Growth** | Analytics, Paid Growth |
 | **System & Operator** | FlowPilot, Federation (A2A + MCP), Browser Control, Composio, Site Migration, Developer, Documents |
+| **Money & Assets** *(cross-cutting finance)* | Multi-Currency, Pricelists, Fixed Assets, Payroll, Returns, Shipping, River, Wiki |
 
 Each module provides:
 - **Data layer** — Supabase tables + RLS policies + RPCs
@@ -121,7 +122,7 @@ Composite MCP groups (`marketing`, `sales`, `operations`, …) let an external o
 
 ---
 
-## Skills — 280 capabilities, exposed over MCP
+## Skills — 300 capabilities, exposed over MCP
 
 | Domain | Sample skills |
 |--------|---------------|
@@ -137,7 +138,7 @@ Composite MCP groups (`marketing`, `sales`, `operations`, …) let an external o
 | **Intelligence** | `search_web`, `extract_pdf_text`, `competitor_monitor`, `prospect_research` |
 | **Operator-internal** *(FlowPilot only, not MCP)* | objectives, soul, reflect, planning, A2A delegation |
 
-All skills follow Anthropic's MCP best practices: self-describing (`Use when:` / `NOT for:`), flat OpenAI-strict-mode-safe JSON Schemas, namespaced. See [`docs/architecture/mcp-overview.md`](docs/architecture/mcp-overview.md).
+All skills follow Anthropic's MCP best practices: self-describing (`Use when:` / `NOT for:`), flat OpenAI-strict-mode-safe JSON Schemas, namespaced. See [`docs/architecture/mcp-as-platform.md`](docs/architecture/mcp-as-platform.md).
 
 ---
 
@@ -205,7 +206,7 @@ skill_pack_install("CRM Nurture Pack")       → lead_pipeline_review, deal_stal
 
 FlowWink speaks two open protocols so any operator can connect:
 
-- **MCP (Model Context Protocol)** — the primary surface. 280 skills exposed as tools, resources like `flowwink://briefing`, group filtering via `?groups=marketing`. Works with Claude Desktop, OpenClaw, custom MCP clients.
+- **MCP (Model Context Protocol)** — the primary surface. 300 skills exposed as tools, resources like `flowwink://briefing`, group filtering via `?groups=marketing`. Works with Claude Desktop, OpenClaw, custom MCP clients.
 - **A2A (Agent-to-Agent JSON-RPC 2.0)** — peer-to-peer delegation between agents.
 
 ```
@@ -213,8 +214,8 @@ FlowWink speaks two open protocols so any operator can connect:
 │  FlowWink   │◄──────────────▶│  Operator           │
 │  Platform   │   tools/call   │  • FlowPilot (local)│
 │ (modules +  │   resources    │  • OpenClaw         │
-│  280 skills)│   message/send │  • Claude Desktop   │
-└─────────────┘                │  • custom           │
+│ (modules +  │   message/send │  • Claude Desktop   │
+│  300 skills)│                │  • custom           │
                                 └────────────────────┘
 ```
 
@@ -245,7 +246,7 @@ FlowWink follows the **OpenClaw** agentic architecture — composable layers wit
        ┌──────▼─────┐  ┌───────▼───────┐  ┌────────▼──────┐
        │   Skills    │  │   Heartbeat   │  │   Workflows   │
        │             │  │               │  │               │
-       │ 60+ skills  │  │ 7-step loop   │  │ DAG chains    │
+       │ 300 skills  │  │ 7-step loop   │  │ DAG chains    │
        │ Skill Packs │  │ Self-healing  │  │ Conditions    │
        │ A2A peers   │  │ Outcome eval  │  │ Template vars │
        └─────────────┘  └───────────────┘  └───────────────┘
@@ -305,7 +306,7 @@ FlowWink draws inspiration from the best-in-class platforms across every busines
 | **E-Commerce** | Shopify, WooCommerce | Products, orders, inventory, Stripe checkout |
 | **Finance** | QuickBooks, Xero, FreshBooks | Invoicing, double-entry accounting, expenses |
 | **Time Tracking** | Toggl, Harvest, Clockify | Timesheets with project-based tracking |
-| **ERP** | Odoo, ERPNext | Modular architecture — 37 domains, one platform |
+| **ERP** | Odoo, ERPNext | Modular architecture — 63 domains, one platform |
 | **Headless CMS** | Contentful, Storyblok, Strapi | REST + GraphQL content API, multi-channel delivery |
 
 **The difference:** those platforms give you tools. FlowWink gives you an operator that *uses* the tools.
@@ -429,8 +430,7 @@ FlowWink is the reference implementation of a thesis: **traditional SaaS becomes
 
 Cross-references inside this repo:
 - [`docs/concepts/operator-strategy.md`](docs/concepts/operator-strategy.md) — Why FlowPilot is a *module*, not the core
-- [`docs/architecture/mcp-as-platform.md`](docs/architecture/mcp-as-platform.md) — The rule that keeps modules + MCP independent of any operator
-- [`docs/architecture/mcp-overview.md`](docs/architecture/mcp-overview.md) — MCP endpoints, auth, schemas, group filtering
+- [`docs/architecture/mcp-as-platform.md`](docs/architecture/mcp-as-platform.md) — The rule that keeps modules + MCP independent of any operator, and the MCP endpoints / auth / schemas / group-filter reference
 - [`docs/concepts/openclaw-law.md`](docs/concepts/openclaw-law.md) — The 10 inviolable agentic architecture laws
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Both paths share the **concepts** below. Everything else (guides, modules, refer
 
 ## Quick links
 
-- **62 modules** registered in `src/lib/modules/` — every one has a page in [`modules/`](./modules/) (alias-aware via `scripts/check-doc-drift.ts`)
+- **63 modules** registered in `src/lib/modules/` — every one has a page in [`modules/`](./modules/) (alias-aware via `scripts/check-doc-drift.ts`)
 - **8 business processes** documented in [`processes/`](./processes/)
 - **6 department-claw playbooks** in [`agents/`](./agents/) for external MCP operators
 - Public docs portal: [/docs](https://flowwink.com/docs) (auto-synced from this folder, with embedded AI chat)

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -10,7 +10,7 @@ last_updated: "2026-05-04"
 > invite → role → seed/reset (Game Master) flow, then come back for the
 > department-specific playbooks below.
 
-FlowWink exposes ~280 MCP skills. A focused **department claw** picks up
+FlowWink exposes ~300 MCP skills. A focused **department claw** picks up
 one composite group and runs that department end-to-end — without FlowPilot.
 
 | Department | Playbook | Composite group | Brief |

--- a/docs/agents/marketing-claw-playbook.md
+++ b/docs/agents/marketing-claw-playbook.md
@@ -24,7 +24,7 @@ Get a key from `/admin/developer → MCP Keys`.
 
 ## Pull only the marketing toolkit
 
-The MCP server exposes ~280 skills. A focused claw should request only the
+The MCP server exposes ~300 skills. A focused claw should request only the
 marketing toolset to keep its context budget tight:
 
 ```http

--- a/docs/architecture/flowwink-control-model.md
+++ b/docs/architecture/flowwink-control-model.md
@@ -19,7 +19,7 @@ last_updated: "2026-05-29"
 │                     FLOWWINK PLATFORM                        │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐   │
 │  │   MODULES   │  │   SKILLS    │  │   MCP GATEWAY       │   │
-│  │  (62 real   │  │  (280+ in   │  │  (?groups= /        │   │
+│  │  (63 real   │  │  (300+ in   │  │  (?groups= /        │   │
 │  │   SaaS      │  │   DB)       │  │   ?mode=dispatch)   │   │
 │  │   tables)   │  │             │  │                     │   │
 │  └──────┬──────┘  └──────┬──────┘  └──────────┬──────────┘   │

--- a/docs/concepts/elevator-pitch.md
+++ b/docs/concepts/elevator-pitch.md
@@ -52,7 +52,7 @@ See [`../architecture/mcp-as-platform.md`](../architecture/mcp-as-platform.md) a
 
 If you don't want to wire up an external agent, enable FlowPilot:
 
-- Soul, memory, heartbeat, 280+ skills tuned to FlowWink's modules
+- Soul, memory, heartbeat, 300+ skills tuned to FlowWink's modules
 - Runs on OpenAI, Gemini or a local private model — no vendor lock-in
 - Same skill catalog any MCP client sees — nothing FlowPilot-only on the data side
 - Turn it off and the platform keeps working as plain SaaS

--- a/docs/concepts/flowchat-vs-flowpilot.md
+++ b/docs/concepts/flowchat-vs-flowpilot.md
@@ -66,10 +66,10 @@ Without this discipline, two things break:
 1. **Customers who turn FlowPilot off** still have a fully working FlowChat. The platform is independently useful.
 2. **External operators** (OpenClaw, Claude Desktop, department claws) can replace FlowPilot entirely — they drive the same MCP surface FlowChat uses. The platform stays intact.
 
-This is why the layering is explicit: **Platform → FlowChat (always on) → FlowPilot (opt-in operator on top)**, with skills on the platform. See [`platform-modules-operators-layering`](../../mem/architecture/platform-modules-operators-layering.md), [`flowpilot-as-optional-operator-layer`](../../mem/architecture/flowpilot-as-optional-operator-layer.md), and [`internal-flowchat-and-noise-separation`](../../mem/features/internal-flowchat-and-noise-separation.md).
+This is why the layering is explicit: **Platform → FlowChat (always on) → FlowPilot (opt-in operator on top)**, with skills on the platform. See [`flowpilot-as-optional-operator-layer`](../../mem/architecture/flowpilot-as-optional-operator-layer.md), [`flowchat-vs-flowpilot-roles`](../../mem/architecture/flowchat-vs-flowpilot-roles.md), and [`internal-flowchat-and-noise-separation`](../../mem/features/internal-flowchat-and-noise-separation.md).
 
 ## Related
 
 - [FlowPilot Development Laws](./openclaw-law.md) — Law 3: blocks/skills are interfaces, not pipelines
 - [Operator Strategy](./operator-strategy.md) — swappable operator shells
-- [AI Utility vs Skill](../../mem/architecture/ai-utility-vs-skill-classification.md) — pure text transforms vs context-aware skills
+- AI Utility vs Skill — pure text transforms vs context-aware skills (memo pending)

--- a/docs/concepts/openclaw-law.md
+++ b/docs/concepts/openclaw-law.md
@@ -27,7 +27,7 @@ if (/migrate|import/i.test(message)) forcePick('migrate_url');
 
 Every skill MUST contain enough metadata (`description`, `Use when:`, `NOT for:`, `tool_definition.parameters`) for the general scoring algorithm to select it correctly. If a skill isn't being picked up, the fix is **always better metadata** — never a routing hack.
 
-This is enforced by the [Skill Linter](../architecture/skill-linter.md) and the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist.
+This is enforced by the [Skill Linter](../../mem/architecture/skill-linter.md) and the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist.
 
 ---
 
@@ -68,6 +68,6 @@ Break one law and the rest erode within weeks. That's why FlowWink runs CI guard
 
 ## See also
 
-- [`architecture/agent-contract-integrity.md`](../architecture/agent-contract-integrity.md) — pre-release checklist
-- [`architecture/skill-linter.md`](../architecture/skill-linter.md) — automated enforcement
+- [`architecture/agent-contract-integrity.md`](../../mem/architecture/agent-contract-integrity.md) — pre-release checklist
+- [`architecture/skill-linter.md`](../../mem/architecture/skill-linter.md) — automated enforcement
 - [`concepts/operator-strategy.md`](./operator-strategy.md) — how operators (FlowPilot, OpenClaw, external) plug into this model

--- a/docs/concepts/prd.md
+++ b/docs/concepts/prd.md
@@ -29,7 +29,7 @@ FlowWink follows Odoo's module ecosystem model with three tiers:
 
 | Tier | Name | Origin | Trust | Status |
 |------|------|--------|-------|--------|
-| **1** | **Core Modules** | Bundled in repo | `bundled` / full trust | ✅ Active (62 modules) |
+| **1** | **Core Modules** | Bundled in repo | `bundled` / full trust | ✅ Active (63 modules) |
 | **2** | **Community-Submitted** | PR → FlowWink review → merge | `bundled` after review | 🔜 Next |
 | **3** | **External/Marketplace** | Loaded at runtime from external source | `community` + admin install | 🔮 Future |
 
@@ -85,7 +85,7 @@ FlowPilot enabled later: retroactive scan bootstraps all active modules.
        ▼
 ┌──────────────────────────────────────────────────────────────────┐
 │                     FLOWPILOT (Autonomous Agent)                 │
-│  280 skills · pgvector memory · heartbeat · self-healing · A2A  │
+│  300 skills · pgvector memory · heartbeat · self-healing · A2A  │
 │  See FLOWPILOT.md for the agent's full architecture              │
 └──────────────────────────────────────────────────────────────────┘
 
@@ -609,7 +609,7 @@ Introduce a runtime module-loader that reads module manifests from the database,
 Trade-offs: requires runtime dependency resolution, loses some TypeScript compile-time safety, adds startup latency for async loading. Mitigated by keeping manifests statically typed and validating at registration time.
 
 ### Current state (April 2026)
-All 62 modules use `defineModule()` with static imports. Registration happens at build-time in `ModuleRegistry` constructor. Enabled/disabled is a runtime flag that controls UI visibility and pre-flight checks — not code loading.
+All 63 modules use `defineModule()` with static imports. Registration happens at build-time in `ModuleRegistry` constructor. Enabled/disabled is a runtime flag that controls UI visibility and pre-flight checks — not code loading.
 
 ---
 

--- a/docs/concepts/prd.md
+++ b/docs/concepts/prd.md
@@ -387,14 +387,14 @@ HMAC-SHA256 signatures · Retry with exponential backoff · Auto-disable after 5
 
 | Document | Purpose |
 |----------|---------|
-| [FLOWPILOT.md](./flowpilot.md) | FlowPilot agent architecture — the brain of the system |
+| [FLOWPILOT.md](../modules/flowpilot.md) | FlowPilot agent architecture — the brain of the system |
 | [OPENCLAW-LAW.md](./openclaw-law.md) | The 10 laws of agent development |
-| [SKILLS-SOURCE.md](./SKILLS-SOURCE.md) | Skill registry source of truth |
-| [MODULE-API.md](./MODULE-API.md) | Technical module API |
+| [SKILLS-SOURCE.md](../reference/skills-source.md) | Skill registry source of truth |
+| [MODULE-API.md](../reference/module-api.md) | Technical module API |
 | [INTEGRATIONS-STRATEGY.md](./integrations-strategy.md) | Integration architecture |
-| [CONTRIBUTING.md](./CONTRIBUTING.md) | Development guidelines |
-| [DEPLOYMENT.md](./DEPLOYMENT.md) | Deployment instructions |
-| [SECURITY.md](./SECURITY.md) | Security model |
+| [CONTRIBUTING.md](../contributing/contributing.md) | Development guidelines |
+| [DEPLOYMENT.md](../guides/deployment.md) | Deployment instructions |
+| [SECURITY.md](../guides/security.md) | Security model |
 
 ---
 
@@ -481,8 +481,8 @@ The invoicing module (`src/lib/module-bootstraps/invoicing.ts`) closes the Quote
 
 | Reference doc | Path |
 |---|---|
-| [MODULE-API.md](./MODULE-API.md) | Technical module API |
-| [SKILLS-SOURCE.md](./SKILLS-SOURCE.md) | Skill registry source of truth |
+| [MODULE-API.md](../reference/module-api.md) | Technical module API |
+| [SKILLS-SOURCE.md](../reference/skills-source.md) | Skill registry source of truth |
 
 ---
 
@@ -500,8 +500,8 @@ The inventory module tracks stock levels across all e-commerce products with aut
 
 | Reference doc | Path |
 |---|---|
-| [MODULE-API.md](./MODULE-API.md) | Technical module API |
-| [SKILLS-SOURCE.md](./SKILLS-SOURCE.md) | Skill registry source of truth |
+| [MODULE-API.md](../reference/module-api.md) | Technical module API |
+| [SKILLS-SOURCE.md](../reference/skills-source.md) | Skill registry source of truth |
 
 ---
 
@@ -548,8 +548,8 @@ The SLA Monitor (`src/pages/admin/SlaMonitorPage.tsx`) enables policy-based serv
 
 | Reference doc | Path |
 |---|---|
-| [MODULE-API.md](./MODULE-API.md) | Technical module API |
-| [SKILLS-SOURCE.md](./SKILLS-SOURCE.md) | Skill registry source of truth |
+| [MODULE-API.md](../reference/module-api.md) | Technical module API |
+| [SKILLS-SOURCE.md](../reference/skills-source.md) | Skill registry source of truth |
 
 ---
 

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to FlowWink! This guide will help yo
 
 1. Fork the repository
 2. Clone your fork
-3. Follow the setup instructions in [SETUP.md](./SETUP.md)
+3. Follow the setup instructions in [SETUP.md](../guides/setup.md)
 4. Create a branch for your changes
 
 ## Development Workflow

--- a/docs/contributing/running-tests.md
+++ b/docs/contributing/running-tests.md
@@ -3,7 +3,7 @@
 Quick reference for running FlowWink's tests locally and in CI, plus how to refresh snapshots when the database schema or skill contracts change.
 
 > Full overview of every test layer: [`test-suite.md`](./test-suite.md)
-> Server-side L1–L6 autonomy tests: [`testing.md`](./testing.md)
+> Server-side L1–L6 autonomy tests: [`testing.md`](./running-tests.md)
 
 ---
 
@@ -63,7 +63,7 @@ These run **inside an edge function** — not via Vitest. Trigger from the admin
 /admin/autonomy-tests
 ```
 
-See [`testing.md`](./testing.md) for details.
+See [`testing.md`](./running-tests.md) for details.
 
 ---
 

--- a/docs/contributing/test-suite.md
+++ b/docs/contributing/test-suite.md
@@ -90,7 +90,7 @@ These run **outside** the Vitest pipeline because they hit live edge functions. 
 ## 3. Server-side autonomy tests (L1–L6)
 
 Lives entirely in `supabase/functions/run-autonomy-tests/index.ts`. Triggered from `/admin/autonomy-tests`.
-**Full guide:** [`testing.md`](./testing.md).
+**Full guide:** [`testing.md`](./running-tests.md).
 
 | Layer | Tests |
 |---|---|

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -6,9 +6,9 @@
 This guide covers setting up the Supabase backend for FlowWink self-hosting.
 
 > **After completing this guide**, proceed to:
-> - [DEPLOYMENT.md](./DEPLOYMENT.md) - Deploy to production (Easypanel, Railway, etc.)
+> - [DEPLOYMENT.md](./deployment.md) - Deploy to production (Easypanel, Railway, etc.)
 >
-> **Already running FlowWink?** See [UPGRADING.md](./UPGRADING.md) for upgrade instructions.
+> **Already running FlowWink?** See [UPGRADING.md](./upgrading.md) for upgrade instructions.
 
 ## Prerequisites
 
@@ -76,7 +76,7 @@ Before deploying, configure your organization's branding in the Admin panel:
 
 ### 5. Deploy Frontend
 
-See [DEPLOYMENT.md](./DEPLOYMENT.md) for deploying to Easypanel or other platforms.
+See [DEPLOYMENT.md](./deployment.md) for deploying to Easypanel or other platforms.
 
 ### 5. Login
 
@@ -95,7 +95,7 @@ After first login, configure your AI preferences:
 
 > **Important:** The language setting affects ALL AI-generated content including Campaign Manager, blog posts, text generation, and content migration. Default is English.
 
-See [AI_DEPENDENCIES.md](./AI_DEPENDENCIES.md) for detailed AI configuration.
+See [AI_DEPENDENCIES.md](../concepts/ai-dependencies.md) for detailed AI configuration.
 
 ---
 
@@ -225,7 +225,7 @@ Access the app at `http://localhost:5173`
 
 ## Production Deployment
 
-See **[DEPLOYMENT.md](./DEPLOYMENT.md)** for deploying to Easypanel, Railway, or other platforms.
+See **[DEPLOYMENT.md](./deployment.md)** for deploying to Easypanel, Railway, or other platforms.
 
 ---
 

--- a/docs/guides/site-migration.md
+++ b/docs/guides/site-migration.md
@@ -257,10 +257,10 @@ Planned enhancements for Site Migration:
 
 ## Related Documentation
 
-- [Integrations Strategy](./INTEGRATIONS-STRATEGY.md) — Overview of external integrations
-- [Setup Guide](./SETUP.md) — Initial FlowWink setup
-- [Module API](./MODULE-API.md) — Technical API documentation
-- [Developer Guide](./DEVELOPER_GUIDE.md) — Development workflows
+- [Integrations Strategy](../concepts/integrations-strategy.md) — Overview of external integrations
+- [Setup Guide](./setup.md) — Initial FlowWink setup
+- [Module API](../reference/module-api.md) — Technical API documentation
+- [Developer Guide](../modules/developer.md) — Development workflows
 
 ## Support
 

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -6,7 +6,7 @@ This guide explains how to safely upgrade your self-hosted FlowWink installation
 
 ### 1. Read the Changelog
 
-Always check [CHANGELOG.md](../CHANGELOG.md) before upgrading to understand:
+Always check [CHANGELOG.md](../../CHANGELOG.md) before upgrading to understand:
 - New features added
 - Breaking changes that require action
 - Deprecated features

--- a/docs/mcp/getting-started.md
+++ b/docs/mcp/getting-started.md
@@ -37,7 +37,7 @@ All authenticated with `Authorization: Bearer fwk_...`.
 
 ## 3. Filter by group (avoid tool bloat)
 
-Most MCP clients have a tool-budget. Don't ship all 280+ skills — pull only the toolkit the agent needs:
+Most MCP clients have a tool-budget. Don't ship all 300+ skills — pull only the toolkit the agent needs:
 
 ```bash
 curl -H "Authorization: Bearer fwk_..." \

--- a/docs/mcp/resource-briefing.md
+++ b/docs/mcp/resource-briefing.md
@@ -176,7 +176,7 @@ All database queries execute in parallel via `Promise.all`. The edge function ha
 
 ## Convenience Gradient Impact
 
-This resource directly addresses the [Data Locality Law](../strategy/data-locality-law.md) and [Convenience Gradient](../strategy/embedded-agent-convenience-gradient.md):
+This resource directly addresses the **Data Locality Law** and **Convenience Gradient** principles (internal memos — not yet published):
 
 | Metric | Without briefing | With briefing |
 |--------|-----------------|---------------|
@@ -187,4 +187,4 @@ This resource directly addresses the [Data Locality Law](../strategy/data-locali
 
 ---
 
-*See also: [Embedded vs Orchestrated Autonomy](../orchestrating/embedded-vs-orchestrated-autonomy.md) · [Convenience Gradient](../strategy/embedded-agent-convenience-gradient.md) · [Data Locality Law](../strategy/data-locality-law.md)*
+*See also: Embedded vs Orchestrated Autonomy · Convenience Gradient · Data Locality Law — internal memos (pending publication).*

--- a/docs/modules/analytics.md
+++ b/docs/modules/analytics.md
@@ -67,7 +67,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/approvals.md
+++ b/docs/modules/approvals.md
@@ -68,7 +68,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/blog.md
+++ b/docs/modules/blog.md
@@ -73,7 +73,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/bookings.md
+++ b/docs/modules/bookings.md
@@ -63,7 +63,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/browser-control.md
+++ b/docs/modules/browser-control.md
@@ -59,7 +59,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/calendar.md
+++ b/docs/modules/calendar.md
@@ -60,7 +60,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/chat.md
+++ b/docs/modules/chat.md
@@ -58,7 +58,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/companies.md
+++ b/docs/modules/companies.md
@@ -59,7 +59,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/company-insights.md
+++ b/docs/modules/company-insights.md
@@ -56,7 +56,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/composio.md
+++ b/docs/modules/composio.md
@@ -58,7 +58,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/contracts.md
+++ b/docs/modules/contracts.md
@@ -72,7 +72,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/customer360.md
+++ b/docs/modules/customer360.md
@@ -61,7 +61,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/deals.md
+++ b/docs/modules/deals.md
@@ -61,7 +61,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/developer.md
+++ b/docs/modules/developer.md
@@ -51,7 +51,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/docs.md
+++ b/docs/modules/docs.md
@@ -60,7 +60,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/documents.md
+++ b/docs/modules/documents.md
@@ -70,7 +70,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/ecommerce.md
+++ b/docs/modules/ecommerce.md
@@ -67,7 +67,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/email.md
+++ b/docs/modules/email.md
@@ -61,7 +61,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/expenses.md
+++ b/docs/modules/expenses.md
@@ -75,7 +75,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/field-service.md
+++ b/docs/modules/field-service.md
@@ -61,7 +61,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/fixed-assets.md
+++ b/docs/modules/fixed-assets.md
@@ -4,6 +4,7 @@ module_id: "fixedAssets"
 version: "1.0.0"
 category: "data"
 autonomy: "agent-capable"
+manual: true
 ---
 
 # Fixed Assets

--- a/docs/modules/fixed-assets.md
+++ b/docs/modules/fixed-assets.md
@@ -83,4 +83,4 @@ Key rules:
 - Follow `ModuleDefinition<I, O>` contract pattern
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)

--- a/docs/modules/forms.md
+++ b/docs/modules/forms.md
@@ -57,7 +57,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/global-elements.md
+++ b/docs/modules/global-elements.md
@@ -40,7 +40,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/handbook.md
+++ b/docs/modules/handbook.md
@@ -61,7 +61,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/hr.md
+++ b/docs/modules/hr.md
@@ -67,7 +67,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -58,7 +58,7 @@ generated: true
 | [Accounting](./accounting.md) | — | 11 | Double-entry accounting with autonomous reconciliation, multi-locale chart of accounts, and pluggable export adapters (S |
 
 | [CRM](./crm.md) | — | 15 | Unified Sales Intelligence + Lead Loop. Lead → Opportunity → Customer with autonomous scoring, Firecrawl enrichment, and |
-| [Customer 360](./customer-360.md) | — | — | Unified view of every signal, deal, order, invoice, ticket, booking, subscription, chat and webinar tied to a person — w |
+| [Customer 360](./customer360.md) | — | — | Unified view of every signal, deal, order, invoice, ticket, booking, subscription, chat and webinar tied to a person — w |
 | [Federation](./federation.md) | — | 6 | Multi-agent federation — connect FlowPilot to external Architects (Claude, OpenClaw peers) via MCP, A2A, and /v1/respons |
 | [FlowPilot](./flowpilot.md) | — | — | The autonomous AI operator at the heart of FlowWink. Soul + objectives + skills + memory + heartbeat + reflection — mode |
 | [river.md](./river.md) | — | — | — |

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -14,7 +14,7 @@ generated: true
 - 🟡 **config-required** — requires setup before agent use
 - ⚪ **manual** — no agent skills; UI-driven
 
-**Total:** 62 modules across 6 categories.
+**Total:** 63 modules across 6 categories.
 
 
 ## Content

--- a/docs/modules/inventory.md
+++ b/docs/modules/inventory.md
@@ -79,7 +79,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/invoicing.md
+++ b/docs/modules/invoicing.md
@@ -73,7 +73,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/knowledge-base.md
+++ b/docs/modules/knowledge-base.md
@@ -53,7 +53,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/leads.md
+++ b/docs/modules/leads.md
@@ -69,7 +69,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/live-support.md
+++ b/docs/modules/live-support.md
@@ -62,7 +62,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/manufacturing.md
+++ b/docs/modules/manufacturing.md
@@ -69,7 +69,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/media-library.md
+++ b/docs/modules/media-library.md
@@ -53,7 +53,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/multi-currency.md
+++ b/docs/modules/multi-currency.md
@@ -69,7 +69,7 @@ The module ships three optional layers — all enabled together when the module 
 ## Used in Processes
 
 - [record-to-report](../processes/record-to-report.md)
-- [order-to-cash](../processes/order-to-cash.md)
+- [order-to-cash](../processes/order-to-delivery.md)
 - [procure-to-pay](../processes/procure-to-pay.md)
 
 ## File Map
@@ -87,4 +87,4 @@ Key rules:
 - Follow `ModuleDefinition<I, O>` contract pattern
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)

--- a/docs/modules/multi-currency.md
+++ b/docs/modules/multi-currency.md
@@ -4,6 +4,7 @@ module_id: "multiCurrency"
 version: "1.0.0"
 category: "data"
 autonomy: "agent-capable"
+manual: true
 ---
 
 # Multi-Currency

--- a/docs/modules/newsletter.md
+++ b/docs/modules/newsletter.md
@@ -69,7 +69,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/orders.md
+++ b/docs/modules/orders.md
@@ -53,7 +53,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/overview.md
+++ b/docs/modules/overview.md
@@ -135,7 +135,7 @@ Each module has auto-generated documentation with API contracts, webhook events,
 | Analytics | [analytics.md](./analytics.md) |
 | Approvals | [approvals.md](./approvals.md) |
 | Blog | [blog.md](./blog.md) |
-| Booking | [booking.md](./booking.md) |
+| Booking | [booking.md](./bookings.md) |
 | Browser Control | [browser-control.md](./browser-control.md) |
 | Calendar | [calendar.md](./calendar.md) |
 | Chat | [chat.md](./chat.md) |
@@ -158,9 +158,9 @@ Each module has auto-generated documentation with API contracts, webhook events,
 | HR | [hr.md](./hr.md) |
 | Inventory | [inventory.md](./inventory.md) |
 | Invoicing | [invoicing.md](./invoicing.md) |
-| Knowledge Base | [kb.md](./kb.md) |
+| Knowledge Base | [kb.md](./knowledge-base.md) |
 | Live Support | [live-support.md](./live-support.md) |
-| Media Library | [media.md](./media.md) |
+| Media Library | [media.md](./media-library.md) |
 | Newsletter | [newsletter.md](./newsletter.md) |
 | Paid Growth | [paid-growth.md](./paid-growth.md) |
 | Pages | [pages.md](./pages.md) |

--- a/docs/modules/overview.md
+++ b/docs/modules/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Module Overview
 summary: All FlowWink modules, their skills, webhooks, and relationships
+manual: true
 read_when:
   - Planning module work
   - Understanding system capabilities

--- a/docs/modules/pages.md
+++ b/docs/modules/pages.md
@@ -68,7 +68,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/paid-growth.md
+++ b/docs/modules/paid-growth.md
@@ -59,7 +59,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/payroll.md
+++ b/docs/modules/payroll.md
@@ -4,6 +4,7 @@ module_id: "payroll"
 version: "1.0.0"
 category: "data"
 autonomy: "agent-capable"
+manual: true
 ---
 
 # Payroll (SE-locale MVP)

--- a/docs/modules/payroll.md
+++ b/docs/modules/payroll.md
@@ -94,4 +94,4 @@ Key rules:
 - Follow `ModuleDefinition<I, O>` contract pattern
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)

--- a/docs/modules/pos.md
+++ b/docs/modules/pos.md
@@ -64,7 +64,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/pricelists.md
+++ b/docs/modules/pricelists.md
@@ -62,7 +62,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/projects.md
+++ b/docs/modules/projects.md
@@ -68,7 +68,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/purchasing.md
+++ b/docs/modules/purchasing.md
@@ -78,7 +78,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -71,7 +71,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/reconciliation.md
+++ b/docs/modules/reconciliation.md
@@ -75,7 +75,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/recruitment.md
+++ b/docs/modules/recruitment.md
@@ -74,7 +74,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/resume.md
+++ b/docs/modules/resume.md
@@ -62,7 +62,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/returns.md
+++ b/docs/modules/returns.md
@@ -62,7 +62,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/river.md
+++ b/docs/modules/river.md
@@ -1,3 +1,10 @@
+---
+id: river
+name: River
+manual: true
+description: Internal team social feed — X / Instagram / Slack-inspired, with threads, reactions, and realtime.
+---
+
 # River
 
 Internal team social feed — X / Instagram / Slack-inspired. Short messages, images, threaded replies, emoji reactions, realtime.

--- a/docs/modules/sales-intelligence.md
+++ b/docs/modules/sales-intelligence.md
@@ -67,7 +67,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/shipping.md
+++ b/docs/modules/shipping.md
@@ -64,7 +64,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/site-migration.md
+++ b/docs/modules/site-migration.md
@@ -64,7 +64,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/sla.md
+++ b/docs/modules/sla.md
@@ -68,7 +68,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/subscriptions-invoice-billing.md
+++ b/docs/modules/subscriptions-invoice-billing.md
@@ -1,3 +1,10 @@
+---
+id: subscriptions-invoice-billing
+name: Invoice-Driven Subscriptions
+manual: true
+description: B2B manual (invoice-billed) subscriptions — the design and operations playbook alongside the Stripe-mirrored subscriptions module.
+---
+
 # Invoice-Driven Subscriptions (B2B Manual Billing)
 
 Companion doc to [`subscriptions.md`](./subscriptions.md). Covers the full design, operations and recovery playbook for **manual (invoice-billed) subscriptions** — the B2B path that runs alongside Stripe.

--- a/docs/modules/subscriptions.md
+++ b/docs/modules/subscriptions.md
@@ -76,7 +76,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/surveys.md
+++ b/docs/modules/surveys.md
@@ -63,7 +63,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/templates.md
+++ b/docs/modules/templates.md
@@ -59,7 +59,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/tickets.md
+++ b/docs/modules/tickets.md
@@ -65,7 +65,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/timesheets.md
+++ b/docs/modules/timesheets.md
@@ -69,7 +69,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/webinars.md
+++ b/docs/modules/webinars.md
@@ -73,7 +73,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/modules/wiki.md
+++ b/docs/modules/wiki.md
@@ -1,3 +1,10 @@
+---
+id: wiki
+name: Wiki
+manual: true
+description: Internal TEdit-style wiki / intranet for FlowWink.
+---
+
 # Wiki
 
 > Internal TEdit-style wiki / intranet for FlowWink.

--- a/docs/modules/workspace-chat.md
+++ b/docs/modules/workspace-chat.md
@@ -56,7 +56,7 @@ Key rules:
 - All schema changes require idempotent migrations
 - Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))
 - Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))
-- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
+- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)
 
 ---
 

--- a/docs/operators/comparison.md
+++ b/docs/operators/comparison.md
@@ -34,7 +34,7 @@ The comparison below is from the operator's point of view — what you actually 
 
 ## When to pick something else
 
-- **You need an Odoo-style apps marketplace today.** FlowWink's module count is growing (~62 modules) but Odoo has 10 000+ third-party apps. If your business depends on a specific industry vertical app, check Odoo first.
+- **You need an Odoo-style apps marketplace today.** FlowWink's module count is growing (~63 modules) but Odoo has 10 000+ third-party apps. If your business depends on a specific industry vertical app, check Odoo first.
 - **You're a Fortune-500 multi-entity, multi-currency consolidation.** NetSuite is purpose-built for that. FlowWink supports multi-currency and locale packs but is not yet a consolidation suite.
 - **You only need CRM and marketing automation.** HubSpot is best-of-breed for that narrow scope — FlowWink is a wider system and may be over-engineered for pure CRM use.
 
@@ -43,7 +43,7 @@ The comparison below is from the operator's point of view — what you actually 
 1. **MCP-native by design.** Every business capability is a skill, every skill is callable by any MCP client. You aren't waiting for the vendor to ship an "AI feature."
 2. **Operator-agnostic.** Run FlowPilot, or run Claude Desktop, or run no agent at all — the platform is the same.
 3. **Single codebase, single DB.** No integration glue between CMS, CRM and ERP. A lead has the same `id` whether it was captured from a landing page, a chat conversation or a manual entry.
-4. **Department claws.** Specialist external agents (marketing, sales, finance, ops, support, success) each get a focused composite MCP group instead of seeing all ~280 skills.
+4. **Department claws.** Specialist external agents (marketing, sales, finance, ops, support, success) each get a focused composite MCP group instead of seeing all ~300 skills.
 
 ## Related
 

--- a/docs/pilot/architecture.md
+++ b/docs/pilot/architecture.md
@@ -1,6 +1,6 @@
 # Pilot Architecture — Deep Dive
 
-> Technical reference for the Pilot reasoning engine. Read [README.md](./README.md) first for the overview.
+> Technical reference for the Pilot reasoning engine. Read the [pilot docs index](../pilot/) first for the overview.
 
 ---
 
@@ -318,4 +318,4 @@ Every tool execution is logged to `agent_activity`:
 
 ---
 
-*See also: [README](./README.md) · [Handler Reference](./handlers-reference.md)*
+*See also: [Pilot docs index](../pilot/) · [Handler Reference](./handlers-reference.md)*

--- a/docs/pilot/context-engine.md
+++ b/docs/pilot/context-engine.md
@@ -105,7 +105,7 @@ Only the 20 most recently used skills (by `agent_activity` in the last 14 days) 
 
 ## Lazy Instruction Loading (OpenClaw LAW 3)
 
-**Problem:** 280+ skills × ~2,000 chars instructions each = ~146,000 chars of instructions. This exceeds any reasonable context window.
+**Problem:** 300+ skills × ~2,000 chars instructions each = ~600,000 chars of instructions. This exceeds any reasonable context window.
 
 **Solution:** Instructions are loaded on-demand, not upfront.
 

--- a/docs/pilot/handlers-reference.md
+++ b/docs/pilot/handlers-reference.md
@@ -177,4 +177,4 @@ Returns `null` if no provider is available (graceful degradation — memory stil
 
 ---
 
-*See also: [README](./README.md) · [Architecture](./architecture.md)*
+*See also: [Pilot docs index](../pilot/) · [Architecture](./architecture.md)*

--- a/docs/reference/headless-api.md
+++ b/docs/reference/headless-api.md
@@ -709,7 +709,7 @@ The agent receives only the tools from the requested groups. Without the paramet
 mcp_url: https://example.supabase.co/functions/v1/mcp-server?groups=crm,commerce,content,analytics,system
 ```
 
-This reduces ~280 tools down to ~25, keeping accuracy high while maintaining full operational coverage.
+This reduces ~300 tools down to ~25, keeping accuracy high while maintaining full operational coverage.
 
 ### Research References
 

--- a/docs/reference/skills-source.md
+++ b/docs/reference/skills-source.md
@@ -24,7 +24,7 @@ When a module is **enabled**, the bootstrap seeds those rows into `public.agent_
 ## Adding a skill
 
 1. Add a `SkillSeed` to the module's `skillSeeds` array.
-2. Pass [`Agent Contract Integrity`](../architecture/agent-contract-integrity.md) — every NOT NULL DB column the action writes must be in the JSON schema (`bun run lint:skills`).
+2. Pass [`Agent Contract Integrity`](../../mem/architecture/agent-contract-integrity.md) — every NOT NULL DB column the action writes must be in the JSON schema (`bun run lint:skills`).
 3. Write `description` with explicit `Use when:` and `NOT for:` markers (Law 2 — skills are self-describing).
 4. Disable & re-enable the module, or run the "Sync Skills" action in `/admin/developer`.
 
@@ -34,4 +34,4 @@ When a module is **enabled**, the bootstrap seeds those rows into `public.agent_
 
 ---
 
-*See also: [Module API](./module-api.md) · [MCP as Platform](../architecture/mcp-as-platform.md) · [Agent Contract Integrity](../architecture/agent-contract-integrity.md)*
+*See also: [Module API](./module-api.md) · [MCP as Platform](../architecture/mcp-as-platform.md) · [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md)*

--- a/scripts/generate-module-docs.ts
+++ b/scripts/generate-module-docs.ts
@@ -656,7 +656,7 @@ function generateMarkdown(
   lines.push('- All schema changes require idempotent migrations');
   lines.push('- Skills must be self-describing ([Law 2](../concepts/openclaw-law.md))');
   lines.push('- Blocks are interfaces, not pipelines ([Law 3](../concepts/openclaw-law.md))');
-  lines.push('- New skills must pass the [Agent Contract Integrity](../architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)');
+  lines.push('- New skills must pass the [Agent Contract Integrity](../../mem/architecture/agent-contract-integrity.md) checklist (`bun run lint:skills`)');
   lines.push('');
   lines.push('---');
   lines.push('');


### PR DESCRIPTION
# Documentation audit — 13 June 2026

Follow-up to the previous docs audit (`2026-06-06`, which never landed because those changes were uncommitted and got overwritten by 280 new commits). All fixes here are **durable**: the previous audit's work was fragile because it only patched the symptom, not the cause. This time we patched the regenerator too.

## What changed

3 commits, 87 files, +157 / -132.

### 1. README + doc content claims (12 files)

| Claim | Was | Now | Source of truth |
|-------|-----|-----|------------------|
| Version badge | v2.1 | **v1.3.0** | `package.json` |
| "62 modules" (6 places) | 62 | **63** | `ls src/lib/modules/*-module.ts \| wc -l` |
| "280 skills" (10 places) | 280 | **300** | `grep -hE "name: ['\"][a-z_]+['\"]" src/lib/modules/*-module.ts \| sort -u \| wc -l` |
| Module table | Missing 9, listed 3 phantoms | All 63 accounted for | cross-checked vs `src/lib/modules/index.ts` |
| ERP row "37 domains" | 37 | 63 | matches module count |
| `context-engine.md` math | 280 × 2,000 = 146,000 (impossible) | 300 × 2,000 = 600,000 | consistent now |
| `mcp-overview.md` link (README ×2) | broken | → `mcp-as-platform.md` | file existence check |

### 2. Broken internal links (73 files, 110 → 0)

Three mechanical patterns accounted for ~95 of the 110:

- **moved-to-mem** (~60 links): module docs and `concepts/openclaw-law.md`, `reference/skills-source.md` linked to `../architecture/agent-contract-integrity.md` and `../architecture/skill-linter.md` — both files actually live in `mem/architecture/`. Repointed.
- **case-mismatch** (~15): ALL-CAPS filenames like `DEPLOYMENT.md`, `SKILLS-SOURCE.md` in `prd.md`, `setup.md`, `site-migration.md`, `contributing.md`. Real files are lowercase.
- **wrong-filename** (8): `docs/modules/overview.md` had `booking.md`/`kb.md`/`media.md` (should be plural/`knowledge-base`/`media-library`); `multi-currency.md` had `order-to-cash` (renamed to `order-to-delivery`); etc.

The remaining 7 were judgment fixes:
- `docs/mcp/resource-briefing.md`: 5 links to `docs/strategy/` and `docs/orchestrating/` folders that don't exist (the referenced memos are planned but not written). Converted to plain text with a "pending publication" note.
- `docs/concepts/flowchat-vs-flowpilot.md`: 2 similar mem-not-yet-written cases. One repointed to the closest existing memo, one demoted to plain text.
- `docs/pilot/{architecture,handlers-reference}.md` (3): linked to `./README.md` which doesn't exist. Now point to `../pilot/` (the directory index).

### 3. Generator + manual-doc protection (8 files) — **the durable fix**

Two structural changes to prevent the audit from regressing:

**Fix A** — `scripts/generate-module-docs.ts:659` had a hardcoded broken link. Every `bun run scripts/generate-module-docs.ts` invocation would re-create the same broken `[Agent Contract Integrity]`. Repointed to `../../mem/architecture/agent-contract-integrity.md` (where the file actually lives).

**Fix B** — 7 hand-written module docs lacked the `manual: true` opt-out flag in their frontmatter, so a future generator run would silently overwrite them with the generic template. Added the flag (and full frontmatter where none existed) to: `fixed-assets`, `multi-currency`, `overview`, `payroll`, `river`, `wiki`, `subscriptions-invoice-billing`.

After this PR the docs/modules/ landscape is:

- **11 manual docs** (script skips): accounting, crm, federation, fixed-assets, flowpilot, multi-currency, overview, payroll, river, subscriptions-invoice-billing, wiki
- **58 auto-generated** (regenerated with the correct link from the fixed script)

## Verification

- 0 broken internal file links (was 110): `python3` link checker over 159 docs + README
- 0 occurrences of `280` skills, `62 modules`, `v2.1`, `Signature/`, `Content Campaigns` in README
- `package.json` version 1.3.0 matches README badge
- 63 source modules in `src/lib/modules/` match the README module table (after removing phantoms, adding the 9 missing)

## What I did NOT verify

- I did not run the dev server or build. The fixes are static (markdown + one TS line in the generator).
- I did not run `bun run scripts/generate-module-docs.ts` to confirm it produces the expected output — bun is not installed in the audit environment, and the doc-drift script itself requires Vite (`VITE_SUPABASE_URL` env var) to even start. **Worth flagging as a separate issue: the check:doc-drift CI script is Vite-coupled and crashes outside a Vite runtime.** Not in scope for this audit.
- `docs/.handoff-2026-06-10.md` exists at the docs root — looks like an in-flight working file. Did not touch.

## Test plan

- [x] Re-run the link checker: 0 broken
- [ ] `bun run scripts/generate-module-docs.ts --module invoicing` to spot-check that the regenerated doc has the correct link
- [ ] CI: `check:doc-drift` (if unblocked from the Vite issue) should pass

🤖 Generated by the docs maintainer agent as a follow-up to the 6 June audit.
