### PR TITLE
feat(web-scrape): map mode — restores site discovery killed with firecrawl-map

### DIFF
--- a/docs/operators/session-memory.md
+++ b/docs/operators/session-memory.md
@@ -348,6 +348,46 @@ Note: Lovable's `LoadDemoDataButton` calls `seed_module_demo` — that RPC was
 admin/service-gated in #134; the button runs as an authenticated admin so it
 passes. No break, just so you know the intersection is intentional.
 
+**⇄ Cloud → local Claude (2026-07-25) — firecrawl-map: backend + my half are
+DONE, one line left in your file.** You left #3 for me to pair on; here's the
+pairing. `firecrawl-map` is gone from the repo, so I rebuilt discovery as a
+**map mode on `web-scrape`** (edge, my file) rather than resurrecting a function
+— the freeze principle says new capability goes on the existing kernel:
+
+```
+POST web-scrape { url, mode: 'map', search?, limit? }
+→ { success, provider, baseUrl, siteName, platform,
+    links: [url…],           // flat list — what YOUR discover action wants
+    pages: [DiscoveredPage],  // classified page/blog/kb/skip + selected
+    stats: { total, pages, blog, kb, skip, selected } }
+```
+Provider chain mirrors scrape mode: Firecrawl `/v1/map` when a key exists, else
+a **keyless sitemap.xml walk** (follows one level of sitemap-index), so discovery
+degrades instead of gating on a paid key (Law 4). `search` is applied server-side
+by Firecrawl and client-side on the sitemap path, so narrowing works either way.
+
+**Done by me:** the map mode + `useCopilot.ts:1183` repointed (and its user-facing
+copy no longer claims "Firecrawl" when the sitemap path answered).
+
+**Yours — `src/lib/modules/site-migration-module.ts:146`,** the `discover` case:
+```ts
+// was: invoke('firecrawl-map', { body: { url, options: { search, limit: 500 } } })
+const { data, error } = await supabase.functions.invoke('web-scrape', {
+  body: { url: validated.url, mode: 'map', search: validated.search, limit: 500 },
+});
+```
+Your existing `data?.links || data?.data || []` read keeps working unchanged —
+`links` is in the response for exactly that reason.
+
+Live-verified while building (real sites, no Firecrawl key → the fallback path):
+sitemap walk found 27 URLs on flowwink.com; classification correct on all 8 probe
+paths. Two real bugs the live run caught and I fixed: **stripe.com was detected as
+"woocommerce"** (the bare word appears in their integrations copy — and the caller
+AUTO-ENABLES modules from `platform`, so that would have switched on ecommerce for
+any site merely mentioning Woo; signatures are now asset/script URLs), and title
+parsing picked the longest segment, which gets both "tagline - Vercel" and
+"Stripe | tagline" wrong (now: shortest non-generic part, HTML entities decoded).
+
 ---
 
 0. ~~Flowtable/Flowwork deploy nudge on rzhj~~ **DONE 2026-07-14** — all

--- a/src/hooks/useCopilot.ts
+++ b/src/hooks/useCopilot.ts
@@ -1174,14 +1174,16 @@ export function useCopilot(): UseCopilotReturn {
     const discoverMessage: CopilotMessage = {
       id: generateId(),
       role: 'assistant',
-      content: `🔍 Discovering pages on ${url}...\n\nUsing Firecrawl Map to find all URLs.`,
+      content: `🔍 Discovering pages on ${url}...\n\nMapping the site to find all URLs.`,
       createdAt: new Date(),
     };
     setMessages(prev => [...prev, discoverMessage]);
 
     try {
-      const { data, error: fnError } = await supabase.functions.invoke('firecrawl-map', {
-        body: { url, options: { limit: 100 } },
+      // `firecrawl-map` was removed in the edge-surface consolidation; discovery
+      // now lives as web-scrape's map mode (Firecrawl → sitemap.xml fallback).
+      const { data, error: fnError } = await supabase.functions.invoke('web-scrape', {
+        body: { url, mode: 'map', limit: 100 },
       });
 
       if (fnError) throw new Error(fnError.message);

--- a/supabase/functions/web-scrape/index.ts
+++ b/supabase/functions/web-scrape/index.ts
@@ -22,6 +22,223 @@ interface WebScrapeInput {
   max_length?: number;
   formats?: string[];
   preferred_provider?: 'firecrawl' | 'jina' | 'auto';
+  /** 'scrape' (default) = one page to markdown. 'map' = discover a site's URLs. */
+  mode?: 'scrape' | 'map';
+  /** map only: narrow the URL set (Firecrawl `search`). */
+  search?: string;
+  /** map only: cap the number of URLs returned. */
+  limit?: number;
+}
+
+// ── map mode ────────────────────────────────────────────────────────────────
+// Absorbs the deleted `firecrawl-map` function (removed in the edge-surface
+// consolidation while two callers still invoked it → both 404'd: the Copilot
+// "discover pages" flow and siteMigration's `discover` action).
+//
+// Provider chain mirrors scrape mode: Firecrawl /v1/map when a key is available,
+// otherwise a keyless sitemap.xml walk — so discovery degrades instead of
+// gating on a paid key (Law 4).
+
+interface DiscoveredPage {
+  url: string;
+  path: string;
+  slug: string;
+  suggestedName: string;
+  suggestedType: 'page' | 'blog' | 'kb' | 'skip';
+  selected: boolean;
+  source: 'firecrawl-map' | 'sitemap';
+}
+
+/** URL-path heuristics — the same buckets the migration UI offers. */
+function classifyPath(path: string): 'page' | 'blog' | 'kb' | 'skip' {
+  const p = path.toLowerCase();
+  if (
+    /\.(xml|json|pdf|jpe?g|png|gif|svg|webp|ico|css|js|zip|mp4)$/.test(p) ||
+    /(^|\/)(wp-admin|wp-content|wp-json|cart|checkout|account|login|signin|signup|register|cdn-cgi)(\/|$)/.test(p) ||
+    /(^|\/)(tag|tags|category|categories|author|feed|rss|search)(\/|$)/.test(p) ||
+    /\/page\/\d+\/?$/.test(p)
+  ) return 'skip';
+  if (/(^|\/)(blog|news|nyheter|article|articles|post|posts|insights|stories)(\/|$)/.test(p)) return 'blog';
+  if (/(^|\/)(help|support|docs?|kb|knowledge|knowledgebase|faq|guides?|manual)(\/|$)/.test(p)) return 'kb';
+  return 'page';
+}
+
+/** "/our-team/leadership" → "Leadership"; "/" → "Home". */
+function suggestName(path: string): string {
+  const seg = path.split('/').filter(Boolean).pop();
+  if (!seg) return 'Home';
+  return seg
+    .replace(/\.[a-z0-9]+$/i, '')
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Extract <loc> URLs, following one level of sitemap-index nesting. */
+async function urlsFromSitemap(origin: string, limit: number): Promise<string[]> {
+  const seen = new Set<string>();
+  const readLocs = async (sitemapUrl: string): Promise<string[]> => {
+    try {
+      const res = await fetch(sitemapUrl, { headers: { 'User-Agent': 'FlowWink/1.0 (+site-discovery)' } });
+      if (!res.ok) return [];
+      const xml = await res.text();
+      return [...xml.matchAll(/<loc>\s*([^<\s]+)\s*<\/loc>/gi)].map((m) => m[1]);
+    } catch {
+      return [];
+    }
+  };
+
+  const top = await readLocs(`${origin}/sitemap.xml`);
+  const nested = top.filter((u) => /sitemap.*\.xml$/i.test(u));
+  const direct = top.filter((u) => !/sitemap.*\.xml$/i.test(u));
+  for (const u of direct) seen.add(u);
+
+  // Sitemap index → walk a bounded number of child sitemaps.
+  for (const child of nested.slice(0, 5)) {
+    if (seen.size >= limit) break;
+    for (const u of await readLocs(child)) {
+      if (!/sitemap.*\.xml$/i.test(u)) seen.add(u);
+      if (seen.size >= limit) break;
+    }
+  }
+  return [...seen].slice(0, limit);
+}
+
+/** One cheap homepage fetch → site name + CMS/commerce platform signature. */
+async function detectSite(origin: string): Promise<{ siteName: string; platform: string }> {
+  const host = (() => { try { return new URL(origin).hostname.replace(/^www\./, ''); } catch { return origin; } })();
+  try {
+    const res = await fetch(origin, { headers: { 'User-Agent': 'FlowWink/1.0 (+site-discovery)' } });
+    if (!res.ok) return { siteName: host, platform: 'unknown' };
+    const html = (await res.text()).slice(0, 200_000);
+    const title = html.match(/<title[^>]*>([^<]+)<\/title>/i)?.[1]?.trim();
+    // Match ASSET/SCRIPT signatures, never the bare brand word: stripe.com names
+    // "WooCommerce" in its integrations copy and was misdetected as WooCommerce —
+    // which matters, because the caller AUTO-ENABLES modules from this value.
+    // Order matters: WooCommerce is WordPress, so test the more specific one first.
+    const platform =
+      /wp-content\/plugins\/woocommerce|woocommerce\/assets|wc-ajax=/i.test(html) ? 'woocommerce'
+      : /\/wp-content\/|\/wp-includes\/|\/wp-json/i.test(html) ? 'wordpress'
+      : /cdn\.shopify\.com|Shopify\.theme|myshopify\.com/i.test(html) ? 'shopify'
+      : /static\.wixstatic\.com|static\.parastorage\.com/i.test(html) ? 'wix'
+      : /static1\.squarespace\.com|squarespace\.com\/universal/i.test(html) ? 'squarespace'
+      : /assets\.website-files\.com|assets-global\.website-files\.com|webflow\.js/i.test(html) ? 'webflow'
+      : /js\.hs-scripts\.com|js\.hsforms\.net|hs-analytics\.net/i.test(html) ? 'hubspot'
+      : 'unknown';
+    // Home titles are "Brand | tagline" (Stripe) or "tagline - Brand" (Vercel) —
+    // the brand sits on either side, but is reliably the SHORTEST part once
+    // generic page words are dropped. (Verified against real titles; picking the
+    // longest part gets both of those wrong.)
+    const GENERIC = /^(home|start|startsida|welcome|index|website|home ?page)$/i;
+    // Titles arrive HTML-escaped ("WordPress News &#8211; …"): decode first, or the
+    // separator hides inside an entity and the raw entity leaks into the UI.
+    const decoded = (title ?? '')
+      .replace(/&#(\d+);/g, (_, d) => String.fromCharCode(Number(d)))
+      .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCharCode(parseInt(h, 16)))
+      .replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&apos;/g, "'")
+      .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&nbsp;/g, ' ');
+    const parts = decoded
+      .split(/\s[|—–·-]\s/)
+      .map((s) => s.trim())
+      .filter((s) => s && !GENERIC.test(s));
+    // Nothing but generic words (a literal "Website" title) → the hostname says more.
+    const siteName = parts.length
+      ? parts.sort((a, b) => a.length - b.length)[0]
+      : host;
+    return { siteName, platform };
+  } catch {
+    return { siteName: host, platform: 'unknown' };
+  }
+}
+
+async function mapSite(
+  input: { url: string; search?: string; limit: number },
+  firecrawlKey: string | undefined,
+  firecrawlEnabled: boolean,
+): Promise<Response> {
+  const { url, search, limit } = input;
+  const origin = (() => { try { return new URL(url).origin; } catch { return url.replace(/\/+$/, ''); } })();
+
+  let links: string[] = [];
+  let provider = 'none';
+
+  if (firecrawlKey && firecrawlEnabled) {
+    try {
+      const res = await fetch('https://api.firecrawl.dev/v1/map', {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${firecrawlKey}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url, ...(search ? { search } : {}), limit }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const raw = data.links ?? data.data ?? [];
+        links = (Array.isArray(raw) ? raw : [])
+          .map((l: unknown) => (typeof l === 'string' ? l : (l as { url?: string })?.url))
+          .filter((l: unknown): l is string => typeof l === 'string' && !!l);
+        if (links.length) provider = 'firecrawl';
+      } else {
+        console.warn('[web-scrape:map] Firecrawl map failed:', res.status);
+      }
+    } catch (e) {
+      console.warn('[web-scrape:map] Firecrawl map error:', e);
+    }
+  }
+
+  if (!links.length) {
+    console.log('[web-scrape:map] Falling back to sitemap.xml for:', origin);
+    links = await urlsFromSitemap(origin, limit);
+    if (links.length) provider = 'sitemap';
+    // `search` has no server-side equivalent in the sitemap path — filter here so
+    // the caller's narrowing still applies regardless of which provider answered.
+    if (search) {
+      const needle = search.toLowerCase();
+      links = links.filter((l) => l.toLowerCase().includes(needle));
+    }
+  }
+
+  const { siteName, platform } = await detectSite(origin);
+
+  const pages: DiscoveredPage[] = links.map((link) => {
+    let path = '/';
+    try { path = new URL(link).pathname || '/'; } catch { /* keep '/' */ }
+    const suggestedType = classifyPath(path);
+    return {
+      url: link,
+      path,
+      slug: path.split('/').filter(Boolean).pop() || 'home',
+      suggestedName: suggestName(path),
+      suggestedType,
+      selected: suggestedType !== 'skip',
+      source: provider === 'firecrawl' ? 'firecrawl-map' : 'sitemap',
+    };
+  });
+
+  const stats = {
+    total: pages.length,
+    pages: pages.filter((p) => p.suggestedType === 'page').length,
+    blog: pages.filter((p) => p.suggestedType === 'blog').length,
+    kb: pages.filter((p) => p.suggestedType === 'kb').length,
+    skip: pages.filter((p) => p.suggestedType === 'skip').length,
+    selected: pages.filter((p) => p.selected).length,
+  };
+
+  console.log(`[web-scrape:map] ${pages.length} URLs via ${provider} (${stats.selected} pre-selected)`);
+
+  return new Response(JSON.stringify({
+    success: pages.length > 0,
+    mode: 'map',
+    provider,
+    baseUrl: origin,
+    siteName,
+    platform,
+    links,   // flat URL list — siteMigration's `discover` action reads this
+    pages,   // classified — the Copilot discovery UI reads this
+    stats,
+    ...(pages.length ? {} : { error: 'No URLs discovered (no Firecrawl key and no reachable sitemap.xml)' }),
+  }), {
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
 }
 
 async function getIntegrationConfig(): Promise<{
@@ -84,7 +301,10 @@ serve(async (req) => {
   }
 
   try {
-    const { url, max_length = 10000, formats = ['markdown'], preferred_provider = 'auto' } = await req.json() as WebScrapeInput;
+    const {
+      url, max_length = 10000, formats = ['markdown'], preferred_provider = 'auto',
+      mode = 'scrape', search, limit = 100,
+    } = await req.json() as WebScrapeInput;
 
     if (!url) {
       return new Response(JSON.stringify({ success: false, error: 'url is required' }), {
@@ -94,6 +314,15 @@ serve(async (req) => {
 
     const firecrawlKey = Deno.env.get('FIRECRAWL_API_KEY');
     const jinaKey = Deno.env.get('JINA_API_KEY');
+
+    if (mode === 'map') {
+      const cfg = await getIntegrationConfig();
+      return await mapSite(
+        { url, search, limit: Math.min(Math.max(Number(limit) || 100, 1), 1000) },
+        firecrawlKey,
+        cfg.firecrawlEnabled,
+      );
+    }
     let content = '';
     let metadata: Record<string, unknown> = {};
     let provider = 'none';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1157,7 +1157,7 @@
         "twilio-ingest": "sha256:957806d29e8500dda98b502a967694476a9fa4c4e35a803934ecaa1e2e204fe9",
         "voice-ingest": "sha256:b2f454ebef1846179377d7409780b4b8de014a1b1486dd91f84f2ecc9f1dd6df",
         "voice-recording": "sha256:41391de110f7f3e138df5c50b1901dd6c7928d2be18ad82fa5e166d48f66cca2",
-        "web-scrape": "sha256:9540495e1438a8a036c5ae60178f737be08ee5e6102abad155a818820ee13d82",
+        "web-scrape": "sha256:f0948362eb60ff2d597de407af0f3eedb3b0f892b75ce4acff960e0b6ebf146f",
         "web-search": "sha256:f8a514ea635ffa553da1cfd5e04aaf0adf159012df1981784c7da81af627c56e",
         "workspace-chat": "sha256:619043de41736dca0df6be8f8a91b06c09282d4af1ea211d29826367bc4a37ae"
       }


### PR DESCRIPTION
Sista posten från arkitekturgranskningen. `firecrawl-map` togs bort i edge-konsolideringen medan **två** anropare fortfarande använde den → båda 404:ade: Copilots "discover pages" och siteMigrations `discover`.

Byggd som ett **läge på befintlig kernel-funktion** i stället för att återuppliva en egen (frysprincipen).

```
POST web-scrape { url, mode:'map', search?, limit? }
→ { success, provider, baseUrl, siteName, platform,
    links[],   // flat — site-migration läser denna
    pages[],   // klassificerade page/blog/kb/skip + selected — Copilot-UI:t
    stats }
```

Båda formerna i ett svar, så ingen anropare behöver mappningslager.

**Provider-kedjan speglar scrape-läget:** Firecrawl `/v1/map` när nyckel finns, annars en **nyckellös sitemap.xml-vandring** (följer ett steg av sitemap-index) — discovery degraderar i stället för att gate:a på betald nyckel (Lag 4).

## Två riktiga buggar som live-testet fångade

Jag testade mot riktiga sajter **utan** Firecrawl-nyckel (alltså fallback-vägen), och det avslöjade två fel innan commit:

1. **stripe.com detekterades som `woocommerce`** — ordet står i deras integrationstext. Inte kosmetiskt: `useCopilot` **auto-aktiverar moduler** utifrån `platform`, så vilken sajt som helst som *nämner* Woo hade slagit på ecommerce-modulen. Signaturerna är nu asset/script-URL:er (`wp-content/plugins/woocommerce`, `cdn.shopify.com`, `static.wixstatic.com`…), inte varumärkesord.
2. **`siteName` tog längsta titelsegmentet** — fel för båda verkliga formerna ("tagline - Vercel", "Stripe | tagline"). Nu kortaste icke-generiska delen, med HTML-entiteter avkodade (`WordPress News &#8211; …` → `WordPress News`) och domännamn som fallback vid generisk titel.

Verifierat efter fix: `wordpress.org/news` → `{WordPress News, wordpress}`, Vercel → `{Vercel, unknown}`, Stripe → `{Stripe, unknown}` ✓. Sitemap-vandringen hittade 27 riktiga URL:er på flowwink.com; klassificeringen korrekt på alla 8 testvägar.

## Koordination med local Claude

Local fixade granskningsfynd #1 och #2 och lämnade uttryckligen #3 till mig att para ihop. Min halva (backend + `useCopilot.ts`) är klar; **deras enda rad** ligger som exakt diff i `session-memory.md`:

```ts
// site-migration-module.ts:146
invoke('web-scrape', { body: { url, mode:'map', search, limit: 500 } })
```
Deras befintliga `data?.links || data?.data || []` fungerar oförändrat — `links` finns i svaret just därför.

## Verifiering

Scrape-läget orört (`mode` defaultar till `'scrape'`). Hela sviten grön (**1137**). Manifest regenererat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_