### PR TITLE
docs: describe current state in place — sprint statuses, edge-surface reality, dead refs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Both paths share the **concepts** below. Everything else (guides, modules, refer
 
 ## Quick links
 
-- **68 modules** registered in `src/lib/modules/` — every one has a page in [`modules/`](./modules/) (alias-aware via `scripts/check-doc-drift.ts`)
+- **67 modules** registered in `src/lib/modules/` — every one has a page in [`modules/`](./modules/) (alias-aware via `scripts/check-doc-drift.ts`)
 - **8 business processes** documented in [`processes/`](./processes/)
 - **6 department-claw playbooks** in [`agents/`](./agents/) for external MCP operators
 - Public docs portal: [/docs](https://flowwink.com/docs) (auto-synced from this folder, with embedded AI chat)
@@ -62,3 +62,5 @@ Both paths share the **concepts** below. Everything else (guides, modules, refer
 ---
 
 *Edit any page on GitHub → push → an admin runs the sync from `/admin/docs` (or wait for the scheduled sync).*
+
+*Convention: docs are updated **in place** to describe the current state. Plan/sprint documents carry a `status` field in their frontmatter (`planned` / `active` / `completed`) plus a dated outcome note when done — we don't archive; we describe what we have now.*

--- a/docs/architecture/conversation-and-retrieval.md
+++ b/docs/architecture/conversation-and-retrieval.md
@@ -37,7 +37,7 @@ and grounding strategy — none with real retrieval:
 | Docs chat | `docs-chat` | Anonymous | Hand-rolled keyword scoring over `docs_pages` ("CAG"). |
 | Flowwork (workspace) | `workspace-chat` | JWT + role gate (`admin`/`employee`/`manager`). Role-agnostic beyond the gate — every allowed role sees the same sources. | `buildContext()` pulls the **25 most-recent rows** per selected source (documents, contracts, kb, pages, crm, employees, wiki, flowtable — the flowtable source is question-driven keyword search over workspace-shared bases, not most-recent rows) into a 15k-token fair-share budget, with `[N]` inline citations. |
 | FlowPilot Operate / FlowChat | `agent-operate` | JWT, admin | Full pilot core (`_shared/agent-reason.ts`, soul, objectives, memories) + `search_skills` → `execute_skill`. The *acting* agent, not a retrieval surface. |
-| Live support (human) | `support-router` → `route_conversation_to_agent` RPC | — | Human handoff; `chat-completion` already skips AI when a human agent is engaged. |
+| Live support (human) | `route_conversation` skill → `route_conversation_to_agent` RPC | — | Human handoff; `chat-completion` already skips AI when a human agent is engaged. |
 
 Supporting facts that shape the design:
 

--- a/docs/architecture/event-bus.md
+++ b/docs/architecture/event-bus.md
@@ -63,7 +63,7 @@ also include a snapshot under `data`.
 
 | Event | Source | Payload | Listeners |
 |-------|--------|---------|-----------|
-| `lead.created` | trigger on `leads` | `{ id, data }` | qualify-lead automation |
+| `lead.created` | trigger on `leads` | `{ id, data }` | `qualify_lead` automation (skill) |
 | `deal.created` | trigger on `deals` | `{ id, data }` | webhook fanout |
 | `deal.stage_changed` | trigger on `deals` | `{ id, from, to, data }` | analytics |
 | `deal.won` | trigger on `deals` | `{ id, data }` | invoice draft, contract |
@@ -187,13 +187,14 @@ that should be visible/auditable in `/admin/automations`.
 Insert via the automations UI or seed in a module:
 
 ```ts
+// Real seed from inventory-module.ts:
 {
-  name: 'Send order confirmation',
+  name: 'Auto-allocate picking on order paid',
   trigger_type: 'event',
   trigger_config: { event: 'order.paid' },
   executor: 'platform',          // or 'flowpilot' / 'external'
-  action_type: 'edge_function',
-  action_config: { function: 'send-order-confirmation' },
+  skill_name: 'allocate_picking',   // the dispatcher runs skills via agent-execute
+  skill_arguments: { p_order_id: '{{event.payload.order_id}}' },
   enabled: true,
 }
 ```

--- a/docs/architecture/flowpilot-2.0.md
+++ b/docs/architecture/flowpilot-2.0.md
@@ -140,7 +140,8 @@ callable by admin UI / external agents), homed in their owning domain modules �
 NOT flowpilot-module.
 
 ### Phase 3 — Curator / learning loop (BR2)  *(SHIPPED 2026-07-12, loop-proven)*
-The **Skill Curator** (`skill-curator` edge fn — platform primitive: better skill metadata
+The **Skill Curator** (originally the `skill-curator` edge fn, since the 2026-07 edge-surface
+consolidation a task on `flowpilot-lifecycle?task=curator` — platform primitive: better skill metadata
 serves every agent, so NOT flowpilot-named) closes the Hermes learning loop by reusing the
 Phase 1+2 machinery end-to-end:
 
@@ -159,8 +160,9 @@ excluded from evidence. Audit-before-overwrite: the previous text is returned + 
 
 **Loop-proven locally:** 5 seeded slug-failures on manage_wiki_page → curator drafted
 "slug is ALWAYS required — find it via search_wiki" → staged → approved → followthrough
-applied it to the live catalog → cooldown blocked re-proposal. `flowpilot-learn` (site
-usage → memory) and `flowpilot-distill` continue unchanged alongside.
+applied it to the live catalog → cooldown blocked re-proposal. The learn task (site
+usage → memory) and the distill task continue unchanged alongside (both now also
+`flowpilot-lifecycle` tasks: `?task=learn`, `?task=distill`).
 
 **Operational note:** an accepted improvement lives in `agent_skills` — a code-seed resync
 restores the bundled text. Promote accepted improvements into the module seeds

--- a/docs/architecture/flowwink-control-model.md
+++ b/docs/architecture/flowwink-control-model.md
@@ -169,8 +169,8 @@ POST /functions/v1/agent-operate
 → scoreSkillsByIntent() from _shared/skills/
 → execute_skill() via agent-execute
 
-# FlowPilot path (autonomous)
-POST /functions/v1/agent-reason
+# FlowPilot path (autonomous) — in-process, no HTTP hop:
+# flowpilot-heartbeat imports _shared/agent-reason.ts
 → scoreSkillsByIntent() from _shared/pilot/../skills/
 → execute_skill() via agent-execute
 

--- a/docs/concepts/ai-dependencies.md
+++ b/docs/concepts/ai-dependencies.md
@@ -85,11 +85,11 @@ GEMINI_API_KEY=...
 - **Lead Qualification** - AI-powered lead scoring and summaries
 - **Content Migration** - Import pages from external websites
 
-**Edge Functions:**
-- `generate-text` (text generation)
-- `enrich-company` (company enrichment)
-- `qualify-lead` (lead qualification)
-- `migrate-page` (content migration)
+**Backing services:**
+- `chat-completion` (text generation via the shared AI toolbar)
+- `enrich_company` skill (`internal:` handler run by `agent-execute`)
+- `qualify_lead` skill (`internal:` handler run by `agent-execute`)
+- `migrate-page` edge function (content migration)
 
 **Configuration:**
 - Admin → Site Settings → System AI tab
@@ -111,7 +111,7 @@ GEMINI_API_KEY=...
 
 **Purpose:** Generate, improve, expand, summarize, translate, and continue text content.
 
-**Edge Function:** `generate-text`
+**Backing service:** `chat-completion` (called by the shared `<AITiptapToolbar>` via `useAITextGeneration` — these are utilities, not skills; see Law 3)
 
 **Actions:**
 - **Expand** - Make text longer with more details
@@ -184,9 +184,9 @@ Lottie and SVG animations are imported as "embed" blocks with the animation URL,
 
 **Purpose:** Automatically extract company information (description, industry, size, etc.) from company websites.
 
-**Edge Functions:**
-- `enrich-company` (AI extraction)
-- `firecrawl` (web scraping)
+**Backing services:**
+- `enrich_company` skill (`internal:` handler run by `agent-execute`, AI extraction)
+- Firecrawl (web scraping, via `browser-fetch`/`web-scrape`)
 
 **Configuration:**
 - Uses the same AI provider as Chat Settings
@@ -203,7 +203,7 @@ Lottie and SVG animations are imported as "embed" blocks with the animation URL,
 
 **Purpose:** Automatically score and qualify leads based on form submissions and company data.
 
-**Edge Function:** `qualify-lead`
+**Backing service:** `qualify_lead` skill (`internal:` handler run by `agent-execute` — deterministic point-based scoring)
 
 **Configuration:**
 - Uses the same AI provider as Chat Settings

--- a/docs/concepts/prd.md
+++ b/docs/concepts/prd.md
@@ -539,7 +539,7 @@ The SLA Monitor (`src/pages/admin/SlaMonitorPage.tsx`) enables policy-based serv
 
 - **Tables**: `sla_policies` (entity_type, metric, target_minutes, severity, enabled), `sla_violations` (policy_id, entity_type, entity_id, severity, actual_minutes, target_minutes, resolved_at)
 - **1 skill**: `sla_check` (evaluate all active SLA policies, detect violations, auto-resolve when entities are handled)
-- **Edge Function**: `sla-check` — iterates over active policies, queries entity tables for breaches, upserts violations, and auto-resolves previously violated entities that are now handled
+- **Backing RPC**: `run_sla_sweep` (SQL function, invoked by the `sla_check` skill) — iterates over active policies, queries entity tables for breaches, upserts violations, and auto-resolves previously violated entities that are now handled
 - **Supported entity types**: `ticket`, `order`, `lead`, `booking`
 - **Supported metrics**: `first_response_time`, `resolution_time`, `fulfillment_time`, `follow_up_time`
 - **Severity levels**: `warning` (approaching SLA), `breach` (exceeded SLA), `critical` (2x exceeded)

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -119,30 +119,31 @@ This is a low-priority optimization, not a security fix.
 
 Not all edge functions require the same level of authentication:
 
+The per-function `verify_jwt` setting in `supabase/config.toml` is the source
+of truth; `src/lib/edge-function-registry.ts` lists the full surface. The
+categories, with current examples:
+
 ### Admin-only functions (require admin role)
 - `check-secrets` — Reads secret presence (not values)
 - `create-user` — Creates new users
-- `generate-text` — AI text generation
-- `chat-completion` — AI chat
-- `newsletter-send` — Sends newsletters
-- `copilot-action` — FlowPilot actions
+- `setup-database`, `system-integrity-check`, `run-*-tests` — ops tooling
+- `integrations-account` — provider API-key management
 - `migrate-page` — Content migration
-- `analyze-brand` — Brand analysis
-- `qualify-lead` — Lead qualification
-- `enrich-company` — Company enrichment
 
 ### Authenticated user functions (any logged-in user)
 - `process-image` — Image processing
-- `unsplash-search` — Stock photo search
+- `workspace-chat` — Flowwork sessions
 
-### Public functions (no auth required)
+### Public functions (no auth required, `verify_jwt = false`)
 - `content-api` — Public content API (read-only)
 - `get-page` — Public page rendering
+- `chat-completion` — Visitor AI chat (anon-key auth)
 - `blog-rss` — RSS feed
 - `llms-txt` — LLM discovery file
-- `sitemap-xml` — Sitemap
+- `sitemap` — Sitemap
 - `track-page-view` — Analytics tracking
-- `newsletter-subscribe` — Newsletter signup
+- `newsletter` — Signup/confirm/track/unsubscribe endpoints
+- Webhooks: `stripe-webhook`, `email-webhook`, `composio-webhook`
 - `newsletter-track` — Email open tracking
 - `newsletter-link` — Link click tracking
 - `stripe-webhook` — Stripe webhook (verified by Stripe signature)

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -509,19 +509,12 @@ When links are shared on social media (Facebook, LinkedIn, Twitter, WhatsApp, Sl
    - `OG Image` - URL to your social sharing image (1200x630px recommended)
    - `Twitter Handle` - Your Twitter/X handle (optional)
 
-2. **Configure nginx** (for production):
-   
-   Edit `nginx.conf` and uncomment the proxy configuration:
-   ```nginx
-   if ($is_social_crawler) {
-       rewrite ^(.*)$ /functions/v1/render-page?path=$1 break;
-       proxy_pass https://YOUR_PROJECT_REF.supabase.co;
-       proxy_set_header Host $proxy_host;
-       proxy_set_header X-Real-IP $remote_addr;
-   }
-   ```
-   
-   Replace `YOUR_PROJECT_REF.supabase.co` with your actual Supabase project URL.
+2. **Crawler-side rendering is currently unavailable.** `nginx.conf` carries a
+   commented-out rewrite to a `render-page` edge function, but that function
+   was never shipped — enabling the rewrite would 404 for crawlers. Leave it
+   commented. The static `index.html` OG tags are what social crawlers see;
+   if per-page crawler meta becomes a requirement, that's a feature request,
+   not a config step.
 
 3. **Test with Facebook Debugger**:
    - Go to [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -143,12 +143,12 @@ supabase link --project-ref YOUR_PROJECT_REF
 **Use the CLI for this — don't loop over the directory.** Two reasons the
 obvious loop breaks a site:
 
-- **The function cap is a cliff.** Supabase Free allows 100 functions; the repo
-  has ~110. A loop deploys fine up to 100, then every remaining call fails with
-  `402 Max number of functions reached` — and the site is silently missing
-  whichever functions came last in the alphabet. At the cap even *updates to
-  existing functions* are rejected, so you cannot ship a fix until you delete
-  something.
+- **The function cap is a cliff.** Supabase Free allows 100 functions. Since
+  the 2026-07 edge-surface consolidation the repo ships ~75, so a full deploy
+  fits — but the failure mode is worth knowing: past the cap every remaining
+  call fails with `402 Max number of functions reached` and the site is
+  silently missing whichever functions came last in the alphabet. At the cap
+  even *updates to existing functions* are rejected.
 - **Blanket `--no-verify-jwt` removes the auth gate from admin-only functions.**
   `supabase/config.toml` sets `verify_jwt` per function for a reason; the CLI
   reads it, a hand-rolled loop does not.
@@ -160,14 +160,16 @@ npm run cli        # then: /update-funcs
 On a project that has no modules configured yet — a fresh install — it asks
 what the site is and deploys that profile:
 
-| Profile | Functions | What you get |
-|---------|-----------|--------------|
-| `cms` | ~51 | Pages, blog, media, newsletter, surveys, webinars |
-| `crm` | ~67 | CMS + leads, companies, customer 360, sales intelligence, bookings, live support |
-| `erp` | ~110 | Everything — **exceeds the Free cap**, needs a paid plan |
+| Profile | What you get |
+|---------|--------------|
+| `cms` | Pages, blog, media, newsletter, surveys, webinars |
+| `crm` | CMS + leads, companies, customer 360, sales intelligence, bookings, live support |
+| `erp` | Everything (~75 functions post-consolidation — now fits the Free cap) |
 
 Preset it non-interactively with `FLOWWINK_PROFILE=cms`, or deploy literally
-everything with `FLOWWINK_DEPLOY_ALL=1` (only on a paid plan).
+everything with `FLOWWINK_DEPLOY_ALL=1`. Profiles are data, not code — they
+live in `supabase/seed/install-profiles.json`; the module→function map behind
+them is `src/lib/edge-function-registry.ts`.
 
 **Enabling more modules later is two steps.** Toggling a module in
 `/admin/modules` seeds its skills immediately, but the browser cannot deploy
@@ -320,107 +322,45 @@ See **[DEPLOYMENT.md](./deployment.md)** for deploying to Easypanel, Railway, or
 
 ## Edge Functions Reference
 
-| Function | Purpose | Auth Required | Secrets Required |
-|----------|---------|---------------|------------------|
-| `analyze-brand` | Extract branding from URLs | Yes | `FIRECRAWL_API_KEY` |
-| `blog-rss` | Generate RSS feed | No | - |
-| `chat-completion` | AI chat responses | No | AI API keys (optional) |
-| `check-secrets` | Check secrets configuration status | Yes (Admin) | - |
-| `content-api` | REST/GraphQL API | No | - |
-| `copilot-action` | AI copilot actions | Yes | AI API keys |
-| `create-checkout` | Create Stripe checkout sessions | No | `STRIPE_SECRET_KEY` |
-| `create-user` | Create users programmatically | No | - |
-| `enrich-company` | Enrich company data | Yes | - |
-| `firecrawl-search` | Web scraping search | Yes | `FIRECRAWL_API_KEY` |
-| `generate-text` | AI text generation | Yes | AI API keys |
-| `get-page` | Cached page fetching | No | - |
-| `invalidate-cache` | Clear page cache | Yes | - |
-| `llms-txt` | LLM text processing | Yes | AI API keys |
-| `migrate-page` | AI content migration | Yes | `FIRECRAWL_API_KEY` |
-| `newsletter-confirm` | Double opt-in confirmation | No | - |
-| `newsletter-export` | GDPR export of subscribers | Yes | - |
-| `newsletter-gdpr` | GDPR operations for newsletters | Yes | - |
-| `newsletter-link` | Newsletter link processing | No | - |
-| `newsletter-send` | Send newsletter campaigns | Yes | `RESEND_API_KEY` |
-| `newsletter-subscribe` | Handle newsletter subscriptions | No | - |
-| `newsletter-track` | Track newsletter opens/clicks | No | - |
-| `newsletter-unsubscribe` | Handle unsubscriptions | No | - |
-| `process-image` | WebP conversion | Yes | - |
-| `publish-scheduled-pages` | Cron job for scheduling | No | - |
-| `qualify-lead` | Lead qualification | Yes | AI API keys |
-| `send-booking-confirmation` | Send booking confirmations | Yes | `RESEND_API_KEY` |
-| `send-order-confirmation` | Send order confirmations | Yes | `RESEND_API_KEY` |
-| `send-webhook` | Trigger webhooks for events | Yes | - |
-| `setup-database` | Database setup/initialization | Yes (Admin) | - |
-| `setup-flowpilot` | Bootstrap agentic layer (skills, soul, identity) | Yes (Admin) | - |
-| `flowpilot-heartbeat` | Autonomous heartbeat loop (admin-configurable schedule) | No | AI API keys |
-| `flowpilot-learn` | Analyze usage data → agent memory | No | - |
-| `sitemap-xml` | Generate sitemap | No | - |
-| `stripe-webhook` | Handle Stripe webhooks | No | `STRIPE_WEBHOOK_SECRET` |
-| `support-router` | Route support requests | No | - |
-| `test-ai-connection` | Test AI provider connections | Yes | AI API keys |
-| `track-page-view` | Track page analytics | No | - |
-| `unsplash-search` | Search Unsplash for images | Yes | `UNSPLASH_ACCESS_KEY` |
-| `update-kb-feedback` | Update knowledge base feedback | Yes | - |
+The deployable surface is ~75 functions after the 2026-07 edge-surface
+consolidation. The authoritative, guardrail-tested list — including which
+modules own which functions and which are core — is
+**`src/lib/edge-function-registry.ts`**; the operator mental model
+(mandatory vs optional, align-down rule, deploy flags) is
+**`docs/operators/edge-function-tiers.md`**.
+
+A few structural points worth knowing during setup:
+
+- **`chat-completion`** is THE AI endpoint (visitor chat, FlowPilot, all AI
+  calls). Public functions like this deploy with `--no-verify-jwt`.
+- **`agent-execute`** runs every registered skill, including the many
+  `internal:` handlers that used to be standalone edge functions.
+- **`comms-send`** handles all transactional outbound email (booking/order/
+  invoice/quote confirmations, reminders); requires `RESEND_API_KEY`.
+- **`flowpilot-lifecycle`** hosts the operator's lifecycle tasks
+  (`?task=briefing|distill|learn|followthrough|curator`).
+- **`integrations-account`** consolidates the provider-key management
+  endpoints (OpenAI, ElevenLabs, Hunter, Firecrawl, Unsplash).
+- Webhooks (`stripe-webhook`, `email-webhook`, `composio-webhook`) need their
+  respective secrets (`STRIPE_WEBHOOK_SECRET`, …).
 
 ---
 
-## Scheduled Publishing Setup
+## Scheduled jobs (cron)
 
-To enable scheduled publishing, set up a cron job that calls the `publish-scheduled-pages` function:
-
-### Using Supabase pg_cron
-
-```sql
--- Run every minute
-SELECT cron.schedule(
-  'publish-scheduled-pages',
-  '* * * * *',
-  $$
-  SELECT net.http_post(
-    url := 'https://YOUR_PROJECT_REF.supabase.co/functions/v1/publish-scheduled-pages',
-    headers := '{"Authorization": "Bearer YOUR_SERVICE_ROLE_KEY"}'::jsonb
-  );
-  $$
-);
-```
+Scheduled publishing needs **no manual setup**: `publish_scheduled_pages()` is
+a plain SQL function registered on pg_cron by migration (there is no edge
+function involved). Cron jobs in general are registered idempotently by
+migrations and read the instance's own URL/key — never hardcode another
+instance's URL in a cron command; the Observability tab's cron-health card
+flags foreign-host jobs, never-ran jobs, and recent HTTP errors.
 
 ### FlowPilot Autonomous Loop
 
-```sql
--- Heartbeat (default: twice daily — schedule managed via admin Autonomy Settings)
-SELECT cron.schedule(
-  'flowpilot-heartbeat',
-  '0 0,12 * * *',
-  $$
-  SELECT net.http_post(
-    url := 'https://YOUR_PROJECT_REF.supabase.co/functions/v1/flowpilot-heartbeat',
-    headers := '{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
-    body := concat('{"time": "', now(), '"}')::jsonb
-  ) AS request_id;
-  $$
-);
-
--- Learn from usage data daily at 03:00 UTC
-SELECT cron.schedule(
-  'flowpilot-learn',
-  '0 3 * * *',
-  $$
-  SELECT net.http_post(
-    url := 'https://YOUR_PROJECT_REF.supabase.co/functions/v1/flowpilot-learn',
-    headers := '{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
-    body := concat('{"time": "', now(), '"}')::jsonb
-  ) AS request_id;
-  $$
-);
-```
-
-### Using External Cron (e.g., cron-job.org)
-
-Set up an HTTP POST request to:
-```
-https://YOUR_PROJECT_REF.supabase.co/functions/v1/publish-scheduled-pages
-```
+The heartbeat schedule is managed from **Admin → Autonomy Settings** (it
+writes the pg_cron entry for `flowpilot-heartbeat`). Lifecycle tasks
+(learn, distill, briefing, curator) run as cron jobs targeting
+`flowpilot-lifecycle?task=<task>` and are likewise registered by migration.
 
 ---
 
@@ -496,7 +436,7 @@ These are the minimum functions needed for pages to work:
    - Name: `get-page`
    - Upload the file: `supabase/functions/get-page/index.ts`
    - Click **Deploy**
-5. Repeat for `track-page-view`, `content-api`, and `sitemap-xml`
+5. Repeat for `track-page-view`, `content-api`, and `sitemap`
 
 **Via Supabase CLI** — these four are public, so they need `--no-verify-jwt`:
 ```bash
@@ -506,7 +446,7 @@ supabase link --project-ref YOUR_PROJECT_REF
 supabase functions deploy get-page --no-verify-jwt
 supabase functions deploy track-page-view --no-verify-jwt
 supabase functions deploy content-api --no-verify-jwt
-supabase functions deploy sitemap-xml --no-verify-jwt
+supabase functions deploy sitemap --no-verify-jwt
 ```
 
 **To (re)deploy everything the site needs**, use the CLI rather than a loop —

--- a/docs/modules/federation.md
+++ b/docs/modules/federation.md
@@ -104,11 +104,12 @@ A2A channels are conversation-oriented. Used when:
 - A peer wants to subscribe to events
 - Bidirectional status streaming during long-running work
 
-The reference implementation is the **Agent Bridge** between Claude Code and Lovable:
-- Endpoint: `https://clawstack.froste.eu/api/bridge`
-- Token: `bridge-dev-token`
-- Pattern: `POST` to send, `GET ?since_id=N` to poll
-- **Always poll with `since_id=0`** when reading — never trust "since last read" optimizations during dev. See `mem://development/bridge-polling-protocol`.
+The A2A surface is served by the `a2a` edge function, with peer discovery via
+`agent-card`. The former reference implementation (the "Agent Bridge" on
+`clawstack.froste.eu`) is **decommissioned** — do not use it. The live external
+peer today is OpenClaw (`https://openclaw.liteit.se`), which operates FlowWink
+instances through the outward MCP gateway (`mcp-server`, `?mode=dispatch`)
+rather than A2A.
 
 ---
 

--- a/docs/operators/edge-function-tiers.md
+++ b/docs/operators/edge-function-tiers.md
@@ -1,15 +1,42 @@
 # Edge-function tiers — mandatory vs optional
 
+> **Updated 2026-07-21 after the edge-surface consolidation.** The deployable
+> surface shrank from ~115 to **75 functions** (see
+> [`docs/architecture/edge-surface-classification.md`](../architecture/edge-surface-classification.md)
+> for the thesis and the executed migration). The **code source of truth** for
+> which functions exist and which modules own them is
+> `src/lib/edge-function-registry.ts` (guardrail-tested against the
+> filesystem); this doc is the operator's mental model on top of it.
+
 The fleet keeps a **deliberately partial** edge-function set per instance: not every
 module is enabled everywhere, and each Supabase project stays **under ~100 edge
-functions** (with margin) by design. So a "missing function" is usually intentional,
-**not** a bug. This doc is the mental model for what must be there vs what may be absent.
+functions** (now with real margin — the full surface is 75) by design. So a
+"missing function" is usually intentional, **not** a bug.
 
 **Guiding principle (Magnus, 2026-07-18):** *core must work; an optional function missing
 for an enabled module is not the end of the world.* The coherence fix for optional gaps is
 to **align the skill layer down to what's deployed** (disable the exposed skill so the agent
-never 404s) — not to deploy up and blow the budget. See
-`memory: project-fleet-edge-skill-alignment`.
+never 404s) — not to deploy up and blow the budget.
+
+## What the consolidation changed
+
+Former standalone functions now live as **tasks/handlers inside a small kernel**:
+
+- `flowpilot-lifecycle` (`?task=briefing|distill|learn|followthrough|curator`)
+  replaced `flowpilot-briefing`, `flowpilot-distill`, `flowpilot-learn`,
+  `flowpilot-followthrough`, `skill-curator`.
+- `comms-send` consolidated the outbound-email senders
+  (booking/order/invoice/quote/contact confirmations, reminders, newsletter send).
+- `integrations-account` consolidated the `*-account` provider-key functions
+  (openai, elevenlabs, hunter, firecrawl, unsplash).
+- `instance-health?check=cron` absorbed the cron-health report surface.
+- Dozens of thin "handlers in disguise" (reconciliation, sla-check, survey-send,
+  extract-receipt-style workers, …) moved to `internal:` skill handlers executed
+  by `agent-execute` — no HTTP function at all.
+
+Cron jobs were repointed to the new endpoints host-preservingly during the
+refactor; old function names in an instance's cron table are drift — the
+Observability tab's cron-health card flags them.
 
 ## Tier 1 — CORE (mandatory on EVERY instance)
 
@@ -21,70 +48,50 @@ The platform/agent cannot function without these. If any is missing on an instan
 | `get-page` | serves every public page (the site itself) |
 | `content-api` | programmatic content access |
 | `chat-completion` | THE AI endpoint — FlowPilot + visitor chat + all AI calls |
-| `agent-execute` | skill-execution engine (every skill runs through it) |
+| `agent-execute` | skill-execution engine (every skill runs through it, incl. all `internal:` handlers) |
 | `mcp-server` | outward MCP gateway + `/rest/*` (external agents) |
 | `automation-dispatcher` | the per-minute automation tick |
 | `flowpilot-heartbeat` | the autonomous ReAct loop |
-| `flowpilot-learn` | learning loop (nightly) |
-| `flowpilot-followthrough` | resumption of staged/multi-step ops |
+| `flowpilot-lifecycle` | briefing/distill/learn/followthrough/curator tasks |
 | `knowledge-indexer` | RAG chunk index (grounding) |
 | `web-search` + `web-scrape` | FlowPilot research (any research-driven objective) |
-| `instance-health` | ops/health monitoring |
+| `instance-health` | ops/health monitoring (incl. `?check=cron`) |
+| `comms-send` | all transactional/outbound email |
 | `newsletter` | scheduled dispatch (`/newsletter/dispatch-scheduled` cron target) |
 
-Verified present on all four fleet instances 2026-07-18 (liteit, www, demo, autoversio).
+The exact core set = functions NOT claimed by any module in
+`MODULE_EDGE_FUNCTIONS` (`src/lib/edge-function-registry.ts`,
+`coreEdgeFunctions()`). Fail-open: an unmapped function counts as core.
 
-## Tier 2 — LIFECYCLE-optional
-
-FlowPilot lifecycle niceties that aren't loop-critical. Deploy where wanted; a missing one
-with **no cron referencing it** is dormant, not broken.
-
-- `flowpilot-distill` — periodic memory consolidation (no cron on the fleet → dormant, fine)
-- `flowpilot-briefing` — daily business briefing (deploy only where a `run_daily_briefing`
-  automation is wanted; e.g. skipped on www to hold its 100-function margin)
-
-## Tier 3 — MODULE-optional (deploy iff the module is enabled)
+## Tier 2 — MODULE-optional (deploy iff the module is enabled)
 
 Present only when the owning module is on. If the module is **off**, the function is
 absent by design → the matching skill must be **disabled** (align-down), not the function
-deployed. Examples:
+deployed. The authoritative module→function map is `MODULE_EDGE_FUNCTIONS` in
+the registry; the Modules admin page shows the computed footprint per plan tier.
 
-- commerce: `create-checkout`, `create-invoice-payment`
-- subscriptions: `subscriptions`, `subscription-billing-cron`
-- reconciliation: `reconciliation`
-- accounting (SE): `accounting-vat-return-se`, `fetch-fx-rates`
-- recruitment: `parse-resume`, `process-job-application`
-- sales-intelligence: `prospect-research`, `prospect-fit-analysis`, `sales-profile-setup`,
-  `qualify-lead`, `enrich-company`, `contact-finder`
-- field-service: `field-service-skill`
-- contact-center / live-support: `contact-center`, `support-router`, `telegram-ingest`
-- customer360: `customer-360`
-- surveys: `survey-send`, `csat-dispatch`
-- sla: `sla-check`
-- media/site: `media-optimize`, `migrate-page`, `analyze-brand`, `github-content-sync`
-- integrations: `composio-proxy`, `browser-fetch`, `firecrawl-account`, `hunter-account`
-
-## Tier 4 — ADMIN / infra-optional
+## Tier 3 — ADMIN / infra-optional
 
 Admin tooling, deployed as needed. These SHOULD stay `verify_jwt=true` (admin-authenticated):
 `create-user`, `setup-database`, `check-secrets`, `system-integrity-check`,
-`test-ai-connection`, `run-autonomy-tests`, `run-platform-tests`, `*-account` (openai,
-elevenlabs, hunter, firecrawl). Webhooks (`stripe-webhook`, `email-webhook`,
+`test-ai-connection`, `run-autonomy-tests`, `run-platform-tests`,
+`integrations-account`. Webhooks (`stripe-webhook`, `email-webhook`,
 `composio-webhook`) are `verify_jwt=false` but only relevant with their integration.
 
 ## Operational rules
 
 1. **Core-verify on every deploy/provision:** confirm all Tier-1 functions are present on
    the instance. Missing → deploy (`--no-verify-jwt` for the public ones).
-2. **Optional gap ≠ bug:** a Tier-3 function missing while its module is enabled → disable
+2. **Optional gap ≠ bug:** a module function missing while its module is enabled → disable
    the exposed skill (align-down), don't blow the budget. Reversible.
 3. **Skill surface must mirror deployed capability** (Law 2): an `enabled + mcp_exposed`
    skill whose `edge:` function isn't deployed 404s — disable it.
-4. **⚠️ `config.toml` is incomplete for full deploys.** 46/124 functions have no
-   `[functions.X]` entry → a full `supabase functions deploy` defaults them to
-   `verify_jwt=true`, which would JWT-gate public/webhook/payment functions
-   (`create-checkout`, `create-invoice-payment`, `quote-pay`, `stripe-webhook`, …).
-   **Do NOT do a blanket full deploy** until config.toml lists `verify_jwt=false` for the
-   public set. Deploy targeted with `--no-verify-jwt` instead.
-5. **Budget:** stay under ~100 edge functions per project with margin. www currently sits at
-   100 — reclaim before adding (e.g. drop `web-search`/`web-scrape` there if research isn't used).
+4. **Check `config.toml` before a blanket full deploy.** Functions without a
+   `[functions.X]` entry default to `verify_jwt=true` on deploy. Most of the
+   unlisted ones are admin functions where that's correct, but verify the
+   public/webhook/payment set (`create-checkout`, `create-invoice-payment`,
+   `quote-pay`, `stripe-webhook`, …) has explicit `verify_jwt=false` entries,
+   or deploy targeted with `--no-verify-jwt`.
+5. **Budget:** with 75 total functions the full surface now fits the Free-tier
+   ceiling (100) even with everything enabled — the freeze principle
+   (no new small edge functions; new capability = skill/handler) keeps it that way.

--- a/docs/operators/openclaw-mcp-qa-status.md
+++ b/docs/operators/openclaw-mcp-qa-status.md
@@ -1,5 +1,12 @@
 # OpenClaw ⇄ MCP-surface QA — session status
 
+> **Point-in-time record (June 2026).** This documents a completed QA
+> campaign; the fixes it describes are merged and live. It is kept for the
+> method (uncoached operator chains + engine-level fixes) and the bug-class
+> catalogue — not as current status. For live drift state, use the instance
+> manifest (`instance_sync_status()` / the Observability sync card) and
+> `scan_beta_findings` on the gateway.
+
 **Goal:** make dev.flowwink.com 100% in sync with a fresh install, and make the
 MCP skill surface fully usable by an autonomous operator (OpenClaw) — "FlowWink
 works only if an OpenClaw can use it as its claws."

--- a/docs/operators/provisioning-and-updates.md
+++ b/docs/operators/provisioning-and-updates.md
@@ -207,15 +207,14 @@ function is never momentarily missing. Prune is skipped if the deploy had
 failures. Do NOT blind `delete-all` then redeploy on a live instance — that's a
 multi-minute outage window; `--prune` achieves the same clean state with none.
 
-**Consolidation into domain routers (optional, not done).** If even a
-fully-loaded site (all modules on → full count → needs Pro) must fit Free, fold
-clusters — transactional emails → `email-send`, provider probes → one function.
-`reconciliation` / `a2a` already route sub-paths via `url.pathname`, so the
-pattern exists. **Same lockstep tail as the RPC rename above:** functions are
-invoked by the admin frontend directly and forks don't auto-deploy — ship the
-router additively, migrate all callers, redeploy all frontends, *then* delete the
-old functions. No dead functions to delete outright (zero-reference ones are
-crons/webhooks/test runners). A planned migration, not a quick win.
+**Consolidation into domain routers (DONE, 2026-07).** The edge-surface
+refactor executed exactly this: transactional emails → `comms-send?kind=…`,
+provider probes → `integrations-account`, FlowPilot lifecycle →
+`flowpilot-lifecycle?task=…`, and dozens of thin functions → `internal:` skill
+handlers in `agent-execute`. The surface is now ~75 functions — a fully-loaded
+site fits the Free tier. Cron jobs were repointed host-preservingly by
+migration; see `docs/architecture/edge-surface-classification.md` for the full
+classification and the freeze principle (no new small edge functions).
 3. **Fail loud on migrations.** `scripts/run-migrations.js` swallows errors so a
    Vercel build "succeeds" against a DB that never migrated — a prime drift
    source. Either fail the build, or decouple migrations from the build and run

--- a/docs/parity/program-80.md
+++ b/docs/parity/program-80.md
@@ -65,16 +65,18 @@ there is no standing daemon. For scheduled cadence, trigger a session weekly
 via GitHub Actions. The program state lives entirely in this repo (matrix,
 scorecards, epics, reference cards) so any session can resume it.
 
-## Current state (2026-07-04)
+## Current state (2026-07-21)
 
-- Mean parity 60% · 6/54 modules ≥ 80% · worst: shipping 31%
-- **R1 in flight** (see roadmap.md): EPIC-05 verify-sweep (first flip done:
-  booking#duration_rules, Stage-3 live), EPIC-06 content cluster, EPIC-07
-  support-to-resolution, EPIC-08 ops UIs. Projected mean after R1: ~66%.
-- **R2 prep started:** grounding reference cards commissioned for the
-  SMB-priority clusters: quote→contract→sign, e-commerce (including
-  authoring the missing `ecommerce.json` scorecard — the module is
-  currently unscored and invisible to the program), CRM depth.
-- Known blockers being worked with the platform owner: deployed
-  agent-execute missing `sanitizeOrTerm` (P1 defect), external operator's
-  stale MCP session.
+- Mean parity **89%** · 55 benchmarked modules · 10 differentiators (no Odoo
+  benchmark) · worst: contact-center 41%, accounting 58%, analytics 58%,
+  chat 58% (see [`parity-matrix.md`](./parity-matrix.md) for the live table).
+- The three sprints spawned by this program — floor wave 1, P1
+  Subscribe-to-Renew, EPIC-03 completion + view consolidation — are all
+  **completed** (statuses + outcome notes in their respective docs).
+- Remaining below-80 modules are mostly P2/P3 tier (contact-center,
+  accounting depth, manufacturing) where the non-goal rule and community
+  handoff apply; lift happens opportunistically per the round loop above.
+- Earlier blockers (missing `sanitizeOrTerm`, stale operator MCP session,
+  migration-ledger drift) are resolved; drift detection is now structural via
+  the instance manifest (`supabase/seed/instance-manifest.json` +
+  `instance_sync_status()` + the Observability sync card).

--- a/docs/parity/sprint-floor-wave1.md
+++ b/docs/parity/sprint-floor-wave1.md
@@ -2,10 +2,19 @@
 title: "Sprint — Raise the floor, wave 1 (companies, returns, handbook, calendar)"
 description: Lift the four cheapest bottom-of-matrix modules with column+skill work; defer integration-heavy gaps to community.
 category: concepts
-status: planned
+status: completed
 ---
 
 # Sprint — Raise the floor, wave 1
+
+> **Outcome (verified against the parity matrix 2026-07-21):** all targets
+> exceeded — companies **93%** (target ≥55), returns **100%** (≥50), calendar
+> **92%** (≥40); handbook is now classed as a FlowWink differentiator (no Odoo
+> benchmark) with its skill surface in place. F1–F4 shipped: the B2B company
+> fields + `find_duplicate_companies`, returns reason/fee/inspection +
+> partial refunds, `manage_handbook_section`, and full calendar-event CRUD.
+> Kept for the record of scope and rationale; see
+> [`parity-matrix.md`](./parity-matrix.md) for live scores.
 
 With EPIC-01–04 complete, the fastest path toward "every module ≥ 80%" is the
 bottom of the matrix. This wave targets the modules whose gaps are **cheap

--- a/docs/parity/sprint-p1-subscribe-to-renew.md
+++ b/docs/parity/sprint-p1-subscribe-to-renew.md
@@ -2,10 +2,18 @@
 title: "Sprint — P1 Subscribe-to-Renew backend (proration + recurring re-score)"
 description: Close the two w3 gaps gating the Subscribe-to-Renew process.
 category: concepts
-status: planned
+status: completed
 ---
 
 # Sprint — P1 Subscribe-to-Renew backend
+
+> **Outcome (verified against the scorecards 2026-07-21):** both gating
+> capabilities are **done** — `invoicing.recurring` (live E2E on the dev
+> instance: `create_manual_subscription` → `generate_subscription_invoice` →
+> `next_invoice_date` advances) and `subscriptions.proration`
+> (`change_subscription` prorates by remaining days; upgrade → draft
+> adjustment invoice, downgrade → credit). Subscriptions sits at 79% parity.
+> Kept for the record of scope and rationale.
 
 [`process-gaps.md`](./process-gaps.md) ranks **Subscribe-to-Renew** as P1, gated by
 `invoicing.recurring` (w3) and `subscriptions.proration` (w3).

--- a/docs/parity/sprint-pipeline-consolidation.md
+++ b/docs/parity/sprint-pipeline-consolidation.md
@@ -2,10 +2,19 @@
 title: "Sprint — EPIC-03 completion + view consolidation"
 description: Migrate leads/deals/tickets to the shared stage engine and consolidate the duplicate pipeline + approval views.
 category: concepts
-status: planned
+status: completed
 ---
 
 # Sprint — EPIC-03 completion + view consolidation
+
+> **Outcome (verified in code + scorecards 2026-07-21):** definition of done
+> met. `deals.custom_stages`, `crm.custom_stages`, `tickets.stage_pipeline`
+> and `deals.probability_weighting` are all **done** (Stage-3 verified, shared
+> `pipeline_stages` + `stage_id`). The UI is consolidated: `/admin/pipelines`
+> redirects to `/admin/pipelines/stages` (stage admin only), and
+> `/admin/approvals/inbox` + `/admin/approvals/chains` redirect into the
+> tabbed `/admin/approvals` page. Kept for the record of the decisions and
+> the sync-keystone design.
 
 Lovable shipped new config-driven admin pages (`/admin/pipelines`, approval inbox/chains)
 that now **coexist** with the older enum-driven views. This sprint finishes EPIC-03

--- a/docs/pilot/module-dependencies.md
+++ b/docs/pilot/module-dependencies.md
@@ -79,11 +79,11 @@ The module's core functionality is **entirely agent-driven**. There is no manual
 | Skill | Handler | Role |
 |-------|---------|------|
 | `prospect_research` | `edge:prospect-research` | Raw data fetch (web scrape + Hunter contacts) |
-| `prospect_fit_analysis` | `edge:prospect-fit-analysis` | Data collection for fit evaluation |
-| `enrich_company` | `edge:enrich-company` | Domain scraping + company enrichment |
-| `qualify_lead` | `edge:qualify-lead` | Deterministic point-based scoring |
-| `contact_finder` | `edge:contact-finder` | Hunter.io contact discovery |
-| `sales_profile_setup` | `edge:sales-profile-setup` | Company/user profile management |
+| `prospect_fit_analysis` | `internal:prospect_fit_analysis` | Data collection for fit evaluation |
+| `enrich_company` | `internal:enrich_company` | Domain scraping + company enrichment |
+| `qualify_lead` | `internal:qualify_lead` | Deterministic point-based scoring |
+| `contact_finder` | `internal:contact_finder` | Hunter.io contact discovery |
+| `sales_profile_setup` | `internal:sales_profile_setup` | Company/user profile management |
 
 **⚠️ Known issue:** `prospect-fit-analysis` currently contains a reasoning-level AI prompt (introduction letters, strategic advice) that should flow through FlowPilot. See [Sensors vs. Reasoning](./sensors-vs-reasoning.md) for details.
 
@@ -161,7 +161,7 @@ New Ticket → ticket_triage
 | `manage_leads` | `module:crm` | List, get, update status/score, delete existing leads |
 | `lead_pipeline_review` | `module:crm` | Audit pipeline by status, score, and days since contact |
 | `lead_nurture_sequence` | `module:newsletter` | Create email drip campaigns for leads |
-| `qualify_lead` | `edge:qualify-lead` | Deterministic point-based lead scoring |
+| `qualify_lead` | `internal:qualify_lead` | Deterministic point-based lead scoring |
 | `crm_task_list` | `db:crm_tasks` | List CRM tasks with lead/deal/priority filters |
 | `crm_task_create` | `db:crm_tasks` | Create follow-up tasks linked to leads or deals |
 | `crm_task_update` | `db:crm_tasks` | Update or complete CRM tasks |

--- a/docs/pilot/sensors-vs-reasoning.md
+++ b/docs/pilot/sensors-vs-reasoning.md
@@ -33,9 +33,9 @@ These are **pure transformations** — structured input in, structured data out.
 | `analyze_receipt` | Image → line items, totals, VAT | Pure OCR + extraction |
 | `parse_resume` | PDF → skills, experience, education | Data transformation |
 | `web-scrape` | URL → structured page content | Raw data extraction |
-| `enrich-company` | Domain → company metadata | Deterministic data fetch |
-| `qualify-lead` | Activity data → numeric score | Point-based calculation with fixed rules |
-| `contact-finder` | Domain → email addresses | API lookup, no judgement |
+| `enrich_company` | Domain → company metadata | Deterministic data fetch |
+| `qualify_lead` | Activity data → numeric score | Point-based calculation with fixed rules |
+| `contact_finder` | Domain → email addresses | API lookup, no judgement |
 
 **Characteristics:**
 - Input and output are both structured data

--- a/docs/processes/book-to-meet.md
+++ b/docs/processes/book-to-meet.md
@@ -15,7 +15,7 @@
 | Module | Role in the process |
 |--------|---------------------|
 | **Booking** | Services, availability windows, blocked dates, the bookings themselves |
-| **Email** | Confirmation on booking (`send-booking-confirmation`) and the 24h reminder sweep (`send-booking-reminders` → `email-send`) |
+| **Email** | Confirmation on booking (`comms-send?kind=booking_confirmation`) and the 24h reminder sweep (`comms-send?kind=booking_reminders` → `email-send`) |
 | **Voice** | Phone intake — booking IVR (UC4): caller picks a slot, callback scheduling pairs with the booking |
 | **Calendar** | Read-only aggregation — bookings appear in the unified `list_events` calendar |
 | **SLA** | Booking-confirmation monitors (`sla_check` / `manage_sla_policy` with `entity_type: booking`) |
@@ -33,7 +33,7 @@ flowchart TD
     C --> D["Slot booked — double-booking rejected<br/>book_appointment_slot"]
     D --> E["Booking created (pending) + confirmation email"]
     E --> F["Confirmed<br/>manage_bookings update_status"]
-    F --> G["Reminder sweep — cron every 15 min, one email, starts within 24h<br/>send-booking-reminders"]
+    F --> G["Reminder sweep — cron every 15 min, one email, starts within 24h<br/>comms-send?kind=booking_reminders"]
     G --> H["Staff assigned<br/>manage_bookings assign_staff"]
     H --> I["Meeting happens"]
     I -->|attended| J["completed"]
@@ -78,8 +78,8 @@ completed / no_show` — `no_show` added by migration `20260703151000`)
 
 | Status | Meaning | Moved forward by | What the transition does |
 |---|---|---|---|
-| `pending` | Requested, awaiting confirmation | visitor (public block), agent (`book_appointment_slot`, `book_appointment`) | Row created; end time derived from service duration; overlap with any non-cancelled booking of the same service rejected (`slot_unavailable`); public-block path invokes `send-booking-confirmation` and fires `booking.submitted` |
-| `confirmed` | Slot is committed | admin / agent (`manage_bookings` `update_status`) | Makes the booking eligible for the reminder sweep (`send-booking-reminders`: starts <24h + `reminder_sent_at IS NULL` → one email, then stamped) and for SLA confirmation monitoring |
+| `pending` | Requested, awaiting confirmation | visitor (public block), agent (`book_appointment_slot`, `book_appointment`) | Row created; end time derived from service duration; overlap with any non-cancelled booking of the same service rejected (`slot_unavailable`); public-block path invokes `comms-send?kind=booking_confirmation` and fires `booking.submitted` |
+| `confirmed` | Slot is committed | admin / agent (`manage_bookings` `update_status`) | Makes the booking eligible for the reminder sweep (`comms-send?kind=booking_reminders`: starts <24h + `reminder_sent_at IS NULL` → one email, then stamped) and for SLA confirmation monitoring |
 | `completed` | Meeting happened | admin / agent (`update_status`) | Terminal bookkeeping — no side effects |
 | `no_show` | Confirmed but customer did not attend | admin / agent (`update_status`, only meaningful for past confirmed bookings — UI gates on `start_time` in the past) | Terminal; keeps the no-show on record for the customer history |
 | `cancelled` | Called off | admin / agent (`manage_bookings` `cancel` or `update_status`) | Stamps `cancelled_at` (+ optional `cancelled_reason`); the slot is freed immediately — overlap checks exclude cancelled bookings |
@@ -112,9 +112,9 @@ assignment, no-show and cancellation run through `manage_bookings`
 | Service setup | ✅ (BookingServicesTab) | ✅ (`manage_booking_availability`) | — |
 | Availability check | — | ✅ (`check_availability` — free_slots) | ✅ Stage-3 verified 2026-07-04 |
 | Booking | ✅ (public block, CreateBookingDialog) | ✅ (`book_appointment_slot`, legacy `book_appointment`) | ✅ Stage-3 verified 2026-07-04 (overlap rejection incl.) |
-| Confirmation email | — | auto (`send-booking-confirmation` on public-block booking) | — |
+| Confirmation email | — | auto (`comms-send?kind=booking_confirmation` on public-block booking) | — |
 | Confirm / status | ✅ | ✅ (`manage_bookings` `update_status`) | ✅ |
-| Reminder | — | auto (`booking-reminders` cron → `send-booking-reminders`) | — |
+| Reminder | — | auto (`booking-reminders` cron → `comms-send?kind=booking_reminders`) | — |
 | Staff assignment | ✅ (BookingsPage) | ✅ (`manage_bookings` `assign_staff`) | ✅ |
 | No-show / complete | ✅ | ✅ (`update_status`) | ✅ |
 | Voice intake | — | ✅ (booking IVR runs the same skills) | — |

--- a/docs/processes/process-review-odoo-smb.md
+++ b/docs/processes/process-review-odoo-smb.md
@@ -42,7 +42,7 @@ customer conversation:
   human-only although `allocate_picking`/`confirm_pick`/`ship_picking` and
   partial fulfillment are agent-runnable. Cycle counting just went dual-surface.
 - **register-to-attend.md** said reminders are "event emission only" — the
-  `send-webinar-reminders` sweep now delivers all four windows itself and
+  `comms-send?kind=webinar_reminders` sweep now delivers all four windows itself and
   wires `follow_up_sent`. Bumped L3 → L4; parity 78% → 89% updated.
 - **support-to-resolution.md** listed multi-channel and CSAT as flat missing —
   email→ticket is verified E2E and feedback capture/analysis exists (the doc

--- a/docs/processes/register-to-attend.md
+++ b/docs/processes/register-to-attend.md
@@ -89,7 +89,7 @@ completed / cancelled`)
 |---|---|---|---|
 | (created) | Person is registered | visitor (WebinarBlock) / agent (`register_webinar`) | Lead auto-linked by email or created (`source=webinar`, +15 score); upsert on `(webinar_id, email)` — re-registering never duplicates; emits `webinar.registered` |
 | `attended` | Showed up (default false) | admin / agent (`mark_webinar_attendance`) | On `attended=true` with a linked lead: +10 lead score; emits `webinar.attended` |
-| `reminder_confirm/t24/t1/post_sent_at` | Reminder markers | `send-webinar-reminders` sweep ('Webinar Reminders' automation, every 15 min) | **Sends the email** (confirm / T-24h / T-1h / post via `email-send`) and stamps the marker — one send per registration per stage, never re-sent. The `webinar.reminder.*` platform events also fire for custom rules |
+| `reminder_confirm/t24/t1/post_sent_at` | Reminder markers | `comms-send?kind=webinar_reminders` sweep ('Webinar Reminders' automation, every 15 min) | **Sends the email** (confirm / T-24h / T-1h / post via `email-send`) and stamps the marker — one send per registration per stage, never re-sent. The `webinar.reminder.*` platform events also fire for custom rules |
 | `follow_up_sent` | Follow-up done (default false) | the post window of the same sweep | Sends thanks (attended) or missed-you (absent), including the recording link when set, and stamps the flag |
 
 ### Who does what
@@ -126,7 +126,7 @@ visitors, chat and MCP operators all use the same RPC.
 
 ## Known gaps (missing for L4/L5)
 
-- ✅ Reminder **delivery** shipped 2026-07-05 — `send-webinar-reminders` edge
+- ✅ Reminder **delivery** shipped 2026-07-05 — `comms-send?kind=webinar_reminders` (formerly `send-webinar-reminders`) edge
   function sweeps all four windows (confirm / T-24h / T-1h / post) and sends
   the emails itself via `email-send`, stamped once per registration; runs as
   the built-in 'Webinar Reminders' automation every 15 min (skill:

--- a/docs/reference/headless-api.md
+++ b/docs/reference/headless-api.md
@@ -709,7 +709,7 @@ The agent receives only the tools from the requested groups. Without the paramet
 mcp_url: https://example.supabase.co/functions/v1/mcp-server?groups=crm,commerce,content,analytics,system
 ```
 
-This reduces ~300 tools down to ~25, keeping accuracy high while maintaining full operational coverage.
+This reduces ~500 tools down to ~25, keeping accuracy high while maintaining full operational coverage.
 
 ### Research References
 

--- a/docs/reference/module-api.md
+++ b/docs/reference/module-api.md
@@ -696,14 +696,18 @@ External systems can act as modules via webhooks:
 
 ### Inbound Webhook (External → FlowWink)
 
+The inbound endpoint is `signal-ingest` (there is no dedicated
+`module-webhook` function). It accepts signals from any external operator
+(webhooks, browser extension, integrations), stores them in
+`agent_memory`/`agent_activity`, and fires automation signals:
+
 ```
-POST /functions/v1/module-webhook
+POST /functions/v1/signal-ingest
 Content-Type: application/json
-X-Module-Secret: your-secret
+Authorization: Bearer <site_settings.signal_ingest_token>
 
 {
-  "module_id": "external-crm",
-  "action": "lead.created",
+  "note": "signal: lead.created from external-crm",
   "payload": {
     "email": "user@example.com",
     "name": "John Doe"

--- a/scripts/deploy-edge-via-api.sh
+++ b/scripts/deploy-edge-via-api.sh
@@ -18,7 +18,7 @@
 #   bash scripts/deploy-edge-via-api.sh <project-ref> <function-name> [--verify-jwt]
 #
 # Example:
-#   SBP_TOKEN=sbp_xxx bash scripts/deploy-edge-via-api.sh lcztuuaxulxivhbnkcpm ai-task
+#   SBP_TOKEN=sbp_xxx bash scripts/deploy-edge-via-api.sh ydcrzguzfipraofvpegu ai-task
 #
 # Notes:
 #   * Public/agent-called functions deploy with verify_jwt=false by default; pass

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1063,7 +1063,7 @@
     },
     "edge_functions": {
       "count": 75,
-      "shared_hash": "sha256:861d02dc5123f4e42664c152157af207477648e37f669ce84a68a14dfd377480",
+      "shared_hash": "sha256:a5116a1e8dbdc1ea98dd5b0dfcc616706d6f77d0728098f85735cb523527349a",
       "functions": {
         "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",


### PR DESCRIPTION
## Vad

Docs-svepet efter skill-count-revisionen och edge-surface-refaktorn, enligt beslutet **"vi behöver inte arkivera — bättre beskriva vad vi har nu"**: varje dokument uppdateras på plats till nuläget, inget flyttas.

## Ändringar

**Parity — sanna statusar (verifierade mot matris + kod, inte gissade):**
- `sprint-floor-wave1` → **completed**: companies 93% (mål ≥55), returns 100% (≥50), calendar 92% (≥40); handbook klassas nu som differentiator.
- `sprint-p1-subscribe-to-renew` → **completed**: `invoicing.recurring` och `subscriptions.proration` båda done (live-E2E-verifierade i scorecards).
- `sprint-pipeline-consolidation` → **completed**: alla fyra gate-capabilities done; `/admin/pipelines` och approvals-rutterna är konsoliderade (redirects verifierade i `App.tsx`).
- `program-80`: current state 2026-07-21 — mean **89%** (var 60%), sämst contact-center 41%; gamla blockers markerade lösta.

**Edge-ytan — beskriver 75-funktioners-nuläget:**
- `operators/edge-function-tiers.md` omskriven: konsolideringarna (`flowpilot-lifecycle`, `comms-send`, `integrations-account`, `internal:`-handlers), pekar på `edge-surface-classification.md` + `edge-function-registry.ts` som sanningskällor.
- `guides/setup.md`: den stale funktionstabellen (44 rader, många spöken) ersatt med registry-pekare + strukturnoter; **`publish-scheduled-pages`-cron-instruktionen** (exakt den ghost-fn som 404:ade i juli-incidenterna) ersatt med den faktiska SQL-funktionsmekanismen; Free-cap-påståendena rättade (75 ryms); `sitemap-xml` → `sitemap`.
- `guides/security.md`: auth-kategoriexemplen bytta till funktioner som finns.

**Döda referenser:**
- `modules/federation.md` (manual: true): clawstack Agent Bridge → dekommissionerad, ersatt med nuvarande A2A/gateway-verklighet (OpenClaw via `?mode=dispatch`).
- `architecture/flowpilot-2.0.md`: skill-curator/learn/distill beskrivs som `flowpilot-lifecycle`-tasks.
- `reference/headless-api.md`: ~300 tools → ~500.
- `scripts/deploy-edge-via-api.sh`: exempel-ref → nya demo-instansen.
- `docs/README.md`: modulantal 67 (verifierat via `check-doc-drift`), + en rad som dokumenterar beskriv-nu-konventionen.

## Verifiering

- `bun run scripts/check-doc-drift.ts` → grön (67 moduler).
- Sprint-utfall kontrollerade mot `parity-matrix.md`, capabilities-JSON och rutterna i `src/App.tsx`.
- Inga kodfiler ändrade (endast docs + en scriptkommentar); rör inte lokala Claudes exklusiva filer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_