### PR TITLE
fix(voice): Live Support Callbacks &amp; Voicemail panels read voice_calls

### DIFF
--- a/src/components/admin/live-support/CallbacksPanel.tsx
+++ b/src/components/admin/live-support/CallbacksPanel.tsx
@@ -3,19 +3,21 @@ import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Phone, Loader2, PhoneCall, Clock } from 'lucide-react';
+import { Phone, Loader2, PhoneCall, Clock, Check } from 'lucide-react';
 import { format, formatDistanceToNow } from 'date-fns';
 import { toast } from 'sonner';
 
-interface CallbackRow {
+// Callbacks live on `voice_calls` (callback_status pending/scheduled), the same
+// source the Voice admin view reads — not the bookings table (which is for
+// customer appointments). Reading the wrong table is why this panel was empty.
+interface VoiceCallbackRow {
   id: string;
-  customer_name: string | null;
-  customer_phone: string | null;
-  customer_email: string | null;
-  start_time: string;
+  from_number: string | null;
+  transcript: string | null;
   status: string | null;
-  notes: string | null;
-  metadata: any;
+  callback_status: string | null;
+  callback_scheduled_at: string | null;
+  started_at: string;
 }
 
 export function CallbacksPanel() {
@@ -24,34 +26,32 @@ export function CallbacksPanel() {
   const { data: rows, isLoading } = useQuery({
     queryKey: ['support-callbacks'],
     queryFn: async () => {
-      // Callbacks ride on the bookings table — surface anything tagged in
-      // metadata.kind = 'callback' OR any future bookings.metadata.channel.
       const { data, error } = await supabase
-        .from('bookings')
-        .select('*')
-        .order('start_time', { ascending: true })
+        .from('voice_calls')
+        .select('id, from_number, transcript, status, callback_status, callback_scheduled_at, started_at')
+        .in('callback_status', ['pending', 'scheduled'])
+        .order('callback_scheduled_at', { ascending: true, nullsFirst: false })
+        .order('started_at', { ascending: false })
         .limit(100);
       if (error) throw error;
-      return ((data ?? []) as any[]).filter(b => {
-        const kind = b?.metadata?.kind ?? b?.metadata?.type;
-        return kind === 'callback' || !!b.customer_phone;
-      }) as CallbackRow[];
+      return (data ?? []) as VoiceCallbackRow[];
     },
   });
 
-  const request = useMutation({
-    mutationFn: async (callback_id: string) => {
-      const { data, error } = await supabase.functions.invoke('agent-execute', {
-        body: {
-          skill_name: 'request_callback',
-          arguments: { action: 'mark_attempted', callback_id },
-        },
-      });
+  const markDone = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase
+        .from('voice_calls')
+        .update({
+          callback_status: 'completed',
+          callback_completed_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        } as never)
+        .eq('id', id);
       if (error) throw error;
-      return data;
     },
     onSuccess: () => {
-      toast.success('Marked as attempted');
+      toast.success('Callback marked done');
       qc.invalidateQueries({ queryKey: ['support-callbacks'] });
     },
     onError: (e: any) => toast.error(e?.message ?? 'Failed'),
@@ -65,7 +65,7 @@ export function CallbacksPanel() {
           Callbacks
         </CardTitle>
         <CardDescription>
-          Scheduled callbacks queued for you and the team.
+          Missed calls and voicemails queued for a callback.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -83,23 +83,39 @@ export function CallbacksPanel() {
               <li key={cb.id} className="py-3 flex items-center justify-between gap-3">
                 <div className="min-w-0">
                   <p className="text-sm font-medium truncate">
-                    {cb.customer_name || cb.customer_phone || 'Anonymous caller'}
+                    {cb.from_number || 'Anonymous caller'}
                   </p>
-                  <p className="text-xs text-muted-foreground flex items-center gap-2">
-                    {cb.customer_phone && <span className="inline-flex items-center gap-1"><Phone className="h-3 w-3" />{cb.customer_phone}</span>}
-                    <span className="inline-flex items-center gap-1"><Clock className="h-3 w-3" />{format(new Date(cb.start_time), 'PP HH:mm')}</span>
-                    <span className="text-muted-foreground/70">· {formatDistanceToNow(new Date(cb.start_time), { addSuffix: true })}</span>
+                  <p className="text-xs text-muted-foreground flex items-center gap-2 flex-wrap">
+                    {cb.from_number && (
+                      <span className="inline-flex items-center gap-1"><Phone className="h-3 w-3" />{cb.from_number}</span>
+                    )}
+                    {cb.callback_scheduled_at ? (
+                      <span className="inline-flex items-center gap-1">
+                        <Clock className="h-3 w-3" />{format(new Date(cb.callback_scheduled_at), 'PP HH:mm')}
+                        <span className="text-muted-foreground/70">· {formatDistanceToNow(new Date(cb.callback_scheduled_at), { addSuffix: true })}</span>
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground/70">Not scheduled</span>
+                    )}
                   </p>
-                  {cb.notes && <p className="text-xs mt-1 text-muted-foreground line-clamp-2">{cb.notes}</p>}
+                  {cb.transcript && <p className="text-xs mt-1 text-muted-foreground line-clamp-2">{cb.transcript}</p>}
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
-                  <Badge variant="outline">{cb.status ?? 'pending'}</Badge>
+                  <Badge variant="outline">{cb.callback_status ?? 'pending'}</Badge>
+                  {cb.from_number && (
+                    <a href={`tel:${cb.from_number}`} className="inline-flex">
+                      <Button size="sm" variant="outline" className="gap-1">
+                        <PhoneCall className="h-3.5 w-3.5" /> Call
+                      </Button>
+                    </a>
+                  )}
                   <Button
-                    size="sm" variant="outline"
-                    onClick={() => request.mutate(cb.id)}
-                    disabled={request.isPending}
+                    size="sm" variant="ghost"
+                    onClick={() => markDone.mutate(cb.id)}
+                    disabled={markDone.isPending}
+                    className="gap-1"
                   >
-                    Mark attempted
+                    <Check className="h-3.5 w-3.5" /> Done
                   </Button>
                 </div>
               </li>

--- a/src/components/admin/live-support/VoicemailPanel.tsx
+++ b/src/components/admin/live-support/VoicemailPanel.tsx
@@ -4,64 +4,58 @@ import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Voicemail, Loader2, Sparkles, Play, Pause } from 'lucide-react';
+import { Voicemail, Loader2, Play, Pause, Check } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { toast } from 'sonner';
 
+// Voicemails live on `voice_calls` (status = 'voicemail'), the same source the
+// Voice admin view reads. The old panel queried a `voicemail_messages` table
+// that was never provisioned, so it always rendered the "not provisioned" state.
 interface VoicemailRow {
   id: string;
   from_number: string | null;
-  from_name: string | null;
   duration_seconds: number | null;
-  audio_url: string | null;
+  recording_url: string | null;
   transcript: string | null;
-  summary: string | null;
-  status: string | null;
-  created_at: string;
+  callback_status: string | null;
+  started_at: string;
 }
 
 export function VoicemailPanel() {
   const qc = useQueryClient();
   const [playingId, setPlayingId] = useState<string | null>(null);
 
-  const { data, isLoading, error } = useQuery({
-    queryKey: ['voicemail-messages'],
+  const { data, isLoading } = useQuery({
+    queryKey: ['voicemail-calls'],
     queryFn: async () => {
-      // voicemail_messages is part of the omnichannel contract owned by
-      // Claude Code. Read defensively so the UI keeps rendering on instances
-      // where the table hasn't been migrated yet.
-      const { data, error } = await (supabase as any)
-        .from('voicemail_messages')
-        .select('*')
-        .order('created_at', { ascending: false })
+      const { data, error } = await supabase
+        .from('voice_calls')
+        .select('id, from_number, duration_seconds, recording_url, transcript, callback_status, started_at')
+        .eq('status', 'voicemail')
+        .order('started_at', { ascending: false })
         .limit(50);
-      if (error) {
-        if ((error as any).code === '42P01' || /relation .* does not exist/i.test(error.message)) {
-          return null; // table not provisioned yet
-        }
-        throw error;
-      }
+      if (error) throw error;
       return (data ?? []) as VoicemailRow[];
     },
-    retry: false,
   });
 
-  const summarize = useMutation({
-    mutationFn: async (voicemail_id: string) => {
-      const { data, error } = await supabase.functions.invoke('agent-execute', {
-        body: {
-          skill_name: 'handle_voicemail',
-          arguments: { action: 'summarize', voicemail_id },
-        },
-      });
+  const markDone = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase
+        .from('voice_calls')
+        .update({
+          callback_status: 'completed',
+          callback_completed_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        } as never)
+        .eq('id', id);
       if (error) throw error;
-      return data;
     },
     onSuccess: () => {
-      toast.success('FlowPilot summarized the voicemail');
-      qc.invalidateQueries({ queryKey: ['voicemail-messages'] });
+      toast.success('Marked handled');
+      qc.invalidateQueries({ queryKey: ['voicemail-calls'] });
     },
-    onError: (e: any) => toast.error(e?.message ?? 'Summarization failed'),
+    onError: (e: any) => toast.error(e?.message ?? 'Failed'),
   });
 
   if (isLoading) {
@@ -74,38 +68,20 @@ export function VoicemailPanel() {
     );
   }
 
-  if (data === null || error) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base flex items-center gap-2">
-            <Voicemail className="h-4 w-4 text-amber-500" />
-            Voicemail
-          </CardTitle>
-          <CardDescription>
-            Voicemail storage isn't provisioned on this instance yet. Once the
-            backend lands voicemail_messages, recordings, transcripts and
-            FlowPilot summaries will appear here.
-          </CardDescription>
-        </CardHeader>
-      </Card>
-    );
-  }
-
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-base flex items-center gap-2">
           <Voicemail className="h-4 w-4 text-amber-500" />
           Voicemail
-          <Badge variant="outline">{data.length}</Badge>
+          <Badge variant="outline">{data?.length ?? 0}</Badge>
         </CardTitle>
         <CardDescription>
-          Inbound voicemails with transcript and a FlowPilot summary.
+          Inbound voicemails with transcript and recording.
         </CardDescription>
       </CardHeader>
       <CardContent>
-        {data.length === 0 ? (
+        {!data || data.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-6">
             No voicemails.
           </p>
@@ -116,16 +92,16 @@ export function VoicemailPanel() {
                 <div className="flex items-center justify-between gap-2">
                   <div className="min-w-0">
                     <p className="text-sm font-medium truncate">
-                      {vm.from_name || vm.from_number || 'Unknown caller'}
+                      {vm.from_number || 'Unknown caller'}
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      {formatDistanceToNow(new Date(vm.created_at), { addSuffix: true })}
+                      {formatDistanceToNow(new Date(vm.started_at), { addSuffix: true })}
                       {vm.duration_seconds ? ` · ${vm.duration_seconds}s` : ''}
                     </p>
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
-                    <Badge variant="outline">{vm.status ?? 'new'}</Badge>
-                    {vm.audio_url && (
+                    <Badge variant="outline">{vm.callback_status ?? 'pending'}</Badge>
+                    {vm.recording_url && (
                       <Button
                         size="sm" variant="ghost"
                         onClick={() => setPlayingId(playingId === vm.id ? null : vm.id)}
@@ -133,36 +109,25 @@ export function VoicemailPanel() {
                         {playingId === vm.id ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
                       </Button>
                     )}
+                    <Button
+                      size="sm" variant="ghost"
+                      onClick={() => markDone.mutate(vm.id)}
+                      disabled={markDone.isPending}
+                      className="gap-1"
+                    >
+                      <Check className="h-3.5 w-3.5" /> Done
+                    </Button>
                   </div>
                 </div>
 
-                {playingId === vm.id && vm.audio_url && (
-                  <audio src={vm.audio_url} controls autoPlay className="w-full h-8" />
-                )}
-
-                {vm.summary ? (
-                  <div className="rounded-md bg-primary/5 border border-primary/10 p-2 text-xs">
-                    <p className="font-medium text-primary mb-1 flex items-center gap-1">
-                      <Sparkles className="h-3 w-3" /> FlowPilot summary
-                    </p>
-                    <p>{vm.summary}</p>
-                  </div>
-                ) : (
-                  <Button
-                    size="sm" variant="outline"
-                    onClick={() => summarize.mutate(vm.id)}
-                    disabled={summarize.isPending}
-                    className="gap-1"
-                  >
-                    <Sparkles className="h-3 w-3" /> Ask FlowPilot to summarize
-                  </Button>
+                {playingId === vm.id && vm.recording_url && (
+                  <audio src={vm.recording_url} controls autoPlay className="w-full h-8" />
                 )}
 
                 {vm.transcript && (
-                  <details className="text-xs">
-                    <summary className="cursor-pointer text-muted-foreground">Transcript</summary>
-                    <p className="mt-1 whitespace-pre-wrap">{vm.transcript}</p>
-                  </details>
+                  <div className="rounded-md bg-muted p-2 text-xs whitespace-pre-wrap">
+                    {vm.transcript}
+                  </div>
                 )}
               </li>
             ))}


### PR DESCRIPTION
The Live Support **Callbacks** and **Voicemail** tabs showed nothing while the Voice admin view showed everything — because they queried the wrong source.

| Panel | Was reading | Now reads |
| --- | --- | --- |
| Callbacks | `bookings` table (customer appointments) | `voice_calls` where `callback_status` in (pending, scheduled) |
| Voicemail | `voicemail_messages` (table never provisioned → permanent "not provisioned" placeholder) | `voice_calls` where `status = 'voicemail'` |

Both panels now read `voice_calls` — the same source as the working Voice view:
- **Callbacks**: pending/scheduled callbacks with scheduled time, transcript snippet, and Call (tel:) + Done actions.
- **Voicemail**: voicemail rows with transcript, recording, and a Done action.
- Actions update `callback_status` directly via Supabase — no dependency on the unwired `request_callback` / `handle_voicemail` skills.

Frontend-only — Vercel auto-deploys from main after merge.

> Note: the recording Play button points at the 46elks auth-protected wav (same as the Voice view), so playback still prompts for 46elks login — the **transcript** is the usable artifact, which is exactly why we transcribe voicemails to text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_