### PR TITLE
fix(edge): repoint 4 dead cross-function calls + make a vacuous autonomy test real

### DIFF
--- a/supabase/functions/browser-fetch/index.ts
+++ b/supabase/functions/browser-fetch/index.ts
@@ -92,13 +92,13 @@ serve(async (req) => {
       });
     }
 
-    // ─── Path C: Public URL → delegate to scrape-url (Firecrawl) ───────
-    console.log(`[browser-fetch] Public URL, delegating to scrape-url: ${targetUrl}`);
+    // ─── Path C: Public URL → delegate to web-scrape (Firecrawl → Jina) ───────
+    console.log(`[browser-fetch] Public URL, delegating to web-scrape: ${targetUrl}`);
 
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
     const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 
-    const scrapeResp = await fetch(`${supabaseUrl}/functions/v1/scrape-url`, {
+    const scrapeResp = await fetch(`${supabaseUrl}/functions/v1/web-scrape`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/supabase/functions/chat-completion/index.ts
+++ b/supabase/functions/chat-completion/index.ts
@@ -228,7 +228,7 @@ async function executeChatTool(
   switch (toolName) {
     case 'firecrawl_search': {
       try {
-        const resp = await fetch(`${supabaseUrl}/functions/v1/firecrawl-search`, {
+        const resp = await fetch(`${supabaseUrl}/functions/v1/web-search`, {
           method: 'POST',
           headers: { 'Authorization': `Bearer ${serviceKey}`, 'apikey': serviceKey, 'Content-Type': 'application/json' },
           body: JSON.stringify({ query: args.query, limit: 3 }),

--- a/supabase/functions/dunning-processor/index.ts
+++ b/supabase/functions/dunning-processor/index.ts
@@ -85,18 +85,25 @@ serve(async (req: Request) => {
       if (step.template && sub?.customer_email) {
         try {
           const messageId = `dunning-${seq.id}-step${stepIdx}`;
-          const { error: emailErr } = await supabase.functions.invoke("send-transactional-email", {
+          // `send-transactional-email` does not exist (it never did in this
+          // history) — dunning mail therefore threw on every attempt and landed
+          // as an `email_failed` action. email-send is the live sender and does
+          // template rendering itself: `template_name` + `variables` are
+          // substituted from `email_templates`.
+          const { error: emailErr } = await supabase.functions.invoke("email-send", {
             body: {
-              templateName: step.template,
-              recipientEmail: sub.customer_email,
-              idempotencyKey: messageId,
-              templateData: {
-                name: sub.customer_name ?? "there",
-                productName: sub.product_name ?? "your subscription",
-                amountCents: seq.mrr_at_risk_cents,
-                currency: seq.currency,
-                failureReason: seq.failure_reason,
-                attemptCount: seq.attempt_count,
+              template_name: step.template,
+              to: sub.customer_email,
+              tags: { kind: "dunning", sequence_id: String(seq.id), message_id: messageId },
+              // email-send declares variables/tags as Record<string, string> and
+              // substitutes {{token}} literally — coerce, don't pass numbers.
+              variables: {
+                name: String(sub.customer_name ?? "there"),
+                productName: String(sub.product_name ?? "your subscription"),
+                amountCents: String(seq.mrr_at_risk_cents ?? ""),
+                currency: String(seq.currency ?? ""),
+                failureReason: String(seq.failure_reason ?? ""),
+                attemptCount: String(seq.attempt_count ?? ""),
               },
             },
           });

--- a/supabase/functions/run-autonomy-tests/index.ts
+++ b/supabase/functions/run-autonomy-tests/index.ts
@@ -592,15 +592,21 @@ async function layer4Tests(supabase: any, supabaseUrl: string, serviceKey: strin
     }
   }));
 
-  // 10. Bootstrap function is deployed and callable
-  results.push(await runTest("L4: setup-flowpilot endpoint responds", 4 as any, async () => {
-    const resp = await fetch(`${supabaseUrl}/functions/v1/setup-flowpilot`, {
-      method: "POST", headers,
-      body: JSON.stringify({ dry_run: true }),
-    });
-    const text = await resp.text();
-    // Should not 500 — either 200 or a controlled error
-    if (resp.status >= 500) throw new Error(`setup-flowpilot returned ${resp.status}: ${text.slice(0, 200)}`);
+  // 10. Skill bootstrap surface is reachable.
+  // WAS: a POST to `setup-flowpilot`, asserting only `status < 500`. That
+  // function does not exist in this codebase, so the probe 404'd — and 404 < 500,
+  // so the test passed while asserting nothing. Bootstrap now runs from the admin
+  // Modules page / flowwink.sh, not an edge function, so the honest check is that
+  // skills are actually seeded and reachable.
+  results.push(await runTest("L4: skills are bootstrapped (agent_skills populated)", 4 as any, async () => {
+    const { count, error } = await supabase
+      .from("agent_skills")
+      .select("id", { count: "exact", head: true })
+      .eq("enabled", true);
+    if (error) throw new Error(`agent_skills query failed: ${error.message}`);
+    if (!count || count < 50) {
+      throw new Error(`Only ${count ?? 0} enabled skills — bootstrap did not run (expected 50+)`);
+    }
   }));
 
   // 11. Instance health endpoint responds with valid shape

--- a/supabase/functions/workspace-chat/index.ts
+++ b/supabase/functions/workspace-chat/index.ts
@@ -367,7 +367,7 @@ const WEB_SEARCH_TOOL = {
 };
 
 async function runWebSearch(supabaseUrl: string, serviceKey: string, query: string, limit = 4) {
-  const resp = await fetch(`${supabaseUrl}/functions/v1/firecrawl-search`, {
+  const resp = await fetch(`${supabaseUrl}/functions/v1/web-search`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260731172326",
-      "migrations_count": 284,
+      "migration_head": "20260801090510",
+      "migrations_count": 285,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1141,6 +1141,10 @@
         {
           "version": "20260731172326",
           "name": "21ca1c3a-0c7e-45a3-b3e0-efb6ad034f1d"
+        },
+        {
+          "version": "20260801090510",
+          "name": "da9ce2f2-cc20-4372-93a6-c87f0e1627e8"
         }
       ]
     },
@@ -1160,11 +1164,11 @@
         "ai-task": "sha256:5cc0884b9c7ab08157ee79a5055f847433cb079732200a07bdae3ef2b666f1f6",
         "automation-dispatcher": "sha256:c0ffa7a2c623209bf82030bd4b6feb1ed9ae92baa4ea5a08772eaa3fa912ea3e",
         "blog-rss": "sha256:dd57f6386804f1e0a4b8e0db3cdb83abc386c5790a677c7fdfe145067ae51be6",
-        "browser-fetch": "sha256:a180bbc1e810c947c430a4d77a32a039f074f9732ea0880a25af80327588174c",
-        "chat-completion": "sha256:00240bb12c645ec8b42e3b4ca576f9d43cc64c094425e7d64ea84faa8f60f489",
+        "browser-fetch": "sha256:762a956222c98ae99b4a361bec94c3d31fcbde6c0d96512755bd50caefa6d652",
+        "chat-completion": "sha256:d6d8c3686997d84e23c54b2f53f47a963d9ce0b987c6cf1bb6b9522a4f0969cd",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:7d51782c0c965937199c1eb471c2664b867a37a32382fba2ecf20f3999bf86aa",
-        "comms-send": "sha256:5ae8861e8216d3e5d89ecddcb3d8c63d919280304d11f7c71ebbea3ef1a547c9",
+        "comms-send": "sha256:645be8963ea70b6182ff57ea3771c3fe528135d72e7238bf8fc26aacce952a4b",
         "composio-proxy": "sha256:e612946242eddbd49713de47d042b231fb600b3bfd5d9fa8e35469d29b4039e6",
         "composio-webhook": "sha256:27f17b7198bfbab422931ef1c872da083299e095792e43b98b4154ec79c858ca",
         "consultant-match": "sha256:1419717affb3711a2d7f13d44c9a228e1557a3d927e3aa05ee5e179584131e1b",
@@ -1179,7 +1183,7 @@
         "docs-chat": "sha256:8a78fddb7cba24df21044920daaea0ad9798ec970ecdb334d4845124ed7550eb",
         "document-share": "sha256:16c5281eb83fc8409d0b8c2906bb05ee74a7956786497e3eeaa7f2883067dd67",
         "document-sign-request": "sha256:43d75660ec58b6c85670c33d8f32508db5abd71e3b008c8a6e99422386a5b6dc",
-        "dunning-processor": "sha256:8d71e58e74cf852e9b1e435779f59cf7e07e9ad61ccd91c0367763bc76b3f772",
+        "dunning-processor": "sha256:e05e55a6624859ed9f36f296aa5eccbb313f5d70f861a84067af4a4738b12679",
         "elks46-ingest": "sha256:a1b085f53ec559914dd98a664838bb751ea12ec965cd181230e3eff8bed6635b",
         "email-send": "sha256:ba9a480597310e011f685e4ec51224621f3712d2f874883bc6db8b778483c943",
         "email-webhook": "sha256:0ab483c28ad242ba4cbadc329f56a029ef246c89e669bd81184ce9017ede007d",
@@ -1200,14 +1204,14 @@
         "mcp-server": "sha256:0d98de809c2402fe0712a26e39f515ec9a6f55f71cb8f1739bf894ef7e45d9a3",
         "media-optimize": "sha256:ddaa5868b1f154561a900e133ab64c6ffd0ebef9751098b2a42c03684c34d496",
         "migrate-page": "sha256:766be614771b490303abefc25efff5ade8417a833fc8c8ed0fc4e725f84fec81",
-        "newsletter": "sha256:5372f558d834384a4f9ff8f1c63134f4ce17e07b42f2050c7e40af0759fb4fa2",
+        "newsletter": "sha256:e0d314e514159b86b4ff263f4e6084753265f2b8cef27a01711595f52e102ee1",
         "openclaw-responses": "sha256:70efb4b23cd1fb08427337148ccd47097d30a0e746bb27ad17120b39498dec3b",
         "process-image": "sha256:b7a65c7cf8f1b80ec4ae22aec5ab2ec7521ead15ee3f96e08921da90ed41b985",
-        "process-job-application": "sha256:559beb704d521c604e18ae8766fff1eb3c279441365a96eb48a661132b6f0c21",
+        "process-job-application": "sha256:25776893a0080b2bce6674c66d0c6539a0d0238a5eb18f1d0755c17248d0f900",
         "quote-expiry-reminders": "sha256:6d9b763668aefb9948af581d5d54f52879814f964f61f8cca345db4e57805034",
         "quote-pay": "sha256:f42a8accc1489304c32b0e3a2c5f30188faa898e48e9323698ed624ca9aea296",
         "quote-sign": "sha256:c7b303564411e34fef83893c5f615576baa50e657eba64628f403ff386436f78",
-        "run-autonomy-tests": "sha256:1686a331e5859a2a70df6961eb9610a75e387c55c333fc89f1edcd412c86cf7c",
+        "run-autonomy-tests": "sha256:d326b88ef0d263ed7604ba1eb75a770126d785e26211888b2093fcb325cc8c22",
         "run-platform-tests": "sha256:3a38e5a9f5a3888fe80455cb244deb5839ab9adee2e8f6e918f4d046d6bb6f1e",
         "score-visitor-intent": "sha256:c45442de0d34a5f9660a75a15c269aa5988ca7dbc2631e476418c66e58e6f79e",
         "send-webhook": "sha256:32dfe4c3c613760f0e64a523404057f5fdf5e2e41af56535f0a66b1bc4d38679",
@@ -1227,7 +1231,7 @@
         "voice-recording": "sha256:41391de110f7f3e138df5c50b1901dd6c7928d2be18ad82fa5e166d48f66cca2",
         "web-scrape": "sha256:f0948362eb60ff2d597de407af0f3eedb3b0f892b75ce4acff960e0b6ebf146f",
         "web-search": "sha256:f8a514ea635ffa553da1cfd5e04aaf0adf159012df1981784c7da81af627c56e",
-        "workspace-chat": "sha256:619043de41736dca0df6be8f8a91b06c09282d4af1ea211d29826367bc4a37ae"
+        "workspace-chat": "sha256:357dcc372b82c181c9f865576891c2b20511bd2672afc5d52accbfa16d8e832e"
       }
     },
     "frontend": {


### PR DESCRIPTION
Checkup efter en veckas Lovable-shipping (**239 commits** sedan min sista merge).

## Lovables egna arbete: bra

Den städade **själv** bort döda edge-referenser (`qualify-lead` → agent-execute-skill, `parse-resume` → intern handler), fixade en kolumnbugg (`employees.full_name` → `name`), la till **inga** nya edge-funktioner (frysprincipen höll), och mina säkerhetsgrindar (demo-seed, faktura-PDF, blockkontrakt) är intakta.

## main var RÖD

En ny migration (`20260801090510`, verifikationsnumrering + webinar-backfills) och 4 ändrade edge-funktioner landade **utan manifest-regen**. Regenererat → grönt.

## Fyra döda cross-function-anrop (alla pre-existerande, inte Lovable-regressioner)

| Anropare | Död funktion | Konsekvens |
|---|---|---|
| `dunning-processor` | `send-transactional-email` | **Betalningspåminnelser går aldrig ut** |
| `chat-completion` | `firecrawl-search` | Webbsök i besökschatt returnerar alltid "Search failed" |
| `workspace-chat` | `firecrawl-search` | Samma i Flowwork |
| `browser-fetch` (Path C) | `scrape-url` | Publik-URL-hämtning 404:ar |

**Dunning är den viktiga.** Invoket kastar, loggas som `email_failed`, och återvinningsmailet uteblir. Jag var noga med att inte överdriva: dev har **noll** dunning-sekvenser, så vägen har aldrig körts — buggen är **latent** och slår till första gången en riktig prenumerationsbetalning misslyckas, alltså precis fel ögonblick. Repointad till `email-send` som gör egen template-rendering (`templateName`/`templateData`/`recipientEmail` → `template_name`/`variables`/`to`), med strängkoercion eftersom `email-send` deklarerar `Record<string, string>` och substituerar `{{token}}` literalt.

## Ett test som inte kunde fela

`run-autonomy-tests` sonderade `setup-flowpilot` (borttagen — bootstrap sker via Modules-sidan/`flowwink.sh`) och kollade bara `status < 500`. **404 är < 500**, så testet passerade utan att pröva något. Ersatt med en riktig kontroll att `agent_skills` faktiskt är seedad.

## Orört

`firecrawl-map` i `site-migration-module.ts` — local Claudes fil, redan överlämnad i `session-memory` med exakt diff. `a2a-negotiate` är en **fjärr-peers** endpoint-path, inte vår.

## Verifiering

Hela sviten grön (**1197**). Svepet "varje `functions.invoke`/`functions/v1`-mål mot disk" är nu rent bortsett från de två ovan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_