### PR TITLE
docs(mem): federation transport-agnostic + split developer module (architecture notes)

### DIFF
--- a/mem/architecture/split-developer-module-agent-access-vs-dev-tools.md
+++ b/mem/architecture/split-developer-module-agent-access-vs-dev-tools.md
@@ -1,0 +1,53 @@
+---
+name: Split the developer module — Agent Access (prod) vs Dev Tools (internal)
+description: The `developer` module is overloaded — it bundles MCP/agent-access (a production capability you enable to be operated by an MCP agent) with destructive dev/test tooling (reset_module_data, seed_demo, test runners). Enabling MCP operation drags in the dev tools. Target — split into two concerns. Deferred.
+type: architecture
+---
+
+# Split `developer` into "Agent Access" (prod) and "Dev Tools" (internal)
+
+## The problem
+`developer` is a grab-bag bundling two unrelated concerns:
+
+```
+developer module (today):
+├─ MCP / Agent Access  (PRODUCTION — wanted when an agent operates the instance)
+│   ├─ API keys (ApiKeysPage)         ── mint the key an external MCP agent uses
+│   ├─ MCP activity log (McpActivityPanel)
+│   ├─ MCP skills panel (McpSkillsPanel)
+│   └─ global_search (rpc:mcp_global_search)
+└─ Dev / Test tooling  (INTERNAL — must NOT be on customer prod)
+    ├─ reset_module_data   ⚠ destructive (wipes module data)
+    ├─ seed_module_demo    ⚠ seeds demo data
+    ├─ lint_skill
+    └─ test pages: /admin/autonomy-tests, /admin/platform-tests
+       (+ edge fns run-autonomy-tests, run-platform-tests)
+```
+
+**The catch:** to let an MCP agent operate your instance you must enable `developer`
+(that's where API keys live) — which *also* surfaces `reset_module_data` (destructive),
+demo seeding, and test runners. Being *operated* by an agent should not force exposing
+"wipe my data" buttons.
+
+## Target: two concerns
+1. **Agent Access / MCP (production).** API keys, MCP log, MCP skills panel, global_search.
+   This is the "MCP is the way forward" surface — a normal customer enables it to be
+   agent-operated. Readily available, its own module/concept.
+2. **Dev Tools (internal).** Test runners + reset/seed/lint. Off on customer prod; tighter
+   gate (dev-mode / non-prod / super-admin) since parts are destructive.
+
+## Why this resolves two earlier tensions at once
+- **MCP onboarding** (`mem://federation/federation-page-transport-agnostic`): enabling Agent
+  Access gives keys+log with NO test runners and NO reset button.
+- **Test-fn deploy vs admin 404:** `run-{autonomy,platform}-tests` map to **Dev Tools** →
+  off on customer prod → not deployed (−2 slots, incl. fixing `run-platform-tests` currently
+  being CORE = on every site) AND their pages are hidden → no 404. Deploy-visibility and
+  page-visibility move together.
+- Shows the naive fixes were wrong: "devOnly = never deploy" breaks the always-routable admin
+  test pages; "gate tests under `developer`" would still ship them to MCP-access sites (e.g.
+  www has developer ON for MCP). Only the split is consistent.
+
+## Decision (this session)
+Record the target. **Do NOT touch test-fn deploy gating until the split exists** — otherwise
+we break UX (404) or drag dev tools onto MCP sites. MCP-forward; Agent Access should be a
+first-class production surface separate from Dev Tools.

--- a/mem/federation/federation-page-transport-agnostic.md
+++ b/mem/federation/federation-page-transport-agnostic.md
@@ -1,0 +1,48 @@
+---
+name: Federation page is transport-agnostic (A2A or MCP)
+description: The Federation page was conceived as a transport-agnostic "external agent surface" — A2A or MCP, it doesn't matter — which is why an agent's findings surface there. Note on the resulting MCP-onboarding/UX coupling, deferred.
+type: architecture
+---
+
+# Federation page = transport-agnostic agent surface
+
+**Intent.** The Federation page is a *concept*, not a protocol: "the place where external
+agents connect, get tasked, and report back." Whether the transport is **A2A** (Google
+agent-to-agent JSON-RPC) or **MCP** is deliberately irrelevant. That's why an invited
+agent's **findings** (e.g. the "QA agent exercises the MCP surface and reports structured
+findings" mission) surface on the Federation page — the page owns the *agent relationship*,
+not the wire.
+
+## MCP is the spine; federation rides on it (already true in code)
+- `api_keys` is the single MCP credential store. `mcp-server` validates any key from it and
+  exposes the **enabled modules'** skills — it is module-agnostic and works with the
+  federation module OFF (see comment in mcp-server + `mem://architecture/mcp-exposure-invariants`).
+- Federation is a *consumer*: `federation-invite-peer` mints an `api_key` + registers an
+  `a2a_peer` (trust groups, transitive trust); OpenClaw missions inject MCP callback creds so
+  the Claw reports findings **back via MCP**. So MCP is already the callback transport even for
+  A2A/OpenClaw flows.
+
+## The coupling we noticed (DEFERRED — left as-is for now)
+There are two doors to MCP credentials, gated by different modules:
+- **Developer page** (`/admin/developer`, `developer` module) → `useCreateApiKey`: a plain MCP
+  key. No federation needed. Some MCP log also lives here.
+- **Federation page** (`/admin/federation`, `federation` module) → `AgentInvites`: key **+**
+  mission templates **+** `a2a_peer` registration. This richer "invite an MCP agent and task
+  it" flow only shows when the **federation module is on**.
+
+So today, onboarding an external **MCP** agent with a mission effectively requires the
+federation module enabled (sidebar visibility) — even though MCP itself doesn't need it. Mild
+tension with "MCP is the way forward."
+
+## If we ever revisit
+Conceptually two distinct things are bundled:
+1. *Issue MCP key + dispatch a mission* → a **Developer/MCP** concern (no `a2a_peer` required).
+2. *Register a trusted federated peer* (transitive trust, OpenClaw boss→worker) → a **Federation/A2A**
+   concern.
+
+Clean move: surface MCP-agent onboarding under Developer (decoupled from federation); keep the
+A2A peer/trust/OpenClaw bits on the Federation page. Not urgent: selective deploy means a
+federation-OFF site deploys none of the a2a functions (0 slot cost), and MCP works regardless.
+
+**Decision (this session):** leave it. MCP-forward; A2A may stay as long as it doesn't get
+complex. Recorded for later, not acted on.


### PR DESCRIPTION
Two architecture memory notes from this session's design discussion (no code changes):

1. **`mem/federation/federation-page-transport-agnostic.md`** — the Federation page is a transport-agnostic agent surface (A2A *or* MCP); MCP is the spine, federation rides on it; the MCP-onboarding/UX coupling is recorded and deferred.
2. **`mem/architecture/split-developer-module-agent-access-vs-dev-tools.md`** — the `developer` module is overloaded (MCP/agent-access + destructive dev/test tooling); target is to split into Agent Access (prod) vs Dev Tools (internal); resolves the MCP-onboarding and test-fn-deploy/404 tensions. Deferred.

Docs only. Recorded for later; not acted on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_