### PR TITLE
fix(blocks): unblock red main (10 missing block contracts) + ⌘K handoff note

### DIFF
--- a/docs/operators/session-memory.md
+++ b/docs/operators/session-memory.md
@@ -323,6 +323,31 @@ crosses into another module's table, declare co-ownership in that module's
 `data.tables` or route via a skill. 21/67 modules still lack `data.tables` — worth
 completing so the ownership map is total.
 
+**⇄ Cloud → whoever picks it up (2026-07-25) — ⌘K quick-create bugs (frontend).**
+From the same review. These live in `src/components/admin/QuickCreateMenu.tsx`
+(the `+` menu, `ACTIONS`) and `src/components/admin/AdminSearchCommand.tsx` (⌘K,
+`QUICK_ACTIONS`) — Lovable's hot files (`AdminSearchCommand` had a "Work in
+progress" commit the evening of 07-24, and Lovable was live in this area wiring
+`LoadDemoDataButton`). **Collision-safe path: let Lovable do it (its files) or
+whoever grabs it once Lovable is idle.** Not urgent, still unfixed on main as of
+`9ca85afd2`:
+1. Wrong module id `'media'` → **`'mediaLibrary'`** (real key in useModules.tsx)
+   in BOTH files (`QuickCreateMenu`~L43, `AdminSearchCommand`~L99). Today the
+   Media action shows when the module is off (⌘K) / never shows (+ menu).
+2. "Time entry" gated on `'projects'` → **`'timesheets'`** (its own module) in
+   both (`QuickCreateMenu`~L48, `AdminSearchCommand`~L103).
+3. ⌘K "New task" (`AdminSearchCommand`~L102) → `/admin/projects?new=task` opens
+   the *New Project* dialog; use the real `CreateTaskDialog` the `+` menu uses.
+4. "New campaign" (`AdminSearchCommand`~L98) gated on `'paidGrowth'` but the nav
+   (`adminNavigation.ts:103`) gates `/admin/campaigns` on `'developer'` — pick one.
+5. The two registries are hand-duplicated and already drifting — extract ONE
+   shared list (e.g. `src/components/admin/quickActions.ts`) both surfaces consume.
+6. Double ⌘K dialog: `CopilotPage.tsx` registers its own listener + dialog on top
+   of the global one in `AdminSidebar` — remove the CopilotPage instance.
+Note: Lovable's `LoadDemoDataButton` calls `seed_module_demo` — that RPC was
+admin/service-gated in #134; the button runs as an authenticated admin so it
+passes. No break, just so you know the intersection is intentional.
+
 ---
 
 0. ~~Flowtable/Flowwork deploy nudge on rzhj~~ **DONE 2026-07-14** — all

--- a/src/test/platform/block-quality.test.ts
+++ b/src/test/platform/block-quality.test.ts
@@ -19,6 +19,8 @@
  * because that module uses Deno-style imports incompatible with vitest.
  */
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 import { BLOCK_REFERENCE, getImportableBlockTypes } from "@/lib/block-reference";
 
 // ─── Mirrored from _shared/normalize-blocks.ts ────────────────────────────────
@@ -208,6 +210,17 @@ const BLOCK_CONTRACTS: Record<string, { required: string[][]; forbidden?: string
   'latest-posts':     { required: [] },
   'bento-grid':       { required: [['items']] },
   'notification-toast': { required: [['notifications']] },
+  // Added 2026-07-25 — mirror of normalize-blocks.ts (keep the two in sync).
+  'parallax-section': { required: [['title', 'backgroundImage']] },
+  'section-divider':  { required: [] },
+  'featured-carousel': { required: [['slides']] },
+  'sticky-scroll':    { required: [['chapters']] },
+  'ai-faq':           { required: [] },
+  'pricing-calculator': { required: [['variables', 'basePrice']] },
+  'quick-links':      { required: [['links']] },
+  'chat-launcher':    { required: [] },
+  'ai-assistant':     { required: [] },
+  contact:            { required: [] },
 };
 
 function validateBlockContracts(blocks: Record<string, unknown>[]): void {
@@ -1188,6 +1201,34 @@ describe("Block schema coverage — contracts and tiptap fields align with block
       orphaned,
       `Orphaned BLOCK_CONTRACTS entries for non-importable types: ${orphaned.join(', ')}`,
     ).toHaveLength(0);
+  });
+
+  // The mirror above is hand-maintained. It HAD silently drifted (it carried
+  // `popup` and `latest-posts` entries the runtime gate never had), which is
+  // invisible because every other test here reads the mirror, not the source.
+  // This asserts the two key sets match, so updating one without the other fails.
+  it("the BLOCK_CONTRACTS mirror matches normalize-blocks.ts (no silent drift)", () => {
+    const source = readFileSync(
+      resolve(__dirname, '../../../supabase/functions/_shared/normalize-blocks.ts'),
+      'utf8',
+    );
+    const seg = source.slice(
+      source.indexOf('export const BLOCK_CONTRACTS'),
+      source.indexOf('export function validateBlockContracts'),
+    );
+    const sourceKeys = new Set(
+      [...seg.matchAll(/^\s+('?[a-zA-Z][a-zA-Z-]*'?):\s*\{\s*required/gm)]
+        .map(m => m[1].replace(/'/g, '')),
+    );
+    const mirrorKeys = new Set(Object.keys(BLOCK_CONTRACTS));
+    const missingFromMirror = [...sourceKeys].filter(k => !mirrorKeys.has(k));
+    const missingFromSource = [...mirrorKeys].filter(k => !sourceKeys.has(k));
+    expect(
+      { missingFromMirror, missingFromSource },
+      `BLOCK_CONTRACTS drift between normalize-blocks.ts and this mirror — ` +
+      `add to mirror: [${missingFromMirror.join(', ')}]; ` +
+      `add to normalize-blocks.ts: [${missingFromSource.join(', ')}]`,
+    ).toEqual({ missingFromMirror: [], missingFromSource: [] });
   });
 
   it("every top-level tiptap field in BLOCK_REFERENCE is covered by TIPTAP_FIELDS", () => {

--- a/supabase/functions/_shared/normalize-blocks.ts
+++ b/supabase/functions/_shared/normalize-blocks.ts
@@ -259,6 +259,24 @@ export const BLOCK_CONTRACTS: Record<string, { required: string[][]; forbidden?:
   'article-grid':     { required: [] },
   'bento-grid':       { required: [['items']] },
   'notification-toast': { required: [['notifications']] },
+  // Were only in the test mirror — synced back so the runtime gate matches it.
+  popup:              { required: [] },
+  'latest-posts':     { required: [] },
+  // Added 2026-07-25: these became importable without contracts, which left the
+  // import gate skipping them entirely (and CI red). Permissive where the block
+  // has a designed empty state or auto-fetches its own data; a data requirement
+  // only where the block renders nothing at all without it (same convention as
+  // features/stats/testimonials above).
+  'parallax-section': { required: [['title', 'backgroundImage']] },
+  'section-divider':  { required: [] },   // pure layout (shape/colour), like `separator`
+  'featured-carousel': { required: [['slides']] },
+  'sticky-scroll':    { required: [['chapters']] },
+  'ai-faq':           { required: [] },   // has emptyStateText — empty is a designed state
+  'pricing-calculator': { required: [['variables', 'basePrice']] },
+  'quick-links':      { required: [['links']] },
+  'chat-launcher':    { required: [] },   // auto-connects to the chat endpoint
+  'ai-assistant':     { required: [] },   // auto-connects to the chat endpoint
+  contact:            { required: [] },   // renders a form; title/subtitle optional
 };
 
 /**

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1083,7 +1083,7 @@
     },
     "edge_functions": {
       "count": 75,
-      "shared_hash": "sha256:5d61c9de9346658ec4334bc582313d2fc364d8e5da7fab8feb756999b1b836b7",
+      "shared_hash": "sha256:9d95f1985b30c09ee76fb03c083193e8a313c713cbce4f9efa5707a2263a5024",
       "functions": {
         "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",


### PR DESCRIPTION
## 🔴 Huvudsaken: main var röd — nu grön

CI föll på den här PR:en trots att den var **docs-only** (1 markdown-fil). Orsak: **main själv var röd**, jag ärvde bara felet. Verifierat genom att köra testet direkt på `origin/main`.

Rot: 10 blocktyper blev importerbara 2026-07-24 utan `BLOCK_CONTRACTS`-poster → `block-quality.test.ts` föll på **varje** PR. Dessutom hoppade import-grinden (`validateBlockContracts`) över dem helt — en okontrakterad typ träffar `continue` och släpps igenom ovaliderad.

**Kontrakten är skrivna konservativt**, eftersom ett saknat required-fält **droppar blocket** vid import (`_remove`):

| Klass | Block | Kontrakt |
|---|---|---|
| Renderar inget utan sin array | `featured-carousel`, `sticky-scroll`, `quick-links`, `pricing-calculator` | kräver `slides` / `chapters` / `links` / `variables\|basePrice` — samma konvention som `features`/`stats` |
| Designat tomt-läge el. auto-hämtar | `ai-faq` (har `emptyStateText`), `chat-launcher`, `ai-assistant` (auto-kopplar, som undantagna `chat`), `contact`, `section-divider` (ren layout, som undantagna `separator`) | inget krav |
| Visuell hero-typ | `parallax-section` | `title\|backgroundImage` (endera räcker; ingendera = tom bard) |

## Bonus: stängde en tyst drift

Testets handunderhållna spegel bar `popup` och `latest-posts` som runtime-grinden **aldrig** haft — osynligt eftersom alla tester läser spegeln, inte källan. Synkade in båda i `normalize-blocks.ts` och la till ett test som jämför nyckelmängderna. **Negativt testat**: injicerad skenpost fäller det, borttagen passerar.

## Plus: ⌘K-handoffnoten (ursprungliga syftet)

Lovable-MCP:n var nere, så de sex ⌘K/quick-create-fynden ligger nu i `session-memory.md` för upplock (Lovables heta filer → den eller den som tar det när Lovable är idle). Dubbelarbets-koll gjord: buggarna kvarstår på main.

## Verifiering

Hela sviten grön (**1135 tester**). Manifest regenererat (`_shared`-hashen flyttades av edge-ändringen). Rörde **inte** `block-reference.ts` (Lovables fil).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5