### PR TITLE
Edge-function budget: registry + selective deploy + admin usage card (Supabase Free tier)

### DIFF
--- a/docs/operators/provisioning-and-updates.md
+++ b/docs/operators/provisioning-and-updates.md
@@ -166,19 +166,31 @@ supabase migration repair --status applied 00000000000000 --db-url '<conn>'
 
 Re-baseline every ~6 months as deltas accumulate.
 
-### 2. Consolidate edge functions into domain routers
+### 2. Edge-function footprint vs the Supabase Free ceiling
 
-~99 functions sits at the Supabase free-tier ceiling. The `reconciliation` /
-`a2a` functions already route sub-paths via `url.pathname`, so the pattern
-exists. **But consolidation here has the same lockstep tail as the RPC rename
-above:** nearly every function is invoked by the admin frontend directly, and
-forks don't auto-deploy — so you cannot delete an old function until *every*
-frontend (including forks) is live on the new router. Safe sequence: ship the
-router additively, migrate all callers, redeploy all frontends, *then* delete
-the old functions. There are no dead functions to delete outright (all
-zero-reference ones are crons/webhooks/test runners). Treat this as a planned
-migration, not a quick win — and consider routing the admin UI through fewer
-gateways first.
+Supabase caps functions per project by plan (Free 100 · Pro 500 · Team 1000).
+FlowWink ships 100+, so a Free-tier fork that deploys all of them hits the wall.
+
+**Selective deploy (implemented).** `flowwink.sh /update-funcs` deploys only the
+functions a site's enabled modules need. The map is
+`src/lib/edge-function-registry.ts` → `supabase/seed/edge-function-map.json`
+(regenerate: `npm run edge-map:json`): ~37 **core** functions always deploy; the
+rest are **module-bound** and skip only when *every* owning module is explicitly
+disabled (fail-open — missing/unknown modules and brand-new functions always
+deploy). Admins see the live footprint vs 100 on `/admin/modules`
+(EdgeFunctionUsageCard) with an upgrade-to-Pro nudge as they grow into modules.
+Force the old behaviour with `FLOWWINK_DEPLOY_ALL=1`. Adding a module with its
+own function? Add it to `MODULE_EDGE_FUNCTIONS` and rerun `edge-map:json`.
+
+**Consolidation into domain routers (optional, not done).** If even a
+fully-loaded site (all modules on → full count → needs Pro) must fit Free, fold
+clusters — transactional emails → `email-send`, provider probes → one function.
+`reconciliation` / `a2a` already route sub-paths via `url.pathname`, so the
+pattern exists. **Same lockstep tail as the RPC rename above:** functions are
+invoked by the admin frontend directly and forks don't auto-deploy — ship the
+router additively, migrate all callers, redeploy all frontends, *then* delete the
+old functions. No dead functions to delete outright (zero-reference ones are
+crons/webhooks/test runners). A planned migration, not a quick win.
 3. **Fail loud on migrations.** `scripts/run-migrations.js` swallows errors so a
    Vercel build "succeeds" against a DB that never migrated — a prime drift
    source. Either fail the build, or decouple migrations from the build and run

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "parity:report": "bun run scripts/parity-report.ts",
     "parity:check": "bun run scripts/parity-report.ts --check",
     "skills:json": "bun run scripts/skills-to-json.ts",
+    "edge-map:json": "bun run scripts/edge-functions-to-json.ts",
     "sync:skills": "bun run scripts/sync-skills.ts",
     "fleet:status": "bun run scripts/fleet-status.ts",
     "local:smoke": "bun run scripts/local-smoke.ts",

--- a/scripts/edge-functions-to-json.ts
+++ b/scripts/edge-functions-to-json.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+/**
+ * Edge Function Map Export
+ *
+ * Exports the edge-function registry to a versioned artifact:
+ *   supabase/seed/edge-function-map.json
+ *
+ * This lets the provisioning script (scripts/flowwink.sh) do SELECTIVE DEPLOY —
+ * deploy only the functions a site's enabled modules require, instead of all of
+ * them — without importing TypeScript/React. Same pattern as skills-to-json.ts.
+ *
+ * Run whenever edge functions or MODULE_EDGE_FUNCTIONS change:
+ *   bun run scripts/edge-functions-to-json.ts   (or: npm run edge-map:json)
+ *
+ * The guardrail test edge-function-registry.guardrails.test.ts fails if this
+ * artifact drifts from the registry — regenerate and commit when it does.
+ */
+import { resolve, join } from 'node:path';
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+
+const ROOT = resolve(import.meta.dir, '..');
+const OUT_DIR = join(ROOT, 'supabase', 'seed');
+const OUT_FILE = join(OUT_DIR, 'edge-function-map.json');
+
+const reg = (await import(join(ROOT, 'src', 'lib', 'edge-function-registry.ts'))) as typeof import('../src/lib/edge-function-registry');
+
+const core = reg.coreEdgeFunctions().sort();
+const modules = Object.fromEntries(
+  Object.entries(reg.MODULE_EDGE_FUNCTIONS)
+    .map(([id, fns]) => [id, [...(fns ?? [])].sort()])
+    .sort(([a], [b]) => a.localeCompare(b)),
+);
+
+const artifact = {
+  // Static header; no timestamp so the file is reproducible (guardrail-friendly).
+  generated_by: 'scripts/edge-functions-to-json.ts',
+  note: 'Selective-deploy map. Core = always deployed. modules[<id>] = deployed only when that module is enabled. Unknown/new functions: deploy (fail-open).',
+  total: reg.ALL_EDGE_FUNCTIONS.length,
+  core_count: core.length,
+  plan_limits: reg.PLAN_FUNCTION_LIMITS,
+  core,
+  modules,
+};
+
+if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
+writeFileSync(OUT_FILE, JSON.stringify(artifact, null, 2) + '\n');
+
+const moduleFnCount = Object.values(modules).reduce((n, f) => n + f.length, 0);
+console.log(
+  `✅ Wrote supabase/seed/edge-function-map.json — ${artifact.total} functions ` +
+    `(${core.length} core, ${moduleFnCount} module-bound across ${Object.keys(modules).length} modules)`,
+);

--- a/scripts/flowwink.sh
+++ b/scripts/flowwink.sh
@@ -90,7 +90,7 @@ cmd_help() {
     echo ""
     echo -e "  ${BOLD}── Update existing installation ──────────────────────${NC}"
     echo -e "  ${CYAN}/update-db${NC}       Push new database migrations to linked project"
-    echo -e "  ${CYAN}/update-funcs${NC}    Re-deploy all edge functions (picks up code changes)"
+    echo -e "  ${CYAN}/update-funcs${NC}    Deploy edge functions for enabled modules (FLOWWINK_DEPLOY_ALL=1 for all)"
     echo -e "  ${CYAN}/set-keys${NC}        Add or rotate API keys & Supabase secrets"
     echo -e "  ${CYAN}/create-admin${NC}    Create a new admin user account"
     echo -e "  ${CYAN}/patch-flowpilot${NC} (deprecated) FlowPilot is now seeded via /admin/modules"
@@ -290,14 +290,68 @@ cmd_update_funcs() {
         return 1
     fi
 
-    local functions total
-    functions=$(find "$functions_dir" -mindepth 1 -maxdepth 1 -type d | while read -r dir; do
+    local all_functions
+    all_functions=$(find "$functions_dir" -mindepth 1 -maxdepth 1 -type d | while read -r dir; do
         [ -f "$dir/index.ts" ] && basename "$dir"
     done | sort)
-    total=$(echo "$functions" | wc -l | tr -d ' ')
+
+    # ── Selective deploy ─────────────────────────────────────────────────────
+    # Deploy only functions the site's enabled modules need (Supabase Free caps
+    # at 100/project). Fail-open: any uncertainty → deploy everything.
+    # Override with FLOWWINK_DEPLOY_ALL=1.
+    local functions total skipped="" skipped_count=0
+    functions="$all_functions"
+    local map_file="supabase/seed/edge-function-map.json"
+
+    if [ "${FLOWWINK_DEPLOY_ALL:-0}" != "1" ] && [ -f "$map_file" ]; then
+        local token modules_json
+        token=$(cat "$HOME/.supabase/access-token" 2>/dev/null || true)
+        if [ -n "$token" ]; then
+            local resp
+            resp=$(curl -s -X POST "https://api.supabase.com/v1/projects/${PROJECT_REF}/database/query" \
+                -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" \
+                -d "$(jq -n '{query:"select value from site_settings where key='"'"'modules'"'"' limit 1"}')" 2>/dev/null || echo "")
+            modules_json=$(echo "$resp" | jq -c '.[0].value // empty' 2>/dev/null || echo "")
+
+            if [ -n "$modules_json" ]; then
+                # Skip a function ONLY if EVERY owning module is explicitly
+                # { enabled: false }. Missing/unknown modules and core/new
+                # functions always deploy. (fail-open)
+                local disabled_arr
+                disabled_arr=$(echo "$modules_json" | jq -c '[to_entries[] | select(.value.enabled == false) | .key]' 2>/dev/null || echo "[]")
+                if [ -n "$disabled_arr" ] && [ "$disabled_arr" != "[]" ]; then
+                    local skip_set
+                    skip_set=$(jq -r --argjson dis "$disabled_arr" \
+                        '([.modules | to_entries[] | .key as $mod | .value[] | {fn:., mod:$mod}]
+                            | group_by(.fn)
+                            | map({fn:.[0].fn, owners:map(.mod)})) as $owned
+                         | $owned[] | select((.owners - $dis) | length == 0) | .fn' \
+                        "$map_file" 2>/dev/null || echo "")
+                    if [ -n "$skip_set" ]; then
+                        local keep="" f
+                        for f in $all_functions; do
+                            if grep -qxF "$f" <<<"$skip_set"; then
+                                skipped+="$f"$'\n'           # all owning modules disabled
+                                skipped_count=$((skipped_count + 1))
+                            else
+                                keep+="$f"$'\n'
+                            fi
+                        done
+                        functions=$(echo "$keep" | sed '/^$/d')
+                    fi
+                fi
+            fi
+        fi
+    fi
+
+    total=$(echo "$functions" | grep -c . | tr -d ' ')
 
     echo -e "  ${DIM}Project: ${PROJECT_NAME}${NC}"
-    echo -e "  Deploying ${total} functions..."
+    if [ "$skipped_count" -gt 0 ]; then
+        echo -e "  Deploying ${total} functions ${DIM}(${skipped_count} skipped — module disabled)${NC}..."
+    else
+        echo -e "  Deploying ${total} functions..."
+    fi
     echo ""
 
     local count=0 failed=0
@@ -335,6 +389,12 @@ cmd_update_funcs() {
             echo "${failed_errors[$i]}" | grep -i "error\|failed\|invalid" | head -3 | sed 's/^/    /'
             echo ""
         done
+    fi
+
+    if [ "$skipped_count" -gt 0 ]; then
+        echo ""
+        echo -e "  ${DIM}Skipped ${skipped_count} function(s) for disabled modules (Free-tier friendly).${NC}"
+        echo -e "  ${DIM}Enable the module in admin, or set FLOWWINK_DEPLOY_ALL=1 to deploy all.${NC}"
     fi
     echo ""
 }

--- a/src/components/admin/modules/EdgeFunctionUsageCard.tsx
+++ b/src/components/admin/modules/EdgeFunctionUsageCard.tsx
@@ -1,0 +1,127 @@
+/**
+ * EdgeFunctionUsageCard — shows how many Supabase Edge Functions the site's
+ * enabled modules require, against the Free-tier ceiling (100). Gives the admin
+ * a clear "time to upgrade to Supabase Pro" signal as they grow into modules.
+ *
+ * Footprint is computed from the edge-function registry (single source of
+ * truth) + the currently-enabled modules, so it updates live as modules toggle.
+ */
+import { useMemo } from 'react';
+import { Server, TriangleAlert, ArrowUpCircle, CheckCircle2 } from 'lucide-react';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import {
+  edgeFunctionUsage,
+  PLAN_FUNCTION_LIMITS,
+  type ModuleId,
+} from '@/lib/edge-function-registry';
+
+interface Props {
+  /** Module ids currently enabled (use the live/unsaved set for instant feedback). */
+  enabledModuleIds: ModuleId[];
+  /** Human-readable module labels keyed by id, for the breakdown. */
+  moduleNames?: Partial<Record<ModuleId, string>>;
+}
+
+const WARN_AT = 0.85; // start nudging toward Pro at 85% of the free ceiling
+
+export function EdgeFunctionUsageCard({ enabledModuleIds, moduleNames }: Props) {
+  const usage = useMemo(() => edgeFunctionUsage(enabledModuleIds), [enabledModuleIds]);
+
+  const pct = Math.min(100, Math.round((usage.required / usage.freeLimit) * 100));
+  const remaining = usage.freeLimit - usage.required;
+  const over = usage.required > usage.freeLimit;
+  const warning = !over && usage.required >= usage.freeLimit * WARN_AT;
+
+  const barColor = over ? '[&>div]:bg-destructive' : warning ? '[&>div]:bg-amber-500' : '';
+
+  return (
+    <Card className={over ? 'border-destructive/40' : warning ? 'border-amber-500/40' : 'border-muted'}>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Server className="h-5 w-5" />
+            Edge function usage
+          </CardTitle>
+          <Badge variant={over ? 'destructive' : warning ? 'secondary' : 'outline'}>
+            {usage.required} / {usage.freeLimit}
+          </Badge>
+        </div>
+        <CardDescription>
+          Supabase Free allows {PLAN_FUNCTION_LIMITS.free} edge functions per project. Your enabled
+          modules deploy {usage.required} ({usage.core} core, always deployed).
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <div className="space-y-1.5">
+          <Progress value={pct} className={barColor} />
+          <div className="flex justify-between text-xs text-muted-foreground">
+            <span>{usage.core} core</span>
+            <span>
+              {over
+                ? `${usage.required - usage.freeLimit} over the Free limit`
+                : `${remaining} slot${remaining === 1 ? '' : 's'} left on Free`}
+            </span>
+          </div>
+        </div>
+
+        {over && (
+          <Alert variant="destructive">
+            <ArrowUpCircle className="h-4 w-4" />
+            <AlertTitle>Upgrade to Supabase Pro</AlertTitle>
+            <AlertDescription className="text-xs">
+              Your enabled modules need {usage.required} functions — past the Free ceiling of{' '}
+              {usage.freeLimit}. Some functions won't deploy until you upgrade this project to{' '}
+              <strong>Pro</strong> ({PLAN_FUNCTION_LIMITS.pro} functions, ~$25/mo). Until then,
+              disable a module above to stay within Free.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {warning && (
+          <Alert>
+            <TriangleAlert className="h-4 w-4" />
+            <AlertTitle>Approaching the Free limit</AlertTitle>
+            <AlertDescription className="text-xs">
+              You have {remaining} edge-function slot{remaining === 1 ? '' : 's'} left on Supabase
+              Free. Enabling a few more modules will require upgrading to Pro.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {!over && !warning && (
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+            Comfortably within the Free tier — grow into more modules anytime.
+          </p>
+        )}
+
+        {usage.perModule.length > 0 && (
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-muted-foreground">Functions added by your modules</p>
+            <div className="space-y-1">
+              {usage.perModule.map(({ moduleId, count }) => (
+                <div key={moduleId} className="flex items-center justify-between text-xs">
+                  <span className="text-foreground">{moduleNames?.[moduleId] ?? moduleId}</span>
+                  <span className="font-mono text-muted-foreground">+{count}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <p className="border-t pt-3 text-xs text-muted-foreground">
+          If you enable <strong>every</strong> module, this site would deploy{' '}
+          <strong>{usage.ifAllEnabled}</strong> functions
+          {usage.allFitsFree
+            ? ' — still within Free.'
+            : ` — which needs Supabase Pro (Free caps at ${usage.freeLimit}).`}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/__tests__/edge-function-registry.guardrails.test.ts
+++ b/src/lib/__tests__/edge-function-registry.guardrails.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Guardrail: the edge-function registry must stay in sync with the deployable
+ * functions on disk, and every module-mapped function must actually exist.
+ *
+ * If this fails, an edge function was added or removed — update
+ * `src/lib/edge-function-registry.ts` (ALL_EDGE_FUNCTIONS / MODULE_EDGE_FUNCTIONS).
+ */
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALL_EDGE_FUNCTIONS,
+  MODULE_EDGE_FUNCTIONS,
+  coreEdgeFunctions,
+  requiredEdgeFunctions,
+} from '../edge-function-registry';
+
+const FUNCTIONS_DIR = join(process.cwd(), 'supabase', 'functions');
+
+/** Deployable function dirs = have index.ts, excluding helpers. */
+function deployableFunctionDirs(): string[] {
+  const SKIP = new Set(['_shared', 'shared', 'tests']);
+  return readdirSync(FUNCTIONS_DIR)
+    .filter((name) => !SKIP.has(name))
+    .filter((name) => {
+      const p = join(FUNCTIONS_DIR, name);
+      return statSync(p).isDirectory() && existsSync(join(p, 'index.ts'));
+    })
+    .sort();
+}
+
+describe('edge-function registry', () => {
+  it('ALL_EDGE_FUNCTIONS matches the deployable function dirs on disk', () => {
+    const onDisk = deployableFunctionDirs();
+    const inRegistry = [...ALL_EDGE_FUNCTIONS].sort();
+
+    const missing = onDisk.filter((f) => !inRegistry.includes(f));
+    const stale = inRegistry.filter((f) => !onDisk.includes(f));
+
+    expect(
+      { missing, stale },
+      `Registry drift — update ALL_EDGE_FUNCTIONS in src/lib/edge-function-registry.ts.\n` +
+        `Missing (on disk, not in registry): ${missing.join(', ') || 'none'}\n` +
+        `Stale (in registry, not on disk): ${stale.join(', ') || 'none'}`,
+    ).toEqual({ missing: [], stale: [] });
+  });
+
+  it('every module-mapped function exists in ALL_EDGE_FUNCTIONS', () => {
+    const known = new Set(ALL_EDGE_FUNCTIONS);
+    const unknown: string[] = [];
+    for (const [moduleId, fns] of Object.entries(MODULE_EDGE_FUNCTIONS)) {
+      for (const fn of fns ?? []) {
+        if (!known.has(fn)) unknown.push(`${moduleId} → ${fn}`);
+      }
+    }
+    expect(unknown, `Module map references unknown functions: ${unknown.join(', ')}`).toEqual([]);
+  });
+
+  it('core + every module-owned function partitions the full set (no orphans)', () => {
+    const core = new Set(coreEdgeFunctions());
+    const owned = new Set(Object.values(MODULE_EDGE_FUNCTIONS).flatMap((f) => [...(f ?? [])]));
+    for (const fn of ALL_EDGE_FUNCTIONS) {
+      expect(core.has(fn) || owned.has(fn), `${fn} is neither core nor module-owned`).toBe(true);
+    }
+  });
+
+  it('no enabled modules → only core functions are required', () => {
+    expect(requiredEdgeFunctions([]).sort()).toEqual(coreEdgeFunctions().sort());
+  });
+
+  it('enabling a module adds exactly its (still-disabled-elsewhere) functions', () => {
+    // voice owns chat-stt etc. exclusively → enabling voice adds all 5.
+    const base = requiredEdgeFunctions([]).length;
+    const withVoice = requiredEdgeFunctions(['voice']).length;
+    expect(withVoice).toBe(base + (MODULE_EDGE_FUNCTIONS.voice?.length ?? 0));
+  });
+});

--- a/src/lib/__tests__/edge-function-registry.guardrails.test.ts
+++ b/src/lib/__tests__/edge-function-registry.guardrails.test.ts
@@ -5,7 +5,7 @@
  * If this fails, an edge function was added or removed — update
  * `src/lib/edge-function-registry.ts` (ALL_EDGE_FUNCTIONS / MODULE_EDGE_FUNCTIONS).
  */
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -74,5 +74,26 @@ describe('edge-function registry', () => {
     const base = requiredEdgeFunctions([]).length;
     const withVoice = requiredEdgeFunctions(['voice']).length;
     expect(withVoice).toBe(base + (MODULE_EDGE_FUNCTIONS.voice?.length ?? 0));
+  });
+
+  it('edge-function-map.json is in sync with the registry (run `npm run edge-map:json`)', () => {
+    const mapPath = join(process.cwd(), 'supabase', 'seed', 'edge-function-map.json');
+    expect(existsSync(mapPath), 'edge-function-map.json missing — run `npm run edge-map:json`').toBe(true);
+    const artifact = JSON.parse(readFileSync(mapPath, 'utf8')) as {
+      total: number;
+      core: string[];
+      modules: Record<string, string[]>;
+    };
+
+    expect(artifact.total, 'total drift — run `npm run edge-map:json`').toBe(ALL_EDGE_FUNCTIONS.length);
+    expect([...artifact.core].sort(), 'core drift — run `npm run edge-map:json`').toEqual(coreEdgeFunctions().sort());
+
+    const expectedModules = Object.fromEntries(
+      Object.entries(MODULE_EDGE_FUNCTIONS).map(([id, fns]) => [id, [...(fns ?? [])].sort()]),
+    );
+    const actualModules = Object.fromEntries(
+      Object.entries(artifact.modules).map(([id, fns]) => [id, [...fns].sort()]),
+    );
+    expect(actualModules, 'module map drift — run `npm run edge-map:json`').toEqual(expectedModules);
   });
 });

--- a/src/lib/edge-function-registry.ts
+++ b/src/lib/edge-function-registry.ts
@@ -1,0 +1,222 @@
+/**
+ * Edge Function Registry — single source of truth for which Supabase Edge
+ * Functions a site actually needs, based on its enabled modules.
+ *
+ * WHY THIS EXISTS
+ * ----------------
+ * Supabase caps the number of edge functions per project by plan:
+ *   Free 100 · Pro 500 · Team 1000 · Enterprise ∞
+ * FlowWink ships 100+ functions. A site that deploys *all* of them hits the
+ * Free-tier ceiling. But no site enables every module — so the provisioning
+ * script should deploy only the functions the site's enabled modules require.
+ *
+ * FAIL-OPEN BY DESIGN
+ * -------------------
+ * A function NOT listed in MODULE_EDGE_FUNCTIONS is treated as CORE and is
+ * ALWAYS deployed. A function owned by several modules deploys if ANY owner is
+ * enabled. The only direction this can err is "deploy something we didn't
+ * strictly need" (harmless) — never "skip something required" (breaking).
+ *
+ * KEEP IN SYNC
+ * ------------
+ * `ALL_EDGE_FUNCTIONS` must match the deployable function dirs on disk
+ * (supabase/functions/<name>/index.ts). The guardrail test
+ * `edge-function-registry.guardrails.test.ts` enforces this — if it fails,
+ * a function was added/removed; update this file.
+ *
+ * Module ids are the keys of `ModulesSettings` (see useModules.tsx).
+ */
+
+import type { ModulesSettings } from '@/hooks/useModules';
+
+export type ModuleId = keyof ModulesSettings;
+
+/** Supabase per-project edge-function ceiling by plan. */
+export const PLAN_FUNCTION_LIMITS = {
+  free: 100,
+  pro: 500,
+  team: 1000,
+  enterprise: Infinity,
+} as const;
+
+export type SupabasePlan = keyof typeof PLAN_FUNCTION_LIMITS;
+
+/** Default assumption for fork sites (see docs/operators/provisioning-and-updates.md). */
+export const DEFAULT_PLAN: SupabasePlan = 'free';
+
+/**
+ * Every deployable edge function (dirs with an index.ts, excluding `_shared`,
+ * the `shared` helper dir, and `tests`). Guardrail-tested against the filesystem.
+ */
+export const ALL_EDGE_FUNCTIONS: readonly string[] = [
+  'a2a', 'agent-card', 'agent-execute', 'agent-operate', 'agent-reason', 'ai-task',
+  'analyze-brand', 'automation-dispatcher', 'blog-rss', 'browser-fetch',
+  'chat-completion', 'chat-stt', 'check-secrets', 'company-profile', 'composio-proxy',
+  'consultant-checkin', 'contact-center', 'contact-finder', 'content-api',
+  'contract-sign', 'copilot-action', 'create-checkout', 'create-invoice-payment',
+  'create-user', 'csat-dispatch', 'customer-360', 'customer-signup', 'demo-cycle',
+  'docs-chat', 'docs-sync', 'dunning-processor', 'elevenlabs-account', 'elks46-ingest',
+  'email-send', 'enrich-company', 'enrich-company-profile', 'event-dispatcher',
+  'extract-pdf-text', 'extract-receipt', 'federation-invite-peer', 'fetch-fx-rates',
+  'fetch-image', 'field-service-skill', 'firecrawl-account', 'flowpilot-briefing',
+  'flowpilot-distill', 'flowpilot-heartbeat', 'flowpilot-learn', 'gatewayapi-ingest',
+  'generate-invoice-pdf', 'get-page', 'github-content-sync', 'gmail-inbox-scan',
+  'gmail-oauth-callback', 'hunter-account', 'instance-health', 'invite-employee',
+  'llms-txt', 'mcp-server', 'migrate-page', 'newsletter-export', 'newsletter-gdpr',
+  'newsletter-link', 'newsletter-send', 'newsletter-subscribe', 'newsletter-track',
+  'openai-account', 'openclaw-responses', 'parse-resume', 'process-image',
+  'process-job-application', 'prospect-fit-analysis', 'prospect-research', 'qualify-lead',
+  'quote-sign', 'reconciliation', 'resume-match', 'run-autonomy-tests',
+  'run-platform-tests', 'sales-profile-setup', 'send-booking-confirmation',
+  'send-contact-email', 'send-invoice-email', 'send-order-confirmation', 'send-quote-email',
+  'send-webhook', 'setup-database', 'signal-dispatcher', 'signal-ingest', 'sitemap',
+  'sla-check', 'stripe-webhook', 'subscription-billing-cron', 'subscriptions',
+  'support-router', 'survey-send', 'system-integrity-check', 'telegram-ingest',
+  'test-ai-connection', 'track-auth-event', 'track-page-view', 'twilio-ingest',
+  'unsplash-search', 'update-autonomy-cron', 'voice-ingest', 'web-scrape', 'web-search',
+  'workspace-chat',
+];
+
+/**
+ * Module → the edge functions it (and only it) needs. A function may appear
+ * under several modules; it deploys if ANY of them is enabled. Functions NOT
+ * listed anywhere here are CORE and always deploy.
+ *
+ * Derivation: skillSeed handlers (`edge:`/`function:` prefixes) + frontend
+ * `invoke()` call sites, attributed to the owning module/feature.
+ */
+export const MODULE_EDGE_FUNCTIONS: Partial<Record<ModuleId, readonly string[]>> = {
+  // ── Communication / contact center ───────────────────────────────────────
+  voice: ['elks46-ingest', 'twilio-ingest', 'gatewayapi-ingest', 'voice-ingest', 'chat-stt'],
+  liveSupport: ['contact-center', 'telegram-ingest', 'support-router', 'csat-dispatch'],
+  email: ['gmail-inbox-scan', 'gmail-oauth-callback'],
+  newsletter: [
+    'newsletter-send', 'newsletter-subscribe', 'newsletter-export',
+    'newsletter-gdpr', 'newsletter-link', 'newsletter-track',
+  ],
+
+  // ── CRM / sales / leads ──────────────────────────────────────────────────
+  leads: ['contact-finder', 'qualify-lead', 'enrich-company'],
+  companies: ['enrich-company'],
+  companyInsights: ['company-profile', 'enrich-company-profile'],
+  customer360: ['customer-360'],
+  salesIntelligence: ['prospect-research', 'prospect-fit-analysis', 'sales-profile-setup', 'signal-ingest'],
+
+  // ── HR / recruitment / consultants ───────────────────────────────────────
+  recruitment: ['parse-resume', 'invite-employee', 'process-job-application'],
+  resume: ['resume-match', 'consultant-checkin'],
+
+  // ── Commerce / finance ───────────────────────────────────────────────────
+  ecommerce: ['create-checkout', 'send-order-confirmation'],
+  invoicing: ['send-invoice-email', 'generate-invoice-pdf', 'create-invoice-payment'],
+  quotes: ['quote-sign', 'send-quote-email'],
+  contracts: ['contract-sign'],
+  bookings: ['send-booking-confirmation'],
+  subscriptions: ['subscriptions', 'subscription-billing-cron', 'dunning-processor'],
+  expenses: ['extract-receipt'],
+  reconciliation: ['reconciliation'],
+  multiCurrency: ['fetch-fx-rates'],
+
+  // ── Field service / SLA / surveys ────────────────────────────────────────
+  fieldService: ['field-service-skill'],
+  sla: ['sla-check'],
+  surveys: ['survey-send'],
+
+  // ── Content / docs / knowledge ───────────────────────────────────────────
+  blog: ['blog-rss'],
+  docs: ['docs-chat', 'docs-sync'],
+  handbook: ['github-content-sync'],
+  workspaceChat: ['workspace-chat'],
+  siteMigration: ['migrate-page', 'analyze-brand'],
+
+  // ── Autonomous operator (off by default) ─────────────────────────────────
+  flowpilot: [
+    'flowpilot-heartbeat', 'flowpilot-briefing', 'flowpilot-learn', 'flowpilot-distill',
+    'update-autonomy-cron', 'run-autonomy-tests', 'web-search', 'web-scrape',
+  ],
+
+  // ── Federation / external agents ─────────────────────────────────────────
+  federation: ['a2a', 'agent-card', 'federation-invite-peer', 'openclaw-responses'],
+
+  // ── Integrations ─────────────────────────────────────────────────────────
+  composio: ['composio-proxy'],
+  browserControl: ['browser-fetch'],
+};
+
+/** All functions that belong to at least one module (i.e. not core). */
+function moduleOwnedFunctions(): Set<string> {
+  const owned = new Set<string>();
+  for (const fns of Object.values(MODULE_EDGE_FUNCTIONS)) {
+    for (const fn of fns ?? []) owned.add(fn);
+  }
+  return owned;
+}
+
+/** Functions deployed on every site regardless of enabled modules. */
+export function coreEdgeFunctions(): string[] {
+  const owned = moduleOwnedFunctions();
+  return ALL_EDGE_FUNCTIONS.filter((fn) => !owned.has(fn));
+}
+
+/**
+ * The functions a site must deploy given its enabled modules.
+ * Core functions always included; a module-owned function is included if any
+ * of its owning modules is enabled. (Fail-open: unknown functions count as core.)
+ */
+export function requiredEdgeFunctions(enabledModuleIds: Iterable<ModuleId>): string[] {
+  const enabled = new Set<ModuleId>(enabledModuleIds);
+  const owned = moduleOwnedFunctions();
+  return ALL_EDGE_FUNCTIONS.filter((fn) => {
+    if (!owned.has(fn)) return true; // core
+    // keep if any owning module is enabled
+    for (const [moduleId, fns] of Object.entries(MODULE_EDGE_FUNCTIONS)) {
+      if ((fns ?? []).includes(fn) && enabled.has(moduleId as ModuleId)) return true;
+    }
+    return false;
+  });
+}
+
+export interface EdgeFunctionUsage {
+  /** Functions this site deploys with its current enabled modules. */
+  required: number;
+  /** Functions deployed regardless of modules. */
+  core: number;
+  /** Footprint if every mappable module were turned on. */
+  ifAllEnabled: number;
+  /** Total functions that exist in the codebase. */
+  total: number;
+  /** Free-tier ceiling (100). */
+  freeLimit: number;
+  /** Per-enabled-module extra functions, for the breakdown UI. */
+  perModule: Array<{ moduleId: ModuleId; functions: string[]; count: number }>;
+  /** True when the current footprint is within Free tier. */
+  withinFree: boolean;
+  /** True when enabling everything would still fit Free tier. */
+  allFitsFree: boolean;
+}
+
+/** Compute the edge-function usage summary for an enabled-module set. */
+export function edgeFunctionUsage(enabledModuleIds: Iterable<ModuleId>): EdgeFunctionUsage {
+  const enabled = new Set<ModuleId>(enabledModuleIds);
+  const required = requiredEdgeFunctions(enabled).length;
+  const core = coreEdgeFunctions().length;
+
+  const perModule = (Object.entries(MODULE_EDGE_FUNCTIONS) as Array<[ModuleId, readonly string[]]>)
+    .filter(([moduleId]) => enabled.has(moduleId))
+    .map(([moduleId, fns]) => ({ moduleId, functions: [...fns], count: fns.length }))
+    .sort((a, b) => b.count - a.count);
+
+  const allModuleIds = Object.keys(MODULE_EDGE_FUNCTIONS) as ModuleId[];
+  const ifAllEnabled = requiredEdgeFunctions(allModuleIds).length;
+
+  return {
+    required,
+    core,
+    ifAllEnabled,
+    total: ALL_EDGE_FUNCTIONS.length,
+    freeLimit: PLAN_FUNCTION_LIMITS.free,
+    perModule,
+    withinFree: required <= PLAN_FUNCTION_LIMITS.free,
+    allFitsFree: ifAllEnabled <= PLAN_FUNCTION_LIMITS.free,
+  };
+}

--- a/src/pages/admin/ModulesPage.tsx
+++ b/src/pages/admin/ModulesPage.tsx
@@ -95,6 +95,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useModules, useUpdateModules, defaultModulesSettings, type ModulesSettings } from "@/hooks/useModules";
 import { useModuleStats } from "@/hooks/useModuleStats";
 import { ModuleCard } from "@/components/admin/modules/ModuleCard";
+import { EdgeFunctionUsageCard } from "@/components/admin/modules/EdgeFunctionUsageCard";
 import { moduleRegistry } from "@/lib/module-registry";
 import { bootstrapModule, teardownModule } from "@/lib/module-bootstrap";
 import { runWithConcurrency } from "@/lib/run-with-concurrency";
@@ -378,6 +379,17 @@ export default function ModulesPage() {
   const totalCount = Object.keys(defaultModulesSettings).length;
   const registeredModules = moduleRegistry.list();
 
+  const enabledModuleIds = localModules
+    ? (Object.entries(localModules)
+        .filter(([, m]) => m.enabled)
+        .map(([id]) => id) as (keyof ModulesSettings)[])
+    : [];
+  const moduleNames = localModules
+    ? (Object.fromEntries(
+        Object.entries(localModules).map(([id, m]) => [id, m.name]),
+      ) as Partial<Record<keyof ModulesSettings, string>>)
+    : {};
+
   return (
     <AdminLayout>
       <div className="space-y-8">
@@ -432,6 +444,9 @@ export default function ModulesPage() {
             </CardContent>
           </Card>
         </div>
+
+        {/* Edge function footprint vs Supabase Free tier */}
+        <EdgeFunctionUsageCard enabledModuleIds={enabledModuleIds} moduleNames={moduleNames} />
 
         {/* Registry Info */}
         <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/20 p-4">

--- a/supabase/seed/edge-function-map.json
+++ b/supabase/seed/edge-function-map.json
@@ -1,0 +1,189 @@
+{
+  "generated_by": "scripts/edge-functions-to-json.ts",
+  "note": "Selective-deploy map. Core = always deployed. modules[<id>] = deployed only when that module is enabled. Unknown/new functions: deploy (fail-open).",
+  "total": 108,
+  "core_count": 37,
+  "plan_limits": {
+    "free": 100,
+    "pro": 500,
+    "team": 1000,
+    "enterprise": null
+  },
+  "core": [
+    "agent-execute",
+    "agent-operate",
+    "agent-reason",
+    "ai-task",
+    "automation-dispatcher",
+    "chat-completion",
+    "check-secrets",
+    "content-api",
+    "copilot-action",
+    "create-user",
+    "customer-signup",
+    "demo-cycle",
+    "elevenlabs-account",
+    "email-send",
+    "event-dispatcher",
+    "extract-pdf-text",
+    "fetch-image",
+    "firecrawl-account",
+    "get-page",
+    "hunter-account",
+    "instance-health",
+    "llms-txt",
+    "mcp-server",
+    "openai-account",
+    "process-image",
+    "run-platform-tests",
+    "send-contact-email",
+    "send-webhook",
+    "setup-database",
+    "signal-dispatcher",
+    "sitemap",
+    "stripe-webhook",
+    "system-integrity-check",
+    "test-ai-connection",
+    "track-auth-event",
+    "track-page-view",
+    "unsplash-search"
+  ],
+  "modules": {
+    "blog": [
+      "blog-rss"
+    ],
+    "bookings": [
+      "send-booking-confirmation"
+    ],
+    "browserControl": [
+      "browser-fetch"
+    ],
+    "companies": [
+      "enrich-company"
+    ],
+    "companyInsights": [
+      "company-profile",
+      "enrich-company-profile"
+    ],
+    "composio": [
+      "composio-proxy"
+    ],
+    "contracts": [
+      "contract-sign"
+    ],
+    "customer360": [
+      "customer-360"
+    ],
+    "docs": [
+      "docs-chat",
+      "docs-sync"
+    ],
+    "ecommerce": [
+      "create-checkout",
+      "send-order-confirmation"
+    ],
+    "email": [
+      "gmail-inbox-scan",
+      "gmail-oauth-callback"
+    ],
+    "expenses": [
+      "extract-receipt"
+    ],
+    "federation": [
+      "a2a",
+      "agent-card",
+      "federation-invite-peer",
+      "openclaw-responses"
+    ],
+    "fieldService": [
+      "field-service-skill"
+    ],
+    "flowpilot": [
+      "flowpilot-briefing",
+      "flowpilot-distill",
+      "flowpilot-heartbeat",
+      "flowpilot-learn",
+      "run-autonomy-tests",
+      "update-autonomy-cron",
+      "web-scrape",
+      "web-search"
+    ],
+    "handbook": [
+      "github-content-sync"
+    ],
+    "invoicing": [
+      "create-invoice-payment",
+      "generate-invoice-pdf",
+      "send-invoice-email"
+    ],
+    "leads": [
+      "contact-finder",
+      "enrich-company",
+      "qualify-lead"
+    ],
+    "liveSupport": [
+      "contact-center",
+      "csat-dispatch",
+      "support-router",
+      "telegram-ingest"
+    ],
+    "multiCurrency": [
+      "fetch-fx-rates"
+    ],
+    "newsletter": [
+      "newsletter-export",
+      "newsletter-gdpr",
+      "newsletter-link",
+      "newsletter-send",
+      "newsletter-subscribe",
+      "newsletter-track"
+    ],
+    "quotes": [
+      "quote-sign",
+      "send-quote-email"
+    ],
+    "reconciliation": [
+      "reconciliation"
+    ],
+    "recruitment": [
+      "invite-employee",
+      "parse-resume",
+      "process-job-application"
+    ],
+    "resume": [
+      "consultant-checkin",
+      "resume-match"
+    ],
+    "salesIntelligence": [
+      "prospect-fit-analysis",
+      "prospect-research",
+      "sales-profile-setup",
+      "signal-ingest"
+    ],
+    "siteMigration": [
+      "analyze-brand",
+      "migrate-page"
+    ],
+    "sla": [
+      "sla-check"
+    ],
+    "subscriptions": [
+      "dunning-processor",
+      "subscription-billing-cron",
+      "subscriptions"
+    ],
+    "surveys": [
+      "survey-send"
+    ],
+    "voice": [
+      "chat-stt",
+      "elks46-ingest",
+      "gatewayapi-ingest",
+      "twilio-ingest",
+      "voice-ingest"
+    ],
+    "workspaceChat": [
+      "workspace-chat"
+    ]
+  }
+}


### PR DESCRIPTION
**Stacked on #87** (base = `claude/project-review-22lava`). Depends on the Lovable voice/WebMeet sync because the registry maps functions that merge introduces (`chat-stt`, `voice-ingest`, `elevenlabs-account`, `contact-center`, `telegram-ingest`, …). Rebase onto `main` once #87 merges.

## Why
All 4 forks run on Supabase **Free**, which caps edge functions at **100/project**. The codebase ships 108 — so a Free fork can't deploy them all (the 101st+ fail). This makes the footprint fit the plan, and tells the admin when to upgrade.

## What

**1. Edge-function registry** (`src/lib/edge-function-registry.ts`) — single source of truth mapping all 108 deployable functions:
- **37 core** (platform: get-page, chat-completion, agent-execute, mcp-server, email-send, stripe-webhook, …) — always deployed.
- **71 module-bound** — deployed only when an owning module is enabled.
- Fail-open: unmapped/new functions = core = always deploy; a multi-owner function deploys if **any** owner is enabled.

**2. Selective deploy** (`flowwink.sh /update-funcs`) — queries `site_settings.modules` and skips a function **only when every owning module is explicitly `enabled:false`**. Missing/unknown modules, core, and new functions always deploy. `FLOWWINK_DEPLOY_ALL=1` forces the old behaviour. Driven by the generated `supabase/seed/edge-function-map.json` (`npm run edge-map:json`).

**3. Admin visibility** (`EdgeFunctionUsageCard` on `/admin/modules`) — live `X / 100` footprint, per-module breakdown, 85% warning, and an upgrade-to-Pro nudge once enabling more modules would exceed Free. Realises the "start free, grow into the platform, upgrade Supabase to unlock everything" story.

**4. Guardrails** — `edge-function-registry.guardrails.test.ts` keeps `ALL_EDGE_FUNCTIONS` in sync with the functions on disk and the JSON artifact in sync with the registry (CI fails on drift with the exact `npm run` to fix).

## Footprint math
108 total → 37 core always on. A fork with voice/federation/flowpilot disabled skips ~13; only enabling essentially everything reaches 108 (> 100 → Pro).

## Tests
307 passing (full vitest), bash `-n` clean, eslint clean. Selective filter verified across sparse-config, multi-owner-kept, and multi-owner-skipped scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_