### PR TITLE
refactor(b2b): viewer read handlers use the shared companyScopeGuard

### DIFF
--- a/src/lib/__tests__/company-scoped-rung3-p1.guardrails.test.ts
+++ b/src/lib/__tests__/company-scoped-rung3-p1.guardrails.test.ts
@@ -23,9 +23,10 @@ describe('rung 3 (B2B) P1 read-rung guardrails', () => {
   it('the handler requires the server-injected _company_id and filters on it', () => {
     const fn = agentExec.slice(agentExec.indexOf('async function executeListCompanyRecords'));
     const body = fn.slice(0, fn.indexOf('\n}\n'));
-    // requires the verified company scope
-    expect(body).toMatch(/_company_id/);
-    expect(body).toMatch(/must be signed in as a company contact/i);
+    // requires the verified company scope, fail-closed via the shared guard
+    // (the guard reads _company_id and returns the "must be signed in" error).
+    expect(body).toMatch(/companyScopeGuard\(args, 'viewer'\)/);
+    expect(body).toMatch(/if \('error' in scope\) return/);
     // the isolation predicate: rows filtered by the injected company id
     expect(body).toMatch(/\.eq\('company_id', companyId\)/);
     // never trusts a model-supplied company/customer field for the lookup

--- a/supabase/functions/agent-execute/index.ts
+++ b/supabase/functions/agent-execute/index.ts
@@ -11784,10 +11784,13 @@ async function executeListCompanyRecords(
   args: Record<string, unknown>,
   table: 'orders' | 'invoices',
 ): Promise<unknown> {
-  const companyId = typeof (args as any)._company_id === 'string' ? (args as any)._company_id : '';
-  if (!companyId) {
-    return { success: false, error: 'You must be signed in as a company contact to see your company records. If you just signed in, your account may not be linked to a company yet — ask your account manager.' };
-  }
+  // Uniform with every other company-scoped handler: resolve scope through the
+  // shared guard (fail-closed on missing _company_id; 'viewer' is the read floor)
+  // rather than an ad-hoc presence check, so the isolation contract is enforced
+  // in exactly one place.
+  const scope = companyScopeGuard(args, 'viewer');
+  if ('error' in scope) return { success: false, error: scope.error };
+  const companyId = scope.companyId;
   const limit = Math.min(Number((args as any).limit) || 20, 50);
 
   if (table === 'orders') {


### PR DESCRIPTION
Follow-up from the consolidated identity-ladder security sweep (#3), which found the ladder **sound with no vulnerabilities**. This applies the one uniformity nit it surfaced.

## Change

The two viewer read skills (`list_company_orders` / `list_company_invoices`, both via `executeListCompanyRecords`) gated on a bare `_company_id` presence check instead of the shared **`companyScopeGuard('viewer')`** that every other company-scoped handler uses. Functionally identical today (viewer is rank 0), but now the fail-closed + role-rank contract lives in **exactly one place** — future-proof if the read floor ever moves off rank 0, and consistent for the next auditor.

## Deliberately NOT changed

`request_company_quote`'s global `QUO-NNNN` sequence. The audit flagged it as a trivial metadata inference (a company can infer platform-wide quote volume from its own number), but the global sequence is **intentional** — it shares the numbering scheme with `manage_quote` so `quote_number` stays unique across the shared `quotes` table. Per-tenant numbering would risk collisions with staff-created quotes; the trivial inference is the cheaper trade. Noted here so the choice is on the record.

## Verification

- Guardrail updated to assert the handler **delegates to `companyScopeGuard`** (stronger than the old inline-string match).
- 929 tests green, agent-execute transpiles clean.

## Deploy note

Redeploy `agent-execute`. No migration, no frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_