### PR TITLE
feat(voice): opt-in callback auto-scheduler (non-conflicting slot + optional SMS)

### DIFF
--- a/src/hooks/useVoice.ts
+++ b/src/hooks/useVoice.ts
@@ -17,6 +17,12 @@ export const defaultVoiceSettings: VoiceSettings = {
   bookingIvrEnabled: false,
   bookingServiceId: undefined,
   smsReplyEnabled: false,
+  autoScheduleCallbacks: false,
+  autoScheduleSms: false,
+  callbackTimezone: 'Europe/Stockholm',
+  callbackWindowStart: '09:00',
+  callbackWindowEnd: '17:00',
+  callbackSlotMinutes: 15,
 };
 
 export function useVoiceSettings() {

--- a/src/lib/voice-providers/types.ts
+++ b/src/lib/voice-providers/types.ts
@@ -103,4 +103,22 @@ export interface VoiceSettings {
    * fasta nummer blockeras med en notis i tråden.
    */
   smsReplyEnabled?: boolean;
+
+  // ── Callback auto-scheduler (opt-in) ───────────────────────────────────────
+  /**
+   * Boka automatiskt in en återuppringningstid (nästa lediga lucka som inte
+   * krockar) när ett missat samtal/röstmeddelande kommer in. Av = manuell
+   * bokning som idag.
+   */
+  autoScheduleCallbacks?: boolean;
+  /** Skicka även ett SMS till uppringaren med den inbokade tiden (mobil-only). */
+  autoScheduleSms?: boolean;
+  /** IANA-tidszon för arbetstidsfönstret (default Europe/Stockholm). */
+  callbackTimezone?: string;
+  /** Arbetstidens start, "HH:MM" lokal tid (default 09:00). */
+  callbackWindowStart?: string;
+  /** Arbetstidens slut, "HH:MM" lokal tid (default 17:00). */
+  callbackWindowEnd?: string;
+  /** Minuter mellan callback-luckor (default 15). */
+  callbackSlotMinutes?: number;
 }

--- a/src/pages/admin/VoicePage.tsx
+++ b/src/pages/admin/VoicePage.tsx
@@ -301,6 +301,78 @@ function VoiceSettingsCard() {
           />
         </div>
 
+        <div className="flex items-center justify-between rounded-md border p-3">
+          <div>
+            <Label className="text-sm font-medium">Auto-schedule callbacks</Label>
+            <p className="text-xs text-muted-foreground">
+              When a missed call or voicemail comes in, automatically book the next free, non-conflicting
+              callback time inside business hours. Off = staff schedule manually (today’s behaviour).
+            </p>
+          </div>
+          <Switch
+            checked={settings.autoScheduleCallbacks ?? false}
+            onCheckedChange={(v) => set('autoScheduleCallbacks', v)}
+          />
+        </div>
+
+        {settings.autoScheduleCallbacks && (
+          <div className="space-y-4 rounded-md border border-dashed p-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label className="text-sm font-medium">Text the caller the booked time</Label>
+                <p className="text-xs text-muted-foreground">
+                  SMS the caller their callback time (mobile numbers only). Off = book silently; staff call at the time.
+                </p>
+              </div>
+              <Switch
+                checked={settings.autoScheduleSms ?? false}
+                onCheckedChange={(v) => set('autoScheduleSms', v)}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <div className="space-y-1">
+                <Label htmlFor="cb-start" className="text-xs">Hours from</Label>
+                <Input
+                  id="cb-start"
+                  type="time"
+                  value={settings.callbackWindowStart ?? '09:00'}
+                  onChange={(e) => set('callbackWindowStart', e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="cb-end" className="text-xs">Hours to</Label>
+                <Input
+                  id="cb-end"
+                  type="time"
+                  value={settings.callbackWindowEnd ?? '17:00'}
+                  onChange={(e) => set('callbackWindowEnd', e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="cb-slot" className="text-xs">Slot (min)</Label>
+                <Input
+                  id="cb-slot"
+                  type="number"
+                  min={5}
+                  step={5}
+                  value={settings.callbackSlotMinutes ?? 15}
+                  onChange={(e) => set('callbackSlotMinutes', Number(e.target.value) || 15)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="cb-tz" className="text-xs">Timezone</Label>
+                <Input
+                  id="cb-tz"
+                  placeholder="Europe/Stockholm"
+                  value={settings.callbackTimezone ?? 'Europe/Stockholm'}
+                  onChange={(e) => set('callbackTimezone', e.target.value || undefined)}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
         <div className="flex items-center justify-end gap-2 border-t pt-4">
           {dirty && (
             <Button variant="ghost" onClick={() => setDraft(null)} disabled={update.isPending}>

--- a/supabase/functions/elks46-ingest/index.ts
+++ b/supabase/functions/elks46-ingest/index.ts
@@ -84,7 +84,102 @@ async function loadVoiceSettings(supabase: ReturnType<typeof getServiceClient>) 
     voicemailGreetingUrl: (v.voicemailGreetingUrl as string) || DEFAULT_GREETING_URL,
     ringTimeoutSeconds: Number(v.ringTimeoutSeconds) > 0 ? Number(v.ringTimeoutSeconds) : 25,
     smsReplyEnabled: v.smsReplyEnabled === true,
+    // Callback auto-scheduler (opt-in). When off, missed calls/voicemails stay
+    // `pending` for a human to schedule manually — exactly today's behaviour.
+    autoScheduleCallbacks: v.autoScheduleCallbacks === true,
+    autoScheduleSms: v.autoScheduleSms === true,
+    callbackTimezone: (v.callbackTimezone as string) || "Europe/Stockholm",
+    callbackWindowStart: (v.callbackWindowStart as string) || "09:00",
+    callbackWindowEnd: (v.callbackWindowEnd as string) || "17:00",
+    callbackSlotMinutes: Number(v.callbackSlotMinutes) > 0 ? Number(v.callbackSlotMinutes) : 15,
   };
+}
+
+type VoiceSettingsResolved = Awaited<ReturnType<typeof loadVoiceSettings>>;
+
+// ── Timezone-aware callback slot finder ──────────────────────────────────────
+// Business hours live in the site's wall-clock timezone, but the edge runtime is
+// UTC, so we convert through Intl. DST-safe.
+
+function tzOffsetMs(instant: Date, timeZone: string): number {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone, hour12: false,
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", second: "2-digit",
+  });
+  const map: Record<string, string> = {};
+  for (const p of dtf.formatToParts(instant)) map[p.type] = p.value;
+  const asUTC = Date.UTC(+map.year, +map.month - 1, +map.day, +map.hour, +map.minute, +map.second);
+  return asUTC - instant.getTime();
+}
+
+// Local wall-clock minutes-since-midnight for a UTC instant, in the given zone.
+function localMinutes(instant: Date, timeZone: string): number {
+  const local = new Date(instant.getTime() + tzOffsetMs(instant, timeZone));
+  return local.getUTCHours() * 60 + local.getUTCMinutes();
+}
+
+// The UTC instant matching a local wall-clock time (same calendar day as `ref`
+// in the zone, optionally +dayOffset days), for `minutesOfDay` past midnight.
+function zonedWallTimeToUtc(ref: Date, timeZone: string, minutesOfDay: number, dayOffset = 0): Date {
+  const local = new Date(ref.getTime() + tzOffsetMs(ref, timeZone));
+  const y = local.getUTCFullYear(), mo = local.getUTCMonth(), d = local.getUTCDate();
+  const guess = Date.UTC(y, mo, d + dayOffset, Math.floor(minutesOfDay / 60), minutesOfDay % 60);
+  // Correct for the offset at the guessed instant (handles DST boundaries).
+  const corrected = guess - tzOffsetMs(new Date(guess), timeZone);
+  return new Date(corrected);
+}
+
+function parseHHMM(s: string, fallback: number): number {
+  const m = /^(\d{1,2}):(\d{2})$/.exec((s || "").trim());
+  if (!m) return fallback;
+  const mins = (+m[1]) * 60 + (+m[2]);
+  return Number.isFinite(mins) && mins >= 0 && mins < 24 * 60 ? mins : fallback;
+}
+
+// Pick the next free callback slot inside business hours that no other scheduled
+// callback already occupies. Returns an ISO string, or null if none found within
+// a week (degrades to leaving the call `pending`).
+async function findNextFreeCallbackSlot(
+  supabase: ReturnType<typeof getServiceClient>,
+  s: VoiceSettingsResolved,
+  now: Date,
+): Promise<string | null> {
+  const tz = s.callbackTimezone;
+  const slotMin = s.callbackSlotMinutes;
+  const slotMs = slotMin * 60_000;
+  const startMin = parseHHMM(s.callbackWindowStart, 9 * 60);
+  const endMin = parseHHMM(s.callbackWindowEnd, 17 * 60);
+  const LEAD_MIN = 20; // never propose a time sooner than ~20 min from now
+
+  // Slots already taken by other scheduled callbacks (rounded to the slot grid).
+  const { data: scheduled } = await supabase
+    .from("voice_calls")
+    .select("callback_scheduled_at")
+    .eq("callback_status", "scheduled")
+    .gte("callback_scheduled_at", new Date(now.getTime() - slotMs).toISOString());
+  const taken = new Set<number>();
+  for (const r of scheduled ?? []) {
+    const t = Date.parse((r as any).callback_scheduled_at);
+    if (Number.isFinite(t)) taken.add(Math.round(t / slotMs) * slotMs);
+  }
+
+  // Start at the next slot boundary at least LEAD_MIN out.
+  let cand = new Date(Math.ceil((now.getTime() + LEAD_MIN * 60_000) / slotMs) * slotMs);
+  for (let i = 0; i < 24 * 60 / slotMin * 7; i++) { // up to ~7 days of slots
+    const mins = localMinutes(cand, tz);
+    if (mins < startMin || mins >= endMin) {
+      // Outside hours → jump to the next window start (today if still before it,
+      // otherwise tomorrow).
+      const dayOffset = mins < startMin ? 0 : 1;
+      cand = zonedWallTimeToUtc(cand, tz, startMin, dayOffset);
+      continue;
+    }
+    const key = Math.round(cand.getTime() / slotMs) * slotMs;
+    if (!taken.has(key)) return cand.toISOString();
+    cand = new Date(cand.getTime() + slotMs);
+  }
+  return null;
 }
 
 // A Swedish mobile number is +46 7x; any other +46 prefix is a landline that
@@ -263,6 +358,66 @@ async function recordVoicemail(
       conversation_status: "waiting_agent",
       updated_at: new Date().toISOString(),
     }).eq("id", conversationId);
+  }
+
+  await maybeAutoScheduleCallback(supabase, { callid, fromNumber, conversationId });
+}
+
+// If the callback auto-scheduler is enabled, pick a non-conflicting slot inside
+// business hours, book it on the (still-pending) call, and — when configured —
+// SMS the caller their callback time. Fully opt-in: with the toggle off this is
+// a no-op and the call stays `pending` for manual handling. Best-effort: any
+// failure is logged, never throws into the webhook path.
+async function maybeAutoScheduleCallback(
+  supabase: ReturnType<typeof getServiceClient>,
+  opts: { callid: string; fromNumber: string; conversationId: string | null },
+): Promise<void> {
+  try {
+    const s = await loadVoiceSettings(supabase);
+    if (!s.autoScheduleCallbacks) return;
+
+    const slotIso = await findNextFreeCallbackSlot(supabase, s, new Date());
+    if (!slotIso) return; // no free slot this week → leave pending for a human
+
+    // Only book if still pending — never override a time a human already set.
+    const { data: booked } = await supabase
+      .from("voice_calls")
+      .update({ callback_status: "scheduled", callback_scheduled_at: slotIso })
+      .eq("provider", "elks46").eq("provider_call_id", opts.callid)
+      .eq("callback_status", "pending")
+      .select("id");
+    if (!booked || booked.length === 0) return;
+
+    const when = new Intl.DateTimeFormat("sv-SE", {
+      timeZone: s.callbackTimezone, weekday: "short", hour: "2-digit", minute: "2-digit",
+    }).format(new Date(slotIso));
+
+    let smsNote = "";
+    const dest = normalizePhone(opts.fromNumber || "");
+    if (s.autoScheduleSms && dest) {
+      if (isLikelySwedishLandline(dest)) {
+        smsNote = " · fast nummer, inget SMS";
+      } else {
+        try {
+          const { fromNumber } = await loadElks46Config(supabase);
+          await sendSms(dest, fromNumber, `Tack för ditt samtal! Vi ringer upp dig ${when}.`);
+          smsNote = ` · SMS skickat till ${dest}`;
+        } catch (e) {
+          console.warn("[elks46-ingest] auto-schedule SMS failed", (e as Error)?.message);
+          smsNote = " · SMS kunde inte skickas";
+        }
+      }
+    }
+
+    if (opts.conversationId) {
+      await supabase.from("chat_messages").insert({
+        conversation_id: opts.conversationId,
+        role: "system",
+        content: `🗓️ Återuppringning inbokad ${when}${smsNote}.`,
+      });
+    }
+  } catch (e) {
+    console.warn("[elks46-ingest] maybeAutoScheduleCallback error", (e as Error)?.message);
   }
 }
 
@@ -456,6 +611,14 @@ async function handleIngest(req: Request): Promise<Response> {
           .eq("provider", "elks46")
           .eq("provider_call_id", callid);
         if (updateErr) console.warn("[elks46-ingest] voice status update failed", updateErr.message);
+        // Missed/busy with no voicemail → still a callback owed. Auto-schedule it
+        // if enabled (the caller hung up before recording, so there's no inbox
+        // thread yet — pass the call's conversation_id if one exists).
+        if (finalStatus !== "completed") {
+          await maybeAutoScheduleCallback(supabase, {
+            callid, fromNumber: normalizedFrom || from, conversationId: existingCall?.conversation_id ?? null,
+          });
+        }
         return hangupResponse();
       }
 


### PR DESCRIPTION
Builds the callback auto-scheduler we scoped. **Fully opt-in** — three modes so nothing changes for sites that prefer today's manual flow:

| Mode | Behaviour |
| --- | --- |
| Off | Missed/voicemail stays `pending` — staff schedule manually (today) |
| On, SMS off | Books the next free time silently; staff just call then |
| On, SMS on | Books a time **and** texts the caller it (mobile only) |

### Scheduling (`elks46-ingest`)
- `findNextFreeCallbackSlot` walks the slot grid inside a business-hours window (**timezone-aware via `Intl`, DST-safe**) and skips slots already held by other scheduled callbacks — so calls spread across the day without colliding.
- Books only if the call is still `callback_status = pending` — never overrides a time a human already set.
- SMS reuses the landline guard (`+46` non-`7` = no SMS) and drops a `role:'system'` note into the thread (*"Återuppringning inbokad tor 10:30 · SMS skickat …"*).
- Best-effort: any failure is logged, never thrown into the 46elks webhook path.

### Settings (Voice page)
`autoScheduleCallbacks` (master), `autoScheduleSms`, `callbackTimezone`, `callbackWindowStart`/`End`, `callbackSlotMinutes`. Window/slot/timezone only render when the master toggle is on. All defaulted (off; 09:00–17:00; 15 min; Europe/Stockholm).

### Deploy
Frontend (Vercel, auto) + redeploy `elks46-ingest` from main after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_