### PR TITLE
feat(contact-center): Fas 0 — omnichannel schema + routing + fix broken chat handoff

### DIFF
--- a/docs/parity/capabilities/contact-center.json
+++ b/docs/parity/capabilities/contact-center.json
@@ -1,0 +1,67 @@
+{
+  "module": "contact-center",
+  "odoo_app": "Live Chat + Helpdesk (omnichannel routing, VOIP voicemail)",
+  "current_maturity": "L1",
+  "target_maturity": "L3",
+  "capabilities": [
+    {
+      "id": "agent_routing",
+      "name": "Presence-aware routing → queue → escalation",
+      "odoo": true,
+      "status": "partial",
+      "weight": 3,
+      "verify": "route_conversation_to_agent RPC + support-router edge function (migration 20260616170000); scratch-Postgres verified 2026-06-16 (least-loaded assignment, idempotent re-route, channel filter, queue fallback, escalation row, unknown-conv guard). Fixes the chat handoff that POSTed to a non-existent support-router (404).",
+      "notes": "Fas 0. Single routing primitive shared by chat handoff and future channel adapters (Law 1). Stage-3: live runtime verify + admin UI sign-off pending."
+    },
+    {
+      "id": "omnichannel_schema",
+      "name": "Channel dimension + contact identity on conversations",
+      "odoo": true,
+      "status": "partial",
+      "weight": 2,
+      "verify": "chat_conversations.channel/.channel_thread_id/.contact_phone/.contact_id + support_agents.supported_channels (migration 20260616170000). Unified Inbox UI (already merged) reads these.",
+      "notes": "Fas 0. Lays the contract the merged Lovable UI is hardcoded against."
+    },
+    {
+      "id": "voicemail_store",
+      "name": "Voicemail store",
+      "odoo": true,
+      "status": "partial",
+      "weight": 1,
+      "verify": "voicemail_messages table (migration 20260616170000); VoicemailPanel reads it. Transcription + analysis skill is Fas 2.",
+      "notes": "Fas 0 lays the table; handle_voicemail skill lands in Fas 2."
+    },
+    {
+      "id": "telegram_channel",
+      "name": "Telegram inbound/outbound adapter",
+      "odoo": false,
+      "status": "missing",
+      "weight": 2,
+      "verify": "telegram-ingest + telegram-send edge functions + manage_channel skill (Fas 1)"
+    },
+    {
+      "id": "callback_offer",
+      "name": "Callback offer + scheduling",
+      "odoo": true,
+      "status": "missing",
+      "weight": 1,
+      "verify": "request_callback skill wrapping book_appointment_slot; rides bookings.metadata.kind='callback' (Fas 2)"
+    },
+    {
+      "id": "voicemail_transcription",
+      "name": "Voicemail → transcription → FlowPilot intent",
+      "odoo": true,
+      "status": "missing",
+      "weight": 2,
+      "verify": "transcribe-voicemail edge function mirroring extract-pdf-text + parse-resume; handle_voicemail skill (Fas 2)"
+    },
+    {
+      "id": "live_voice",
+      "name": "Two-way live voice (WebRTC/PSTN)",
+      "odoo": true,
+      "status": "missing",
+      "weight": 2,
+      "verify": "Deferred (Fas 3) — voice v1 is fallback-only (callback + voicemail) per product decision 2026-06-16"
+    }
+  ]
+}

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -9,12 +9,13 @@ category: reference
 > **GENERATED FILE.** Run `bun run scripts/parity-report.ts` to refresh.
 > Edit `docs/parity/capabilities/<module>.json` to change scores.
 
-**Benchmarked modules:** 53  ·  **Mean parity:** 60%  ·  **Differentiators (no Odoo benchmark):** 10  ·  **Unscored:** 0
+**Benchmarked modules:** 54  ·  **Mean parity:** 59%  ·  **Differentiators (no Odoo benchmark):** 10  ·  **Unscored:** 0
 
 ## Scored modules
 
 | Module | Odoo app | Maturity → target | Parity | Done/Partial/Missing | Open epics |
 |---|---|---|---|---|---|
+| **contact-center** | Live Chat + Helpdesk (omnichannel routing, VOIP voicemail) | L1 → L3 | `███░░░░░░░` 27% | 0/3/3 | — |
 | **shipping** | Inventory → Delivery/Shipping connectors | L2 → L4 | `███░░░░░░░` 31% | 4/2/9 | — |
 | **email** | Mail / Discuss (outbound email) | L3 → L4 | `████░░░░░░` 38% | 2/1/4 | — |
 | **projects** | Project (project.project/project.task) | L3 → L4 | `████░░░░░░` 41% | 5/2/6 | — |
@@ -88,6 +89,7 @@ category: reference
 
 | Module | Capability | Status | Epic |
 |---|---|---|---|
+| contact-center | Presence-aware routing → queue → escalation | partial | — |
 | invoicing | Recurring/subscription invoices | partial | — |
 | manufacturing | Work centers + routing operations | partial | — |
 | reconciliation | Live bank feeds (Plaid/Tink/GoCardless) | missing | — |

--- a/supabase/functions/support-router/index.ts
+++ b/supabase/functions/support-router/index.ts
@@ -1,0 +1,65 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { getServiceClient } from '../_shared/supabase-clients.ts';
+
+/**
+ * Support Router
+ *
+ * The target the chat handoff has POSTed to all along (chat-completion's
+ * `handoff_to_human` / `create_escalation` tools) — it previously 404'd because
+ * the function was never created. It is now a thin wrapper over the
+ * `route_conversation_to_agent` RPC: presence-aware assignment → queue → escalation.
+ *
+ * The SAME RPC is the single routing primitive for every channel (web chat today,
+ * Telegram/SMS/voice adapters later) — no channel-specific routing here (Law 1).
+ *
+ * Request  (from chat-completion, service-role auth):
+ *   { conversationId, sentiment: { urgency, trigger, ... }, customerEmail?, customerName? }
+ * Response (consumed by chat-completion):
+ *   { action: 'handoff_to_agent' | 'create_escalation' | 'error', message, agent_id?, status? }
+ */
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  try {
+    const body = await req.json();
+    const conversationId: string | undefined = body.conversationId;
+    if (!conversationId) {
+      return json({ action: "error", message: "conversationId is required" }, 400);
+    }
+
+    const sentiment = body.sentiment ?? {};
+    const reason: string | null = sentiment.trigger ?? body.reason ?? null;
+    const urgency: string = sentiment.urgency ?? "normal";
+
+    const supabase = getServiceClient();
+    const { data, error } = await supabase.rpc("route_conversation_to_agent", {
+      p_conversation_id: conversationId,
+      p_reason: reason,
+      p_urgency: urgency,
+    });
+
+    if (error) {
+      console.error("[support-router] rpc error:", error.message);
+      return json({ action: "error", message: error.message }, 500);
+    }
+
+    return json(data, 200);
+  } catch (err: any) {
+    console.error("[support-router] error:", err?.message ?? err);
+    return json({ action: "error", message: err?.message ?? "Internal error" }, 500);
+  }
+});
+
+function json(payload: unknown, status: number) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/migrations/20260616170000_7022c36b-c2f2-461f-a44f-0556b8a32663.sql
+++ b/supabase/migrations/20260616170000_7022c36b-c2f2-461f-a44f-0556b8a32663.sql
@@ -1,0 +1,165 @@
+-- Contact Center — Fas 0 foundation: omnichannel dimension on the existing conversation hub,
+-- a voicemail store, and the routing function that the chat handoff has been POSTing to a
+-- non-existent `support-router` function (404) since it was written.
+--
+-- This is additive and idempotent. It does NOT enable any module — it only lays the schema +
+-- routing contract that the (already-merged) Unified Inbox UI is hardcoded against:
+--   chat_conversations.channel / .channel_thread_id / .contact_phone / .contact_id
+--   support_agents.supported_channels
+--   voicemail_messages (VoicemailPanel does select('*'))
+--   route_conversation_to_agent() — presence-aware assignment, queue, or escalation fallback.
+-- Callbacks ride on the existing bookings table (metadata.kind='callback'), so no new table here.
+
+-- ── 1. Omnichannel dimension on conversations ────────────────────────────────
+ALTER TABLE "public"."chat_conversations"
+  ADD COLUMN IF NOT EXISTS "channel" "text" NOT NULL DEFAULT 'web',
+  ADD COLUMN IF NOT EXISTS "channel_thread_id" "text",
+  ADD COLUMN IF NOT EXISTS "contact_phone" "text",
+  ADD COLUMN IF NOT EXISTS "contact_id" "uuid";
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.table_constraints
+                 WHERE constraint_name = 'chat_conversations_contact_id_fkey'
+                   AND table_name = 'chat_conversations') THEN
+    ALTER TABLE "public"."chat_conversations" ADD CONSTRAINT "chat_conversations_contact_id_fkey"
+      FOREIGN KEY ("contact_id") REFERENCES "public"."leads"("id") ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Upsert key for channel adapters: one open thread per (channel, external thread id).
+CREATE INDEX IF NOT EXISTS "chat_conversations_channel_thread_idx"
+  ON "public"."chat_conversations" ("channel", "channel_thread_id")
+  WHERE "channel_thread_id" IS NOT NULL;
+
+-- ── 2. Per-channel agent competence ──────────────────────────────────────────
+ALTER TABLE "public"."support_agents"
+  ADD COLUMN IF NOT EXISTS "supported_channels" "text"[] NOT NULL DEFAULT '{web}'::text[];
+
+-- ── 3. Voicemail store (transcription + FlowPilot analysis land here in Fas 2) ─
+CREATE TABLE IF NOT EXISTS "public"."voicemail_messages" (
+  "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+  "conversation_id" "uuid",
+  "contact_phone" "text",
+  "audio_url" "text",
+  "duration_seconds" integer,
+  "transcript_text" "text",
+  "transcript_status" "text" NOT NULL DEFAULT 'pending',
+  "intent" "text",
+  "sentiment" "text",
+  "summary" "text",
+  "callback_requested" boolean NOT NULL DEFAULT false,
+  "ai_model_used" "text",
+  "transcribed_at" timestamp with time zone,
+  "analyzed_at" timestamp with time zone,
+  "created_at" timestamp with time zone NOT NULL DEFAULT "now"(),
+  CONSTRAINT "voicemail_messages_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "voicemail_messages_transcript_status_check"
+    CHECK (("transcript_status" = ANY (ARRAY['pending'::text, 'success'::text, 'failed'::text])))
+);
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.table_constraints
+                 WHERE constraint_name = 'voicemail_messages_conversation_id_fkey'
+                   AND table_name = 'voicemail_messages') THEN
+    ALTER TABLE "public"."voicemail_messages" ADD CONSTRAINT "voicemail_messages_conversation_id_fkey"
+      FOREIGN KEY ("conversation_id") REFERENCES "public"."chat_conversations"("id") ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "voicemail_messages_created_idx"
+  ON "public"."voicemail_messages" ("created_at" DESC);
+
+ALTER TABLE "public"."voicemail_messages" OWNER TO "postgres";
+ALTER TABLE "public"."voicemail_messages" ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies
+                 WHERE tablename = 'voicemail_messages' AND policyname = 'voicemail_service_all') THEN
+    CREATE POLICY "voicemail_service_all" ON "public"."voicemail_messages"
+      FOR ALL TO "service_role" USING (true) WITH CHECK (true);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies
+                 WHERE tablename = 'voicemail_messages' AND policyname = 'voicemail_admin_read') THEN
+    CREATE POLICY "voicemail_admin_read" ON "public"."voicemail_messages"
+      FOR SELECT TO "authenticated" USING (true);
+  END IF;
+END $$;
+
+-- ── 4. The router: presence-aware assignment → queue → escalation fallback ────
+-- Single source of truth for "get this conversation to a human". Both the chat handoff
+-- (via the support-router edge function) and future channel adapters call this — no
+-- channel-specific routing branches (Law 1). Channel is read from the conversation row.
+CREATE OR REPLACE FUNCTION "public"."route_conversation_to_agent"(
+  "p_conversation_id" "uuid",
+  "p_reason" "text" DEFAULT NULL,
+  "p_urgency" "text" DEFAULT 'normal'
+) RETURNS "jsonb"
+LANGUAGE "plpgsql" SECURITY DEFINER SET "search_path" TO 'public' AS $$
+DECLARE
+  v_channel text;
+  v_urgency text := CASE WHEN p_urgency IN ('low','normal','high','urgent') THEN p_urgency ELSE 'normal' END;
+  v_agent uuid;
+  v_existing uuid;
+  v_status text;
+BEGIN
+  SELECT COALESCE(channel, 'web'), assigned_agent_id, conversation_status
+    INTO v_channel, v_existing, v_status
+  FROM chat_conversations WHERE id = p_conversation_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('action', 'error', 'message', 'Conversation not found');
+  END IF;
+
+  -- Idempotent: already handed to an agent → don't re-assign or double-count
+  -- (the chat handoff tool can fire more than once in a single ReAct loop).
+  IF v_status = 'with_agent' AND v_existing IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'action', 'handoff_to_agent', 'agent_id', v_existing, 'status', 'with_agent',
+      'message', 'Already connected to an agent.');
+  END IF;
+
+  -- Least-loaded online/away agent with free capacity that handles this channel.
+  SELECT id INTO v_agent
+  FROM support_agents
+  WHERE status IN ('online', 'away')
+    AND current_conversations < max_conversations
+    AND supported_channels @> ARRAY[v_channel]
+  ORDER BY current_conversations ASC, last_seen_at DESC
+  LIMIT 1;
+
+  IF v_agent IS NOT NULL THEN
+    UPDATE chat_conversations SET
+      assigned_agent_id = v_agent,
+      conversation_status = 'with_agent',
+      priority = v_urgency,
+      escalation_reason = p_reason,
+      escalated_at = now(),
+      updated_at = now()
+    WHERE id = p_conversation_id;
+
+    UPDATE support_agents SET current_conversations = current_conversations + 1, updated_at = now()
+    WHERE id = v_agent;
+
+    RETURN jsonb_build_object(
+      'action', 'handoff_to_agent', 'agent_id', v_agent, 'status', 'with_agent',
+      'message', 'Connected you to an available agent.');
+  END IF;
+
+  -- No agent free: queue the conversation and record an escalation for follow-up.
+  UPDATE chat_conversations SET
+    conversation_status = 'waiting_agent',
+    assigned_agent_id = NULL,
+    priority = v_urgency,
+    escalation_reason = p_reason,
+    escalated_at = now(),
+    updated_at = now()
+  WHERE id = p_conversation_id;
+
+  INSERT INTO support_escalations (conversation_id, reason, priority)
+  VALUES (p_conversation_id, COALESCE(p_reason, 'Human handoff requested'), v_urgency);
+
+  RETURN jsonb_build_object(
+    'action', 'create_escalation', 'status', 'waiting_agent',
+    'message', 'No agent is available right now — your request is queued and the team will follow up.');
+END $$;
+ALTER FUNCTION "public"."route_conversation_to_agent"("uuid", "text", "text") OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."route_conversation_to_agent"("uuid", "text", "text")
+  TO "anon", "authenticated", "service_role";


### PR DESCRIPTION
## Context

First build step of the **Contact Center** module (per the approved plan: a channel-agnostic conversation hub extending live-support, *not* a telephony module). Lovable already merged the Unified Inbox UI straight to main — this lays the backend contract that UI is hardcoded against, and fixes a latent bug found during exploration.

## What

- **Fixes the broken chat handoff (404).** `chat-completion`'s `handoff_to_human` / `create_escalation` tools have been POSTing to `/functions/v1/support-router` — a function that **never existed**. Every escalation silently 404'd. Created it as a thin wrapper over a new RPC.
- **`route_conversation_to_agent` RPC** — the single routing primitive (Law 1, shared by chat handoff today and channel adapters later): least-loaded online/away agent with free capacity that handles the conversation's `channel`; else queue (`waiting_agent`) + `support_escalations` row. Idempotent re-route (no double-count if the handoff tool fires twice in a ReAct loop).
- **Omnichannel schema** (additive, idempotent): `chat_conversations` += `channel` / `channel_thread_id` / `contact_phone` / `contact_id` (FK `leads`); `support_agents` += `supported_channels[]`; new `voicemail_messages` table (RLS: service all, admin read).
- Callbacks ride the existing `bookings` table (`metadata.kind='callback'`) — no new table.

## Verification

Scratch-Postgres (ephemeral PG14) against a minimal mirror of the hub tables:
- least-loaded assignment (load-0 agent wins over load-1)
- **idempotency guard**: 3 calls on one conversation → same agent, counter = 1 (not 3)
- **channel filter**: telegram conversation routes only to telegram-capable agents; web-only agents online → escalation
- queue fallback (all agents full) → `create_escalation` + escalation row
- unknown conversation → `error`
- migration re-run → clean (idempotent)

## Contract this unblocks (Lovable UI reads these)
`chat_conversations.channel/.channel_thread_id/.contact_phone/.contact_id`, `support_agents.supported_channels`, `voicemail_messages`.

## Not in this PR (next phases)
- **Fas 1**: `contact-center` module + Telegram adapter (`telegram-ingest`/`telegram-send`) + `manage_channel` skill.
- **Fas 2**: `request_callback` (bookings) + `transcribe-voicemail` + `handle_voicemail` skill.
- **Fas 3**: two-way live voice (deferred per product decision).

## Deploy note
`support-router` is internal (called by chat-completion with the service-role key) → deploys with default JWT verification, no `--no-verify-jwt`. The migration must be `db push`'d to instances; module is **not** enabled anywhere yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)