### PR TITLE
fix: dead edge refs + verify_jwt gaps + table-ownership guardrail

### DIFF
--- a/scripts/deploy-fleet.sh
+++ b/scripts/deploy-fleet.sh
@@ -34,7 +34,7 @@ FLEET_JSON="$(dirname "$0")/fleet.json"
 # Edge functions changed in the current release. Override via EDGE_FNS=… .
 # All are agent/server/webhook/cron-invoked → must deploy with --no-verify-jwt
 # (an interactive admin JWT is never present on these call paths).
-EDGE_FNS="${EDGE_FNS:-agent-execute ai-task composio-proxy composio-webhook survey-send update-autonomy-cron}"
+EDGE_FNS="${EDGE_FNS:-agent-execute ai-task composio-proxy composio-webhook}"
 
 ref_for() {
   node -e "const f=require('$FLEET_JSON');const i=f.instances.find(x=>x.name==='$1');if(!i){console.error('unknown instance: $1');process.exit(1)}process.stdout.write(i.ref)"

--- a/src/lib/__tests__/table-ownership.guardrails.test.ts
+++ b/src/lib/__tests__/table-ownership.guardrails.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+/**
+ * Table-ownership guardrail — keeps modules self-contained.
+ *
+ * WHY THIS EXISTS
+ * ----------------
+ * Modularity is FlowWink's core value, but three agents (Claude local, Lovable,
+ * Claude cloud) commit concurrently and cross-module raw-table access creeps in:
+ * an *invoicing* dialog reading `time_entries` directly, a *purchasing* panel
+ * reading `products`, etc. Every such `.from('foreign_table')` is an undeclared
+ * schema dependency — the owning module can't change its tables without an
+ * unknowable blast radius. The sanctioned rails are `callSkill()` (routes through
+ * agent-execute with audit + trust) or a hook exported by the owning domain.
+ *
+ * WHAT IT ASSERTS
+ * ---------------
+ * 1. SINGLE OWNERSHIP: every table appears in at most one module's
+ *    `data.tables`. A table claimed by two modules is ambiguous ownership —
+ *    fix by declaring one owner (or extend the CO_OWNED allowlist deliberately).
+ * 2. NO NEW CROSS-MODULE UI READS: a file under `components/admin/<domain>/`
+ *    whose domain maps to module A must not `.from()` a table owned by module B.
+ *    The current offenders are frozen in GRANDFATHERED below — they are debt to
+ *    pay down, but only *new* violations fail this test. To clear one, route the
+ *    read through `callSkill` / an owning-domain hook and delete its entry.
+ *
+ * This is a static, self-contained check (no DB, no runtime) in the same spirit
+ * as the other *.guardrails.test.ts files.
+ */
+
+const ROOT = join(__dirname, '..', '..', '..');
+const MODULES_DIR = join(ROOT, 'src', 'lib', 'modules');
+const ADMIN_DIR = join(ROOT, 'src', 'components', 'admin');
+
+/** Admin UI sub-directory → the module that owns it. Only unambiguous dirs are
+ *  listed; dirs not here are skipped (shared/cross-cutting UI). */
+const DIR_TO_MODULE: Record<string, string> = {
+  invoices: 'invoicing', crm: 'crm', accounting: 'accounting', hr: 'hr', blog: 'blog',
+  expenses: 'expenses', timesheets: 'timesheets', quotes: 'quotes', contracts: 'contracts',
+  projects: 'projects', tickets: 'tickets', bookings: 'bookings', inventory: 'inventory',
+  purchasing: 'purchasing', recruitment: 'recruitment', subscriptions: 'subscriptions',
+  newsletter: 'newsletter', surveys: 'surveys', webinars: 'webinars', pos: 'pos',
+  deals: 'deals', companies: 'companies', reconciliation: 'reconciliation',
+};
+
+/** Tables deliberately shared by more than one module (declare with a reason). */
+const CO_OWNED = new Set<string>([
+  // (none today — every table has a single owner)
+]);
+
+/**
+ * Frozen baseline of existing cross-module UI reads (file::table). These are
+ * pre-existing debt captured 2026-07-23; the guardrail fails only on NEW
+ * violations. Pay one down by routing through callSkill / an owning-domain hook,
+ * then delete its line here.
+ */
+const GRANDFATHERED = new Set<string>([
+  'src/components/admin/accounting/EventsToBookTab.tsx::bank_transactions',
+  'src/components/admin/inventory/InventoryParityPanels.tsx::products',
+  'src/components/admin/inventory/InventoryV2Panels.tsx::products',
+  'src/components/admin/inventory/InventoryV2Panels.tsx::vendors',
+  'src/components/admin/invoices/InvoiceFromTimesheetsDialog.tsx::leads',
+  'src/components/admin/invoices/InvoiceFromTimesheetsDialog.tsx::projects',
+  'src/components/admin/invoices/InvoiceFromTimesheetsDialog.tsx::time_entries',
+  'src/components/admin/purchasing/AutoReorderSettings.tsx::product_stock',
+  'src/components/admin/purchasing/PurchaseOrderEditor.tsx::products',
+  'src/components/admin/purchasing/VendorProductsManager.tsx::products',
+  'src/components/admin/tickets/TicketKbSuggestions.tsx::kb_articles',
+]);
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    const s = statSync(p);
+    if (s.isDirectory()) walk(p, acc);
+    else if (/\.tsx?$/.test(e)) acc.push(p);
+  }
+  return acc;
+}
+
+/** Build table → owning-module from each module def's `data.tables`. */
+function buildTableOwners(): { owner: Map<string, string>; multi: Array<[string, string, string]> } {
+  const owner = new Map<string, string>();
+  const multi: Array<[string, string, string]> = [];
+  for (const f of readdirSync(MODULES_DIR).filter((f) => f.endsWith('-module.ts'))) {
+    const src = readFileSync(join(MODULES_DIR, f), 'utf8');
+    const idm = src.match(/id:\s*['"]([a-zA-Z0-9_]+)['"]/);
+    const modId = idm ? idm[1] : f.replace('-module.ts', '');
+    const dm = src.match(/data:\s*\{[\s\S]*?tables:\s*\[([\s\S]*?)\]/);
+    if (!dm) continue;
+    for (const m of dm[1].matchAll(/['"]([a-z_][a-z0-9_]*)['"]/g)) {
+      const t = m[1];
+      if (CO_OWNED.has(t)) continue;
+      if (owner.has(t) && owner.get(t) !== modId) multi.push([t, owner.get(t)!, modId]);
+      else if (!owner.has(t)) owner.set(t, modId);
+    }
+  }
+  return { owner, multi };
+}
+
+describe('table-ownership guardrail', () => {
+  const { owner, multi } = buildTableOwners();
+
+  it('every table is owned by exactly one module (declare shared tables in CO_OWNED)', () => {
+    expect(
+      multi,
+      `Tables claimed by two modules' data.tables:\n${multi
+        .map(([t, a, b]) => `  ${t}: ${a} vs ${b}`)
+        .join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('no NEW cross-module raw-table read from an admin domain directory', () => {
+    const violations: string[] = [];
+    for (const fp of walk(ADMIN_DIR)) {
+      const rel = relative(ROOT, fp).split('\\').join('/');
+      const m = rel.match(/components\/admin\/([^/]+)\//);
+      if (!m || !DIR_TO_MODULE[m[1]]) continue;
+      const fileOwner = DIR_TO_MODULE[m[1]];
+      const src = readFileSync(fp, 'utf8');
+      for (const call of src.matchAll(/\.from\(\s*['"]([a-z_][a-z0-9_]*)['"]/g)) {
+        const tbl = call[1];
+        const tblOwner = owner.get(tbl);
+        if (tblOwner && tblOwner !== fileOwner && !GRANDFATHERED.has(`${rel}::${tbl}`)) {
+          violations.push(`${rel} — ${fileOwner} reads ${tbl} (owned by ${tblOwner})`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `New cross-module raw-table access. Route through callSkill() or an owning-\n` +
+        `domain hook instead of .from(foreign_table). Offenders:\n  ${violations.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('grandfathered offenders still exist (prune the allowlist as debt is paid)', () => {
+    // Keeps the allowlist honest: once a read is removed from the code, its line
+    // here must be deleted too, or this fails — preventing a stale allowlist from
+    // silently re-permitting a re-introduced violation.
+    const live = new Set<string>();
+    for (const fp of walk(ADMIN_DIR)) {
+      const rel = relative(ROOT, fp).split('\\').join('/');
+      const src = readFileSync(fp, 'utf8');
+      for (const call of src.matchAll(/\.from\(\s*['"]([a-z_][a-z0-9_]*)['"]/g)) {
+        live.add(`${rel}::${call[1]}`);
+      }
+    }
+    const stale = [...GRANDFATHERED].filter((g) => !live.has(g));
+    expect(stale, `Stale allowlist entries (read is gone — delete these lines):\n  ${stale.join('\n  ')}`).toEqual([]);
+  });
+});

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -205,3 +205,19 @@ verify_jwt = false
 # pg_cron POSTs (learn/followthrough) + heartbeat's internal hop. The task
 # that was JWT-gated standalone (distill) keeps an in-body gate in index.ts.
 verify_jwt = false
+
+[functions.document-share]
+# Anon-callable: resolves a share token and streams/redirects to the file.
+# Auth is the share token itself, not a JWT. Was silently verify_jwt=true
+# (default) → 401 for every share-link recipient on sb_publishable_ keys.
+verify_jwt = false
+
+[functions.agent-card]
+# Public federation discovery card — external peers probe it anonymously.
+# Advertises capabilities (Cache-Control: public). Must be anon-reachable.
+verify_jwt = false
+
+[functions.chat-stt]
+# Public chat-widget speech-to-text (publishable key). Stateless Whisper
+# transcription, no DB access. Was 401ing on sb_publishable_ keys.
+verify_jwt = false

--- a/supabase/functions/quote-expiry-reminders/index.ts
+++ b/supabase/functions/quote-expiry-reminders/index.ts
@@ -68,11 +68,11 @@ Deno.serve(async (req: Request) => {
       }
       const url = `${origin}/quote/${token}`;
       try {
-        const { data: sendData, error: sendErr } = await supabase.functions.invoke('send-quote-email', {
-          body: { quote_id: q.id, public_url: url, reminder: true },
+        const { data: sendData, error: sendErr } = await supabase.functions.invoke('comms-send', {
+          body: { kind: 'quote_email', quote_id: q.id, public_url: url, reminder: true },
         });
         if (sendErr) throw new Error(sendErr.message);
-        if (!sendData?.success) throw new Error(sendData?.error || 'send-quote-email returned failure');
+        if (!sendData?.success) throw new Error(sendData?.error || 'comms-send quote_email returned failure');
 
         await supabase.from('quotes')
           .update({ expiry_reminder_sent_at: new Date().toISOString() })

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1128,7 +1128,7 @@
         "openclaw-responses": "sha256:70efb4b23cd1fb08427337148ccd47097d30a0e746bb27ad17120b39498dec3b",
         "process-image": "sha256:b7a65c7cf8f1b80ec4ae22aec5ab2ec7521ead15ee3f96e08921da90ed41b985",
         "process-job-application": "sha256:559beb704d521c604e18ae8766fff1eb3c279441365a96eb48a661132b6f0c21",
-        "quote-expiry-reminders": "sha256:24aa1a31cde557f25afef96394e6fee6f36c36e2ab29d479157618ea54bdb3b1",
+        "quote-expiry-reminders": "sha256:6d9b763668aefb9948af581d5d54f52879814f964f61f8cca345db4e57805034",
         "quote-pay": "sha256:f42a8accc1489304c32b0e3a2c5f30188faa898e48e9323698ed624ca9aea296",
         "quote-sign": "sha256:c7b303564411e34fef83893c5f615576baa50e657eba64628f403ff386436f78",
         "run-autonomy-tests": "sha256:1686a331e5859a2a70df6961eb9610a75e387c55c333fc89f1edcd412c86cf7c",


### PR DESCRIPTION
Follow-ups from the 2026-07-23 architecture review — the fast in-domain fixes + the structural guardrail. (The P0 anon-writable demo-seed RPCs already merged in #134.)

## Buggfixar

- **`quote-expiry-reminders` var 100% trasig** — anropade den raderade `send-quote-email` → 404 varje körning, `expiry_reminder_sent_at` stämplades aldrig, cron retryade för evigt men rapporterade `success`. Repointad till `comms-send` kind `quote_email` (identisk body: `quote_id`/`public_url`/`reminder`, verifierat mot `quote_email.ts`).
- **`deploy-fleet.sh` avbröt fleet-deploy mitt i** — default-`EDGE_FNS` namngav raderade `survey-send` + `update-autonomy-cron`; `set -e` dödade scriptet *efter* migrationer men *före* skill-sync = exakt den schema/skills-drift runbooken varnar för. Borttagna.
- **`config.toml`** — la till `verify_jwt = false` för `document-share` (delningslänkar 401:ade för *alla* mottagare på `sb_publishable_`-nycklar), `agent-card` (anonym peer-discovery), `chat-stt` (publik widget-STT, ingen DB-åtkomst). Alla tre saknade entry → default JWT-gated.

## Ny guardrail — `table-ownership.guardrails.test.ts`

Dödar en driftklass som tre samtidiga agenter annars matar:
- varje tabell har **exakt en ägarmodul** (214 tabeller, 0 konflikter);
- **inga NYA** cross-module råa `.from(främmande_tabell)` från en admin-domänmapp — dagens 11 överträdelser frysta som `GRANDFATHERED`-skuld, nya fälls i CI;
- en tredje check håller allowlisten ärlig (borttagen läsning ⇒ raden måste bort).

## Medvetet INTE gjort

- **`generate-invoice-pdf` verify_jwt** — hämtar vilken faktura som helst på `invoice_id` utan token-gate; att göra den publik skulle exponera alla fakturor. Kräver publik-token-gate (som quotes `accept_token`) först — flaggat för riktig fix, inte enradsfix.

## Rapporterat (ej fixat — andra agenters filer)

- `agent-execute:7284` anropar raderade `reconciliation`-fn (→ `executeReconciliation`); `firecrawl-map` död referens i `site-migration-module` + `useCopilot`.

## Verifiering

Nya guardrailen + edge-registry- och verify-jwt-guardrailsen gröna; `deploy-fleet.sh` bash-syntax OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_