### PR TITLE
voice: post voicemail once + reply-to-voicemail by SMS + stable default greeting

### DIFF
--- a/src/hooks/useSupportConversations.tsx
+++ b/src/hooks/useSupportConversations.tsx
@@ -432,6 +432,52 @@ export function useConversationMessages(conversationId: string | null) {
             logger.error(`sendMessage: ${smsProvider} relay failed`, await relayResp.text());
           }
         }
+
+        // Voice / voicemail threads: an agent's reply goes out as an SMS to the
+        // caller (e.g. "I'll call you back at 10:30"). The edge function gates
+        // this on the Voice setting + a landline guard. When it declines, we drop
+        // a visible system note into the thread so the agent is never misled into
+        // thinking an undeliverable reply was sent.
+        if (conv?.channel === 'voice') {
+          const relayResp = await fetch(
+            `${baseUrl}/functions/v1/elks46-ingest?action=send`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`,
+                'apikey': apiKey,
+              },
+              body: JSON.stringify({
+                conversation_id: conversationId,
+                message_id: data?.[0]?.id,
+                content,
+              }),
+            },
+          );
+          let notice: string | null = null;
+          if (relayResp.ok) {
+            const result = await relayResp.json().catch(() => ({} as any));
+            if (result?.sms_sent === false) {
+              notice = result.reason === 'landline'
+                ? '⚠️ SMS-svaret skickades inte: uppringaren ringde från ett fast nummer som inte kan ta emot SMS. Ring upp istället.'
+                : result.reason === 'sms_reply_disabled'
+                  ? 'ℹ️ SMS-svar på röstmeddelanden är avstängt. Slå på det i Voice-inställningarna för att kunna svara via SMS.'
+                  : '⚠️ SMS-svaret kunde inte skickas.';
+            }
+          } else {
+            logger.error('sendMessage: voice SMS relay failed', await relayResp.text());
+            notice = '⚠️ SMS-svaret kunde inte skickas (tekniskt fel).';
+          }
+          if (notice) {
+            await supabase.from('chat_messages').insert({
+              conversation_id: conversationId,
+              role: 'system',
+              content: notice,
+            });
+            queryClient.invalidateQueries({ queryKey: ['conversation-messages', conversationId] });
+          }
+        }
       } catch (relayErr) {
         logger.error('sendMessage: channel relay error', relayErr);
       }

--- a/src/hooks/useVoice.ts
+++ b/src/hooks/useVoice.ts
@@ -16,6 +16,7 @@ export const defaultVoiceSettings: VoiceSettings = {
   ringTimeoutSeconds: 20,
   bookingIvrEnabled: false,
   bookingServiceId: undefined,
+  smsReplyEnabled: false,
 };
 
 export function useVoiceSettings() {

--- a/src/lib/voice-providers/types.ts
+++ b/src/lib/voice-providers/types.ts
@@ -97,4 +97,10 @@ export interface VoiceSettings {
   bookingIvrEnabled: boolean;
   /** Vilken booking_service som föreslås i UC4. */
   bookingServiceId?: string;
+  /**
+   * Låt en agent svara på ett röstmeddelande med SMS till uppringaren
+   * (t.ex. "Jag ringer upp dig 10:30"). Skickas bara till mobilnummer —
+   * fasta nummer blockeras med en notis i tråden.
+   */
+  smsReplyEnabled?: boolean;
 }

--- a/src/pages/admin/VoicePage.tsx
+++ b/src/pages/admin/VoicePage.tsx
@@ -284,6 +284,20 @@ function VoiceSettingsCard() {
           </div>
         )}
 
+        <div className="flex items-center justify-between rounded-md border p-3">
+          <div>
+            <Label className="text-sm font-medium">Reply to voicemail by SMS</Label>
+            <p className="text-xs text-muted-foreground">
+              Let an agent answer a voice message with an SMS to the caller (e.g. “I’ll call you back at 10:30”).
+              Sent only to mobile numbers — landlines are blocked with a note in the thread.
+            </p>
+          </div>
+          <Switch
+            checked={settings.smsReplyEnabled ?? false}
+            onCheckedChange={(v) => set('smsReplyEnabled', v)}
+          />
+        </div>
+
         <div className="flex items-center justify-end gap-2 border-t pt-4">
           {dirty && (
             <Button variant="ghost" onClick={() => setDraft(null)} disabled={update.isPending}>

--- a/src/pages/admin/VoicePage.tsx
+++ b/src/pages/admin/VoicePage.tsx
@@ -95,8 +95,11 @@ function CallActionDialog({ call, open, onOpenChange }: { call: VoiceCallRow | n
   if (!call) return null;
 
   const handleSchedule = () => {
+    // `scheduledAt` holds the raw datetime-local value (local "YYYY-MM-DDTHH:mm").
+    // Convert to a UTC ISO string only when persisting — new Date() parses the
+    // local string in the browser's timezone, which is what the user picked.
     update.mutate(
-      { id: call.id, patch: { callback_status: 'scheduled', callback_scheduled_at: scheduledAt || new Date().toISOString() } },
+      { id: call.id, patch: { callback_status: 'scheduled', callback_scheduled_at: scheduledAt ? new Date(scheduledAt).toISOString() : new Date().toISOString() } },
       { onSuccess: () => onOpenChange(false) }
     );
   };
@@ -126,8 +129,8 @@ function CallActionDialog({ call, open, onOpenChange }: { call: VoiceCallRow | n
             <audio src={call.recording_url} controls className="w-full" />
           )}
           <div className="border-t pt-3 space-y-2">
-            <Label htmlFor="schedule">Schedule callback (ISO)</Label>
-            <Input id="schedule" type="datetime-local" value={scheduledAt} onChange={(e) => setScheduledAt(e.target.value ? new Date(e.target.value).toISOString() : '')} />
+            <Label htmlFor="schedule">Schedule callback</Label>
+            <Input id="schedule" type="datetime-local" value={scheduledAt} onChange={(e) => setScheduledAt(e.target.value)} />
           </div>
         </div>
         <DialogFooter className="gap-2">

--- a/supabase/functions/elks46-ingest/index.ts
+++ b/supabase/functions/elks46-ingest/index.ts
@@ -83,7 +83,17 @@ async function loadVoiceSettings(supabase: ReturnType<typeof getServiceClient>) 
   return {
     voicemailGreetingUrl: (v.voicemailGreetingUrl as string) || DEFAULT_GREETING_URL,
     ringTimeoutSeconds: Number(v.ringTimeoutSeconds) > 0 ? Number(v.ringTimeoutSeconds) : 25,
+    smsReplyEnabled: v.smsReplyEnabled === true,
   };
+}
+
+// A Swedish mobile number is +46 7x; any other +46 prefix is a landline that
+// can't receive SMS. We only ever *block* confirmed Swedish landlines — foreign
+// numbers get the benefit of the doubt (likely mobile, and we can't classify
+// them cheaply). This is the guard that stops the silent-failure mode where an
+// agent texts a voicemail caller who phoned in from a fast telefon.
+function isLikelySwedishLandline(num: string): boolean {
+  return /^\+46(?!7)/.test(num);
 }
 
 // 46elks dial-plan: ANSWER the call, play the greeting, then record a voicemail.
@@ -662,8 +672,31 @@ async function handleSend(req: Request): Promise<Response> {
       .select("id, channel, channel_thread_id, visitor_profile")
       .eq("id", conversationId).maybeSingle();
     if (convErr || !conv) return json({ error: "conversation not found" }, 404);
-    if (conv.channel !== "sms") return json({ ok: true, skipped: "not sms" });
-    if (!conv.channel_thread_id) return json({ error: "missing channel_thread_id" }, 400);
+
+    const isVoice = conv.channel === "voice";
+    if (conv.channel !== "sms" && !isVoice) return json({ ok: true, skipped: "unsupported channel" });
+
+    const profile = (conv.visitor_profile as any) || {};
+    // SMS thread → the thread id is the destination. Voice thread → the caller's
+    // number (visitor_profile.from), falling back to the thread id.
+    const destinationRaw = isVoice
+      ? (profile.from || conv.channel_thread_id || "")
+      : (conv.channel_thread_id || "");
+    if (!destinationRaw) return json({ error: "missing destination number" }, 400);
+    const destination = normalizePhone(String(destinationRaw));
+
+    // Voice replies go out as SMS — gated by a Voice setting and a landline
+    // guard so the agent is never misled into thinking an undeliverable reply
+    // was sent. Returns a clear reason the inbox surfaces to the agent.
+    if (isVoice) {
+      const voice = await loadVoiceSettings(supabase);
+      if (!voice.smsReplyEnabled) {
+        return json({ ok: true, sms_sent: false, reason: "sms_reply_disabled" });
+      }
+      if (isLikelySwedishLandline(destination)) {
+        return json({ ok: true, sms_sent: false, reason: "landline" });
+      }
+    }
 
     if (!content && body.message_id) {
       const { data: msg } = await supabase
@@ -673,10 +706,9 @@ async function handleSend(req: Request): Promise<Response> {
     if (!content || !content.trim()) return json({ error: "no content" }, 400);
 
     const { fromNumber } = await loadElks46Config(supabase);
-    const profile = (conv.visitor_profile as any) || {};
     const from = fromNumber || profile.to || "";
-    const data = await sendSms(conv.channel_thread_id, from, content);
-    return json({ ok: true, elks46_message_id: data?.id ?? null });
+    const data = await sendSms(destination, from, content);
+    return json({ ok: true, sms_sent: true, elks46_message_id: data?.id ?? null });
   } catch (err: any) {
     console.error("[elks46-ingest:send] error", err?.message ?? err);
     return json({ error: err?.message ?? "internal error" }, 500);

--- a/supabase/functions/elks46-ingest/index.ts
+++ b/supabase/functions/elks46-ingest/index.ts
@@ -69,8 +69,12 @@ async function loadElks46Config(supabase: ReturnType<typeof getServiceClient>) {
 }
 
 // A reachable default greeting so callers always hear *something* before
-// recording. Admins override via Voice settings (voicemailGreetingUrl).
-const DEFAULT_GREETING_URL = "https://api.46elks.com/static/sounds/welcome-sv.mp3";
+// recording, even if Voice settings (voicemailGreetingUrl) is blank or points
+// at a dead URL. Hosted on the main branch (served at /audio on each site too),
+// so it survives feature-branch deletion — unlike the per-branch raw URL that
+// 404'd after PR #95 merged and left callers with silence.
+const DEFAULT_GREETING_URL =
+  "https://raw.githubusercontent.com/magnusfroste/flowwink/main/public/audio/voicemail-sv.mp3";
 
 async function loadVoiceSettings(supabase: ReturnType<typeof getServiceClient>) {
   const { data } = await supabase
@@ -180,22 +184,33 @@ async function transcribeWav(supabase: ReturnType<typeof getServiceClient>, wavU
 }
 
 // Store a captured voicemail, transcribe it, and drop the transcript into the
-// unified inbox as a text message on the call's voice conversation. Idempotent
-// per call via metadata.voicemail_transcribed so the wav-POST and the terminal
-// hangup callback don't double-post.
+// unified inbox as a text message on the call's voice conversation. Posts
+// EXACTLY ONCE per call: voicemail capture runs over two paths (the 46elks
+// wav-POST and the terminal hangup callback that pulls the recording from the
+// API), and those callbacks can race. We claim the call atomically by flipping
+// status → voicemail with a `status != voicemail` guard in the same UPDATE —
+// Postgres row-locking means only the first invocation matches and proceeds;
+// the loser sees zero rows and bails. (A read-then-write metadata flag wasn't
+// enough: both callbacks read the pre-write row before either wrote it.)
 async function recordVoicemail(
   supabase: ReturnType<typeof getServiceClient>,
   opts: { callid: string; existing: any; wavUrl: string; durationSeconds: number | null; fromNumber: string },
 ): Promise<void> {
-  const { callid, existing, wavUrl, durationSeconds, fromNumber } = opts;
-  const prevMeta = (existing?.metadata && typeof existing.metadata === "object") ? existing.metadata : {};
-  if ((prevMeta as any).voicemail_transcribed === true) return; // already handled
+  const { callid, wavUrl, durationSeconds, fromNumber } = opts;
+
+  const { data: claimed } = await supabase
+    .from("voice_calls")
+    .update({ status: "voicemail", voicemail: true })
+    .eq("provider", "elks46").eq("provider_call_id", callid)
+    .neq("status", "voicemail")
+    .select("id, conversation_id, metadata");
+  if (!claimed || claimed.length === 0) return; // a concurrent callback already claimed it
+  const row = claimed[0] as any;
+  const prevMeta = (row.metadata && typeof row.metadata === "object") ? row.metadata : {};
 
   const transcript = await transcribeWav(supabase, wavUrl);
 
   await supabase.from("voice_calls").update({
-    status: "voicemail",
-    voicemail: true,
     recording_url: wavUrl,
     transcript,
     ended_at: new Date().toISOString(),
@@ -205,7 +220,7 @@ async function recordVoicemail(
   }).eq("provider", "elks46").eq("provider_call_id", callid);
 
   // Ensure a voice conversation exists, then surface the voicemail as text.
-  let conversationId: string | null = existing?.conversation_id ?? null;
+  let conversationId: string | null = row.conversation_id ?? null;
   if (!conversationId) {
     const { data: conv } = await supabase.from("chat_conversations").insert({
       channel: "voice",


### PR DESCRIPTION
Three voice-channel improvements from the first live voicemail test.

## 1. Voicemail posts to the inbox exactly once
Capture runs over two paths (46elks `wav` POST + terminal hangup that pulls the recording from the API) and they could race — both read the row before either wrote the `voicemail_transcribed` flag, so two transcripts were posted. Replaced with an **atomic claim**: flip `status → voicemail` with a `status != voicemail` guard in one UPDATE; Postgres row-locking lets only the first invocation proceed.

## 2. Reply to a voicemail by SMS (opt-in, mobile-only, non-silent)
Closes the loop on voice: an agent answers a voicemail with an SMS to the caller — e.g. *"I'll call you back at 10:30"* after checking the calendar. **Off by default**; toggle in **Voice settings → Reply to voicemail by SMS**.

Guards against the silent-failure mode (texting a caller who phoned from a landline):
- **Backend** (`elks46-ingest` `handleSend`) accepts voice conversations, gated on `smsReplyEnabled` + a Swedish-landline check (`+46` non-`7` = landline). Targets the caller's number (`visitor_profile.from`), returns explicit `{ sms_sent, reason }`.
- **Inbox** (`useSupportConversations`) relays voice replies and, when the edge function declines (landline / feature off / error), drops a visible `role:'system'` note into the thread. The agent is never misled into thinking an undeliverable reply was sent.
- Foreign numbers get the benefit of the doubt. Delivery receipts + full `libphonenumber` parsing deferred.

## 3. Stable default greeting
`DEFAULT_GREETING_URL` → main-hosted `voicemail-sv.mp3` instead of the unverified 46elks static sound, so a blank/broken `voicemailGreetingUrl` still plays a real file. (The live "no answer at all" was a per-branch raw URL that 404'd once PR #95's branch was deleted on merge.)

### Deploy
Frontend (Vercel, auto) + redeploy `elks46-ingest` from main after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)