### PR TITLE
Admin signal: warn when an enabled module's edge function isn't deployed

### DIFF
--- a/scripts/flowwink.sh
+++ b/scripts/flowwink.sh
@@ -412,60 +412,71 @@ cmd_update_funcs() {
         if [ "$failed" -ne 0 ]; then
             echo -e "  ${YELLOW}⚠ Skipping prune — ${failed} function(s) failed to deploy.${NC}"
             echo -e "  ${DIM}Fix the deploy first so prune can't remove something still needed.${NC}"
-            echo ""
-            return 0
-        fi
-
-        local deployed
-        deployed=$(supabase functions list --project-ref "$PROJECT_REF" --output json 2>/dev/null \
-            | jq -r '.[].slug // .[].name' 2>/dev/null || echo "")
-        if [ -z "$deployed" ]; then
-            echo -e "  ${YELLOW}⚠ Could not list deployed functions — skipping prune (nothing deleted).${NC}"
-            echo ""
-            return 0
-        fi
-
-        # extras = deployed − keep-set ($functions). Never touches the keep-set.
-        local extras="" e
-        for e in $deployed; do
-            grep -qxF "$e" <<<"$functions" || extras+="$e"$'\n'
-        done
-        extras=$(echo "$extras" | sed '/^$/d')
-
-        local extra_count
-        extra_count=$(echo "$extras" | grep -c . | tr -d ' ')
-        if [ "$extra_count" -eq 0 ]; then
-            echo -e "  ${GREEN}✓ Nothing to prune — deployed set already matches this site.${NC}"
-            echo ""
-            return 0
-        fi
-
-        echo -e "  These ${extra_count} deployed function(s) are NOT needed by this site:"
-        echo "$extras" | sed 's/^/    ✗ /'
-        echo ""
-        if [ "${FLOWWINK_PRUNE_YES:-0}" != "1" ]; then
-            local confirm
-            read -e -p "  Type DELETE to remove them (anything else cancels): " confirm
-            if [ "$confirm" != "DELETE" ]; then
-                echo -e "  ${DIM}Cancelled — nothing deleted.${NC}"
-                echo ""
-                return 0
-            fi
-        fi
-
-        local pruned=0 prune_failed=0
-        for e in $extras; do
-            printf "  deleting %-42s" "$e"
-            if supabase functions delete "$e" --project-ref "$PROJECT_REF" >/dev/null 2>&1; then
-                echo -e "${GREEN}✓${NC}"; pruned=$((pruned + 1))
+        else
+            local pdeployed
+            pdeployed=$(supabase functions list --project-ref "$PROJECT_REF" --output json 2>/dev/null \
+                | jq -r '.[].slug // .[].name' 2>/dev/null || echo "")
+            if [ -z "$pdeployed" ]; then
+                echo -e "  ${YELLOW}⚠ Could not list deployed functions — skipping prune (nothing deleted).${NC}"
             else
-                echo -e "${RED}✗${NC}"; prune_failed=$((prune_failed + 1))
+                # extras = deployed − keep-set ($functions). Never touches the keep-set.
+                local extras="" e
+                for e in $pdeployed; do
+                    grep -qxF "$e" <<<"$functions" || extras+="$e"$'\n'
+                done
+                extras=$(echo "$extras" | sed '/^$/d')
+                local extra_count
+                extra_count=$(echo "$extras" | grep -c . | tr -d ' ')
+                if [ "$extra_count" -eq 0 ]; then
+                    echo -e "  ${GREEN}✓ Nothing to prune — deployed set already matches this site.${NC}"
+                else
+                    echo -e "  These ${extra_count} deployed function(s) are NOT needed by this site:"
+                    echo "$extras" | sed 's/^/    ✗ /'
+                    echo ""
+                    local do_prune=1
+                    if [ "${FLOWWINK_PRUNE_YES:-0}" != "1" ]; then
+                        local confirm
+                        read -e -p "  Type DELETE to remove them (anything else cancels): " confirm
+                        [ "$confirm" != "DELETE" ] && { echo -e "  ${DIM}Cancelled — nothing deleted.${NC}"; do_prune=0; }
+                    fi
+                    if [ "$do_prune" = "1" ]; then
+                        local pruned=0 prune_failed=0
+                        for e in $extras; do
+                            printf "  deleting %-42s" "$e"
+                            if supabase functions delete "$e" --project-ref "$PROJECT_REF" >/dev/null 2>&1; then
+                                echo -e "${GREEN}✓${NC}"; pruned=$((pruned + 1))
+                            else
+                                echo -e "${RED}✗${NC}"; prune_failed=$((prune_failed + 1))
+                            fi
+                        done
+                        echo ""
+                        echo -e "  ${GREEN}✓ Pruned ${pruned} function(s)${NC}$([ "$prune_failed" -gt 0 ] && echo -e " ${RED}(${prune_failed} failed)${NC}")"
+                    fi
+                fi
             fi
-        done
-        echo ""
-        echo -e "  ${GREEN}✓ Pruned ${pruned} function(s)${NC}$([ "$prune_failed" -gt 0 ] && echo -e " ${RED}(${prune_failed} failed)${NC}")"
+        fi
     fi
+
+    record_deployed_functions
     echo ""
+}
+
+# Record the instance's deployed edge functions into site_settings so the admin
+# Modules page can flag "module enabled but its function isn't deployed".
+record_deployed_functions() {
+    local token deployed json
+    token=$(cat "$HOME/.supabase/access-token" 2>/dev/null || true)
+    [ -z "$token" ] && return 0
+    deployed=$(supabase functions list --project-ref "$PROJECT_REF" --output json 2>/dev/null \
+        | jq -r '.[].slug // .[].name' 2>/dev/null || echo "")
+    [ -z "$deployed" ] && return 0
+    json=$(echo "$deployed" | jq -R . | jq -s -c .)
+    local sql
+    sql="insert into public.site_settings(key, value) values('edge_functions_deployed', jsonb_build_object('functions', '${json}'::jsonb, 'updated_at', now()::text)) on conflict (key) do update set value = excluded.value;"
+    curl -s -o /dev/null -m 25 -X POST "https://api.supabase.com/v1/projects/${PROJECT_REF}/database/query" \
+        -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" \
+        -d "$(jq -n --arg q "$sql" '{query:$q}')" \
+        && echo -e "  ${DIM}Recorded deployed function list for the admin UI.${NC}"
 }
 
 cmd_set_keys() {

--- a/src/components/admin/modules/EdgeFunctionUsageCard.tsx
+++ b/src/components/admin/modules/EdgeFunctionUsageCard.tsx
@@ -7,7 +7,7 @@
  * truth) + the currently-enabled modules, so it updates live as modules toggle.
  */
 import { useMemo } from 'react';
-import { Server, TriangleAlert, ArrowUpCircle, CheckCircle2 } from 'lucide-react';
+import { Server, TriangleAlert, ArrowUpCircle, CheckCircle2, CloudOff } from 'lucide-react';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
@@ -15,9 +15,12 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import {
   edgeFunctionUsage,
+  requiredEdgeFunctions,
+  MODULE_EDGE_FUNCTIONS,
   PLAN_FUNCTION_LIMITS,
   type ModuleId,
 } from '@/lib/edge-function-registry';
+import { useDeployedEdgeFunctions } from '@/hooks/useDeployedEdgeFunctions';
 
 interface Props {
   /** Module ids currently enabled (use the live/unsaved set for instant feedback). */
@@ -30,6 +33,27 @@ const WARN_AT = 0.85; // start nudging toward Pro at 85% of the free ceiling
 
 export function EdgeFunctionUsageCard({ enabledModuleIds, moduleNames }: Props) {
   const usage = useMemo(() => edgeFunctionUsage(enabledModuleIds), [enabledModuleIds]);
+  const { data: deployed } = useDeployedEdgeFunctions();
+
+  // Which enabled modules need an edge-function deploy that hasn't happened yet?
+  // Only meaningful once the deploy script has recorded what's deployed.
+  const undeployed = useMemo(() => {
+    const list = deployed?.functions;
+    if (!list) return null; // status unknown — never deployed via the current script
+    const deployedSet = new Set(list);
+    const required = requiredEdgeFunctions(enabledModuleIds);
+    const missing = required.filter((fn) => !deployedSet.has(fn));
+    if (missing.length === 0) return [];
+    // map missing functions back to the enabled modules that own them
+    const enabled = new Set(enabledModuleIds);
+    const affected: Array<{ moduleId: ModuleId; functions: string[] }> = [];
+    for (const [moduleId, fns] of Object.entries(MODULE_EDGE_FUNCTIONS) as Array<[ModuleId, readonly string[]]>) {
+      if (!enabled.has(moduleId)) continue;
+      const miss = fns.filter((fn) => missing.includes(fn));
+      if (miss.length) affected.push({ moduleId, functions: miss });
+    }
+    return affected;
+  }, [deployed, enabledModuleIds]);
 
   const pct = Math.min(100, Math.round((usage.required / usage.freeLimit) * 100));
   const remaining = usage.freeLimit - usage.required;
@@ -68,6 +92,26 @@ export function EdgeFunctionUsageCard({ enabledModuleIds, moduleNames }: Props) 
             </span>
           </div>
         </div>
+
+        {undeployed && undeployed.length > 0 && (
+          <Alert className="border-amber-500/50">
+            <CloudOff className="h-4 w-4" />
+            <AlertTitle>Edge function deploy needed</AlertTitle>
+            <AlertDescription className="text-xs">
+              {undeployed.length} enabled module(s) have edge functions that aren't deployed on
+              this instance yet — enabling a module in the UI can't deploy them. Run{' '}
+              <code>flowwink.sh /update-funcs</code> to deploy:
+              <ul className="mt-1 space-y-0.5">
+                {undeployed.map(({ moduleId, functions }) => (
+                  <li key={moduleId}>
+                    <span className="font-medium">{moduleNames?.[moduleId] ?? moduleId}</span>
+                    <span className="text-muted-foreground"> — {functions.join(', ')}</span>
+                  </li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
 
         {over && (
           <Alert variant="destructive">

--- a/src/hooks/useDeployedEdgeFunctions.ts
+++ b/src/hooks/useDeployedEdgeFunctions.ts
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * Reads the list of edge functions actually deployed on this instance.
+ *
+ * `flowwink.sh /update-funcs` writes the deployed function slugs to
+ * `site_settings` (key `edge_functions_deployed`) after each deploy. The
+ * Modules page compares this against the functions the enabled modules require,
+ * so it can warn "module enabled but its edge function isn't deployed — run
+ * /update-funcs". The UI cannot deploy functions itself, so this is the signal.
+ *
+ * Returns `functions: null` when the key is absent (never deployed via the
+ * current script) — the UI then shows a neutral "status unknown" hint rather
+ * than a false "missing" alarm.
+ */
+export interface DeployedEdgeFunctions {
+  functions: string[] | null;
+  updatedAt: string | null;
+}
+
+export function useDeployedEdgeFunctions() {
+  return useQuery<DeployedEdgeFunctions>({
+    queryKey: ['site-settings', 'edge_functions_deployed'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('site_settings')
+        .select('value')
+        .eq('key', 'edge_functions_deployed')
+        .maybeSingle();
+      if (error) throw error;
+
+      const value = (data?.value ?? null) as
+        | { functions?: string[]; updated_at?: string }
+        | string[]
+        | null;
+
+      if (Array.isArray(value)) return { functions: value, updatedAt: null };
+      return {
+        functions: Array.isArray(value?.functions) ? value!.functions : null,
+        updatedAt: value?.updated_at ?? null,
+      };
+    },
+    staleTime: 60_000,
+  });
+}


### PR DESCRIPTION
## Why
Enabling a module in the admin UI only flips a DB flag (`site_settings.modules`). The browser **cannot deploy edge functions** — that needs the Supabase CLI + an access token server-side. So a function-backed module (voice, live-support, newsletter, …) can be "on" while its edge function is missing on the instance, silently broken. This surfaces that gap so the admin knows to run `flowwink.sh /update-funcs`.

## What
- **`flowwink.sh /update-funcs`** now records the instance's actually-deployed function slugs to `site_settings` (key `edge_functions_deployed`, with `updated_at`) after deploy + prune — via the management API it already uses. Runs on every exit path (refactored prune so it no longer early-returns past the recording).
- **`useDeployedEdgeFunctions`** reads that list.
- **`EdgeFunctionUsageCard`** compares it to the functions the *enabled* modules require and shows an amber alert — "N enabled module(s) have edge functions not deployed — run `flowwink.sh /update-funcs`" — listing the affected modules + functions. Neutral (no false alarm) when the list was never recorded.

Reliable by design: no CORS-probe guessing or stored management token — the deploy script (which already has the token) is the single writer; the UI just reads a DB row.

## Tests
`bash -n` clean, `tsc --noEmit` clean, eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_