### PR TITLE
fix(security): gate generate-invoice-pdf (public_token for anon, admin for invoice_id)

### DIFF
--- a/src/pages/PublicInvoicePage.tsx
+++ b/src/pages/PublicInvoicePage.tsx
@@ -71,7 +71,7 @@ export default function PublicInvoicePage() {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY}`,
           },
-          body: JSON.stringify({ invoice_id: invoice.id }),
+          body: JSON.stringify({ public_token: token }),
         }
       );
       if (!resp.ok) throw new Error('PDF download failed');

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -221,3 +221,9 @@ verify_jwt = false
 # Public chat-widget speech-to-text (publishable key). Stateless Whisper
 # transcription, no DB access. Was 401ing on sb_publishable_ keys.
 verify_jwt = false
+
+[functions.generate-invoice-pdf]
+# Public path uses the per-invoice public_token (anon, unguessable); the
+# invoice_id path is admin/service-gated in-body (requireServiceOrRole). Kept
+# --no-verify-jwt so the public token path reaches it with the publishable key.
+verify_jwt = false

--- a/supabase/functions/generate-invoice-pdf/index.ts
+++ b/supabase/functions/generate-invoice-pdf/index.ts
@@ -1,5 +1,6 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
 import { getServiceClient } from '../_shared/supabase-clients.ts';
+import { requireServiceOrRole, unauthorized } from '../_shared/edge-auth.ts';
 import { PDFDocument, StandardFonts, rgb } from "https://esm.sh/pdf-lib@1.17.1";
 
 const corsHeaders = {
@@ -14,22 +15,43 @@ Deno.serve(async (req) => {
   }
 
   try {
-    const { invoice_id } = await req.json();
-    if (!invoice_id) {
-      return new Response(JSON.stringify({ error: "invoice_id required" }), {
+    // Two access paths, mirroring the rest of the invoice surface:
+    //  • public_token → the unguessable per-invoice token (invoices.public_token,
+    //    same gate as get_invoice_by_token / create-invoice-payment). Anon OK.
+    //  • invoice_id   → admin/service only. WITHOUT this gate the function fetched
+    //    ANY invoice by id with the service client (RLS off) for any caller with
+    //    the publishable key — an open financial-document leak. (2026-07-23 fix.)
+    const { invoice_id, public_token } = await req.json();
+    if (!invoice_id && !public_token) {
+      return new Response(JSON.stringify({ error: "invoice_id or public_token required" }), {
         status: 400,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
 
-            const supabase = getServiceClient();
+    const supabase = getServiceClient();
 
-    // Fetch invoice with lead
-    const { data: invoice, error: invErr } = await supabase
-      .from("invoices")
-      .select("*, leads(id, name, email, company_id, companies(name))")
-      .eq("id", invoice_id)
-      .single();
+    // Resolve + authorize the invoice.
+    let invoice: any = null;
+    let invErr: { message: string } | null = null;
+    if (public_token) {
+      const { data, error } = await supabase
+        .from("invoices")
+        .select("*, leads(id, name, email, company_id, companies(name))")
+        .eq("public_token", public_token)
+        .maybeSingle();
+      invoice = data; invErr = error;
+    } else {
+      // invoice_id path — must be an admin or the service role.
+      const auth = await requireServiceOrRole(req, supabase, "admin");
+      if (!auth.authorized) return unauthorized(corsHeaders);
+      const { data, error } = await supabase
+        .from("invoices")
+        .select("*, leads(id, name, email, company_id, companies(name))")
+        .eq("id", invoice_id)
+        .single();
+      invoice = data; invErr = error;
+    }
 
     if (invErr || !invoice) {
       return new Response(

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1113,7 +1113,7 @@
         "flowpilot-heartbeat": "sha256:b63e2029bfb8ceb9a19e997454a2775f04cd5529d533825f688a91e682389719",
         "flowpilot-lifecycle": "sha256:4e133600886f67552cfa1501ce2116b72414c07ced34fca927d9a2188770a365",
         "gatewayapi-ingest": "sha256:9daeb71012e0b49d3eee1583d2511a50224cec4e1b69de46a471e1a63d7f066a",
-        "generate-invoice-pdf": "sha256:806a69f2634cf908d4291332f5595f5ec3c1c6c3f7fb27b4ef9e820eaf8a8f23",
+        "generate-invoice-pdf": "sha256:7884b26bb71e22e6e89a1b4429fc9f47a9bac20826008abca71ad213fb365901",
         "get-page": "sha256:29eb67b2b03b57f65c68c681124330c7ef65371108422c6013beaa59cd1b8216",
         "gmail-oauth-callback": "sha256:d218314ac81ba20bd9aa009f41a06112e30c504f7d99b4affb4df90046740606",
         "instance-health": "sha256:19ed2278f4b6656d7923caf70627fe107e529a53ac7f3c5327117bccc55cbf1a",


### PR DESCRIPTION
Closes the invoice-leak deferred from #136 (2026-07-23 architecture review).

## Problemet

`generate-invoice-pdf` körde privilegierat arbete med service-klienten (RLS av) och hämtade **vilken faktura som helst på `invoice_id`** för vilken anropare som helst. Den publika nyckeln som ligger i JS-bundlen passerar gatewayen, så vem som helst kunde gissa/enumerera ett id och dra ut en kunds faktura-PDF.

## Fixen

Två åtkomstvägar, som speglar resten av faktura-ytan (`get_invoice_by_token` och `create-invoice-payment` fungerar redan så):

- **`public_token`** → den ogissningsbara per-faktura-token (`invoices.public_token`, unik + indexerad, alla 33 dev-fakturor har den). Anon OK. `PublicInvoicePage` skickar nu token den redan laddade sidan med, inte `invoice.id`.
- **`invoice_id`** → `requireServiceOrRole(admin)`. Legitima anropare passerar: admin-`InvoiceDetailSheet` (session-JWT), `comms-send/invoice_email` (service-nyckel).

`config.toml`: `verify_jwt=false` så publik-token-vägen når funktionen med publishable-nyckeln; in-body-gaten skyddar id-vägen.

## Rapporterat (lokala Claudes fil — ej rört)

`agent-execute:6756` mailar kunden en `?invoice_id=`-GET-länk till denna funktion — redan icke-funktionell (handlern läser bara POST-body) och nu definitivt admin-gatead; bör maila `/invoice/<public_token>`-sidlänken istället.

## Verifiering

- Alla tre mina anropare säkra (admin-JWT / service-nyckel / public_token).
- Dev-data verifierad: 33/33 fakturor har `public_token`.
- Manifest regenererat; instans-manifest-guardrailen grön.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_