### PR TITLE
fix(content): the operator now remembers what it already published

### DIFF
--- a/docs/operators/session-memory.md
+++ b/docs/operators/session-memory.md
@@ -250,6 +250,82 @@ where RLS allows and for `--no-verify-jwt` public functions.
 
 ## Open queue (next session starts here)
 
+### ⇄ Handoff to local Claude — the blog duplicate corpus (2026-08-05, cloud session)
+
+**What happened.** flowwink.com published **16 near-identical blog posts**
+between 8 Jun and 23 Jul 2026 — the same "MCP + open source AI agents + BOS"
+article re-worded, across Swedish and English, one titled with a literal
+"(2)". Timestamps are 00:00 and 12:00 UTC, twice daily: a **cron automation
+carrying a static topic** through the default content chain
+(`research_content` → `generate_content_proposal` → `write_blog_post`,
+`src/data/flowpilotDefaults.ts:45-47`).
+
+**What the cloud session fixed (merged/branch `claude/project-review-22lava`).**
+Content memory existed since fb223b553 (12 Jul) but was inlined in the
+**flowpilot-heartbeat prompt only** — the duplicates came from
+`automation-dispatcher → agent-execute → ai-task`, which never sees that
+prompt, so they kept landing 11 more days. Promoted to
+`supabase/functions/_shared/domains/content-memory.ts` and wired into the
+`load` hook of `content_research`, `content_proposal` and `seo_content_brief`,
+plus the heartbeat. Guardrails in `src/lib/__tests__/content-memory.test.ts`.
+
+**Two fixes remain, both in YOUR files — reported, not touched:**
+
+1. **`write_blog_post` has no sink-level duplicate check**
+   (`supabase/functions/agent-execute/index.ts:5184-5195`). Worse, the one
+   mechanism that could have caught it was repurposed to *permit* duplication:
+   the slug loop appends `-2`, `-3` on collision so a re-run of the same title
+   inserts cleanly instead of failing. Prompt-level memory is advisory; a sink
+   guard is not. Suggested shape — **warn, don't hard-reject** (a deliberate
+   rewrite is legitimate):
+
+   ```ts
+   import { loadRecentContent, findSimilarTitles }
+     from '../_shared/domains/content-memory.ts';
+
+   // after resolvedTitle, before insert
+   const recent = await loadRecentContent(supabase, { limit: 25 });
+   const similar = findSimilarTitles(resolvedTitle, recent);   // threshold 0.6
+   // ...include in the return value so the operator sees it next turn:
+   //   duplicate_warning: similar.length
+   //     ? `This site has already published ${similar.length} post(s) on this
+   //        subject. Take a different angle or update the existing post via
+   //        manage_blog_posts instead.`
+   //     : undefined,
+   //   similar_posts: similar.map(s => ({ title: s.item.title,
+   //                                      similarity: +s.similarity.toFixed(2) })),
+   ```
+
+   `titleSimilarity` is containment over diacritic-folded, stopword-stripped
+   words — calibrated against the real corpus: duplicates 0.67–1.00, worst
+   false positive 0.17. Tests already cover it; no new measure needed.
+
+2. **Slugs drop every non-ASCII letter.**
+   `title.toLowerCase().replace(/[^a-z0-9]+/g, '-')` runs *before* any
+   transliteration, so "Varför öppna vikters" → `varf-r-ppna-vikters`. On a
+   Swedish-first product that is every slug on the site. Six occurrences in
+   `agent-execute/index.ts` (lines 4084, 4620, 5122, 5135, 5184, 11909) and
+   **ten more in `src/` (cloud session's side — say the word and it ships
+   with a shared `slugify()` both sides import).** The fix is one
+   NFD-normalize plus the Nordic pairs that don't decompose:
+
+   ```ts
+   s.toLowerCase()
+    .replace(/[åäæ]/g, 'a').replace(/[öø]/g, 'o').replace(/ß/g, 'ss')
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')
+   ```
+
+   (Nordic pairs first: `å`/`ä`/`ö` decompose to `a`/`a`/`o` under NFD anyway,
+   but `ø` and `æ` do not.) Changing existing slugs breaks live URLs — apply to
+   **new** slugs only, or pair it with a redirect.
+
+**Also worth a look, not blocking:** the default workflow in
+`flowpilotDefaults.ts:47` passes `write_blog_post` a `proposal:` argument. The
+skill takes `title` + `content` and rejects anything else ("content is
+required"), so that seeded chain cannot have been working as written.
+
+
 ### ⇄ Handoff to local Claude — from the 2026-07-23 architecture review (cloud session)
 
 Cloud session ran a 4-agent holistic review and shipped the fixes that were in

--- a/src/lib/__tests__/content-memory.test.ts
+++ b/src/lib/__tests__/content-memory.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Content Memory — the guard against a recurring content objective re-writing
+ * the same article forever.
+ *
+ * Regression corpus: the real flowwink.com titles published 8 Jun – 23 Jul 2026,
+ * two a day, from one cron automation carrying a static topic. Any change to the
+ * similarity measure must still see these as the same article.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  normalizeTitle,
+  titleSimilarity,
+  findSimilarTitles,
+  formatContentMemory,
+  loadRecentContent,
+} from '../../../supabase/functions/_shared/domains/content-memory.ts';
+
+// findSimilarTitles' default. Kept in one place so the corpus below documents
+// the actual margin: real duplicates land at 0.67-1.0, false positives at 0.17.
+const DUPLICATE_THRESHOLD = 0.6;
+
+// The actual duplicates, from the live RSS feed.
+const REAL_DUPLICATES = [
+  'Why MCP and Open Source AI Agents Are Key to the Future of Business Operating Systems',
+  'The Future of Business Operating Systems: Why MCP, Open Source AI Agents, and Open-Weights Models Matter',
+  'Why MCP and Open Source AI Agents Are Shaping the Future of Business Operating Systems',
+  'Why MCP is the Future of Business Operating Systems with AI Agents',
+  'Why Open Source and Open Weights Make MCP the Future of AI Agents for Business Operating Systems',
+];
+
+const REAL_SWEDISH_DUPLICATES = [
+  'AI Agents och Business Operating Systems: Varför MCP och Öppna Vikters Modeller Är Framtiden',
+  'AI Agenter, Business Operating Systems och MCP: Varför Öppna Vikters Modeller Är Framtiden',
+  'Framtidens Business Operating Systems: Varför AI-agenter, Open Source och Öppna Vikters MCP leder Vägen',
+];
+
+describe('normalizeTitle', () => {
+  it('folds Swedish diacritics so å/ä/ö compare as a/a/o', () => {
+    expect(normalizeTitle('Öppna Vikters Modeller')).toBe('oppna vikters modeller');
+    expect(normalizeTitle('Varför MCP är Framtiden')).toBe('varfor mcp ar framtiden');
+  });
+
+  it('drops punctuation and collapses whitespace', () => {
+    expect(normalizeTitle('AI-agenter,  Open Source & MCP: Varför?')).toBe(
+      'ai agenter open source mcp varfor',
+    );
+  });
+
+  it('survives null/undefined titles', () => {
+    expect(normalizeTitle(undefined as unknown as string)).toBe('');
+    expect(normalizeTitle(null as unknown as string)).toBe('');
+  });
+});
+
+describe('titleSimilarity', () => {
+  it('scores the real English duplicates as the same article', () => {
+    for (let i = 0; i < REAL_DUPLICATES.length; i++) {
+      for (let j = i + 1; j < REAL_DUPLICATES.length; j++) {
+        const sim = titleSimilarity(REAL_DUPLICATES[i], REAL_DUPLICATES[j]);
+        expect(
+          sim,
+          `"${REAL_DUPLICATES[i]}" vs "${REAL_DUPLICATES[j]}" scored ${sim.toFixed(2)}`,
+        ).toBeGreaterThanOrEqual(DUPLICATE_THRESHOLD);
+      }
+    }
+  });
+
+  it('scores the real Swedish duplicates as the same article', () => {
+    for (let i = 0; i < REAL_SWEDISH_DUPLICATES.length; i++) {
+      for (let j = i + 1; j < REAL_SWEDISH_DUPLICATES.length; j++) {
+        const sim = titleSimilarity(REAL_SWEDISH_DUPLICATES[i], REAL_SWEDISH_DUPLICATES[j]);
+        expect(
+          sim,
+          `"${REAL_SWEDISH_DUPLICATES[i]}" vs "${REAL_SWEDISH_DUPLICATES[j]}" scored ${sim.toFixed(2)}`,
+        ).toBeGreaterThanOrEqual(DUPLICATE_THRESHOLD);
+      }
+    }
+  });
+
+  it('does NOT flag genuinely different articles on the same site', () => {
+    const distinct: Array<[string, string]> = [
+      [
+        'Why MCP is the Future of Business Operating Systems with AI Agents',
+        'Bygg ett Content Marketing-maskineri med AI, Open Source och MCP',
+      ],
+      [
+        'Why MCP and Open Source AI Agents Are Key to the Future of Business Operating Systems',
+        'How we cut invoice reconciliation time by 80% with a single automation',
+      ],
+      ['Five ways to shorten your sales cycle', 'A field guide to payroll in Sweden'],
+    ];
+    for (const [a, b] of distinct) {
+      const sim = titleSimilarity(a, b);
+      expect(sim, `"${a}" vs "${b}" scored ${sim.toFixed(2)}`).toBeLessThan(DUPLICATE_THRESHOLD);
+    }
+  });
+
+  it('is symmetric and self-identical', () => {
+    const [a, b] = REAL_DUPLICATES;
+    expect(titleSimilarity(a, b)).toBeCloseTo(titleSimilarity(b, a));
+    expect(titleSimilarity(a, a)).toBe(1);
+  });
+
+  it('returns 0 rather than throwing on empty or stopword-only titles', () => {
+    expect(titleSimilarity('', 'anything')).toBe(0);
+    expect(titleSimilarity('the and of', 'a to in')).toBe(0);
+  });
+});
+
+describe('findSimilarTitles', () => {
+  const existing = REAL_DUPLICATES.map((title) => ({ title, status: 'published' }));
+
+  it('finds prior coverage for a would-be 6th duplicate, most similar first', () => {
+    const hits = findSimilarTitles(
+      'Why MCP, Open Source and AI Agents Are the Future of Business Operating Systems',
+      existing,
+    );
+    expect(hits.length).toBeGreaterThan(0);
+    for (let i = 1; i < hits.length; i++) {
+      expect(hits[i - 1].similarity).toBeGreaterThanOrEqual(hits[i].similarity);
+    }
+  });
+
+  it('returns nothing for a genuinely new topic', () => {
+    expect(findSimilarTitles('Our Q3 pricing changes, explained', existing)).toHaveLength(0);
+  });
+
+  it('handles an empty or missing back-catalogue', () => {
+    expect(findSimilarTitles('anything', [])).toHaveLength(0);
+    expect(findSimilarTitles('anything', undefined as never)).toHaveLength(0);
+  });
+});
+
+describe('formatContentMemory', () => {
+  it('is empty for a site with no posts, so callers can concatenate blindly', () => {
+    expect(formatContentMemory([])).toBe('');
+    expect(formatContentMemory(undefined as never)).toBe('');
+  });
+
+  it('lists every title and tells the model not to re-word or translate one', () => {
+    const block = formatContentMemory(REAL_DUPLICATES.map((title) => ({ title })));
+    for (const t of REAL_DUPLICATES) expect(block).toContain(t.slice(0, 100));
+    expect(block).toMatch(/different angle/i);
+    expect(block).toMatch(/another language/i);
+  });
+
+  it('truncates a runaway title instead of blowing the prompt budget', () => {
+    const block = formatContentMemory([{ title: 'x'.repeat(400) }]);
+    expect(block).toContain('x'.repeat(100));
+    expect(block).not.toContain('x'.repeat(101));
+  });
+});
+
+describe('loadRecentContent', () => {
+  const stubClient = (rows: unknown, throws = false) => ({
+    from: () => ({
+      select: () => ({
+        order: () => ({
+          limit: () => {
+            if (throws) throw new Error('relation "blog_posts" does not exist');
+            return Promise.resolve({ data: rows });
+          },
+        }),
+      }),
+    }),
+  });
+
+  it('drops rows without a title', async () => {
+    const rows = await loadRecentContent(
+      stubClient([{ title: 'Real post' }, { title: '' }, { title: null }, {}]),
+    );
+    expect(rows.map((r) => r.title)).toEqual(['Real post']);
+  });
+
+  it('degrades to empty rather than failing the whole generation', async () => {
+    expect(await loadRecentContent(stubClient(null, true))).toEqual([]);
+    expect(await loadRecentContent(stubClient(null))).toEqual([]);
+  });
+});
+
+// ─── Wiring guardrail ───────────────────────────────────────────────────────
+// The 12 Jul fix put content memory in the heartbeat prompt only, while the
+// duplicates were coming from the cron → automation-dispatcher → ai-task path.
+// Duplicates kept landing for 11 more days. Assert every generative content
+// task actually loads the memory, so the next fix can't be half-wired again.
+describe('every generative content task loads content memory', () => {
+  const tasksSrc = readFileSync(
+    join(process.cwd(), 'supabase/functions/ai-task/tasks.ts'),
+    'utf-8',
+  );
+
+  const CONTENT_TASKS = ['content_research', 'content_proposal', 'seo_content_brief'];
+
+  it.each(CONTENT_TASKS)('%s calls loadContentMemoryBlock', (taskName) => {
+    const start = tasksSrc.indexOf(`name: "${taskName}"`);
+    expect(start, `task ${taskName} not found in tasks.ts`).toBeGreaterThan(-1);
+    // Scan to the next task definition (or EOF) — the whole TaskSpec body.
+    const rest = tasksSrc.slice(start + 1);
+    const nextIdx = rest.search(/\n(?:const \w+Task: TaskSpec|export const TASKS)/);
+    const body = nextIdx === -1 ? rest : rest.slice(0, nextIdx);
+    expect(body).toContain('loadContentMemoryBlock');
+    expect(body).toContain('existing_coverage');
+  });
+
+  it('injects existing_coverage into the prompt, not just the load step', () => {
+    for (const taskName of CONTENT_TASKS) {
+      const start = tasksSrc.indexOf(`name: "${taskName}"`);
+      const rest = tasksSrc.slice(start + 1);
+      const nextIdx = rest.search(/\n(?:const \w+Task: TaskSpec|export const TASKS)/);
+      const body = nextIdx === -1 ? rest : rest.slice(0, nextIdx);
+      const systemIdx = body.indexOf('system:');
+      expect(systemIdx, `${taskName} has no system prompt`).toBeGreaterThan(-1);
+      expect(
+        body.slice(systemIdx).includes('existing_coverage'),
+        `${taskName} loads content memory but never puts it in the system prompt`,
+      ).toBe(true);
+    }
+  });
+
+  it('the heartbeat uses the shared helper rather than its own copy', () => {
+    const heartbeat = readFileSync(
+      join(process.cwd(), 'supabase/functions/flowpilot-heartbeat/index.ts'),
+      'utf-8',
+    );
+    expect(heartbeat).toContain('loadContentMemoryBlock');
+    expect(
+      heartbeat.includes('.from("blog_posts")\n    .select("title'),
+      'heartbeat re-grew a private recent-titles query — use content-memory.ts',
+    ).toBe(false);
+  });
+});

--- a/src/lib/__tests__/flowpilot-hermes.guardrails.test.ts
+++ b/src/lib/__tests__/flowpilot-hermes.guardrails.test.ts
@@ -54,8 +54,12 @@ describe('flowpilot hermes guardrails', () => {
   });
 
   it('heartbeat context includes recent blog titles (content differentiation)', () => {
-    expect(heartbeat).toMatch(/recent blog output/i);
-    expect(heartbeat).toMatch(/from\("blog_posts"\)[\s\S]*?select\("title/);
+    // The titles now come from the shared Content Memory primitive, so the same
+    // memory reaches the ai-task/cron path — which is where the real duplicates
+    // came from. See supabase/functions/_shared/domains/content-memory.ts and
+    // src/lib/__tests__/content-memory.test.ts.
+    expect(heartbeat).toMatch(/loadContentMemoryBlock\(supabase/);
+    expect(heartbeat).toMatch(/from ["'].*_shared\/domains\/content-memory\.ts["']/);
   });
 
   it('completion pass merges results so the heartbeat log reflects both passes', () => {

--- a/supabase/functions/_shared/domains/content-memory.ts
+++ b/supabase/functions/_shared/domains/content-memory.ts
@@ -1,0 +1,137 @@
+/**
+ * Content Memory — what this site has already published.
+ *
+ * A generative content objective without memory degenerates: the operator is
+ * handed the same topic every cycle, has no idea it already answered it, and
+ * re-words yesterday's article. flowwink.com published 16 near-identical posts
+ * about "MCP + open source AI agents + BOS" between 8 Jun and 23 Jul 2026, two
+ * a day at 00:00 and 12:00 UTC — a cron automation carrying a static topic.
+ *
+ * The first fix (fb223b553, 12 Jul) inlined recent titles into the *heartbeat*
+ * prompt only. Duplicates kept landing for another 11 days, because the failing
+ * path was automation-dispatcher → agent-execute → ai-task, which never sees
+ * the heartbeat's prompt. Content memory is a platform primitive with several
+ * consumers, so it lives here — not inside whichever consumer noticed first.
+ * (Same reasoning as the Skill Relevance Engine in _shared/skills/.)
+ *
+ * Consumers:
+ *   1. flowpilot-heartbeat — site stats block, every autonomous wake
+ *   2. ai-task content_research / content_proposal / seo_content_brief — the
+ *      cron/automation path, via each task's `load` hook
+ */
+
+export interface ContentMemoryItem {
+  title: string;
+  status?: string | null;
+  published_at?: string | null;
+  created_at?: string | null;
+}
+
+/** Titles are compared on meaning-bearing words only. */
+const STOPWORDS = new Set([
+  // English
+  'a', 'an', 'and', 'are', 'as', 'at', 'be', 'but', 'by', 'for', 'from', 'how',
+  'in', 'is', 'it', 'of', 'on', 'or', 'the', 'to', 'we', 'what', 'why', 'with',
+  'your', 'you', 'that', 'this', 'these', 'those', 'into', 'are', 'key',
+  // Swedish
+  'och', 'att', 'det', 'som', 'en', 'ett', 'är', 'för', 'med', 'på', 'av',
+  'till', 'den', 'de', 'om', 'så', 'hur', 'varför', 'vad', 'i', 'du', 'vi',
+  'ar', 'for', 'pa', 'sa', 'varfor',
+]);
+
+/** Fold case and diacritics so "Öppna vikter" and "oppna vikter" compare equal. */
+export function normalizeTitle(title: string): string {
+  return String(title || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokens(title: string): Set<string> {
+  return new Set(
+    normalizeTitle(title)
+      .split(' ')
+      .filter((w) => w.length > 2 && !STOPWORDS.has(w)),
+  );
+}
+
+/**
+ * How much of the shorter title's substance already appears in the other, 0..1
+ * (containment / overlap coefficient over meaning-bearing words).
+ *
+ * Deliberately a bag-of-words measure, not an embedding: it must run inline in
+ * a prompt-building path with no model call, and the failure mode it catches is
+ * re-wording — which preserves the noun phrases almost perfectly.
+ *
+ * Containment rather than Jaccard because the real duplicates vary in length —
+ * "AI Agents och BOS: Varför MCP och Öppna Vikters Modeller Är Framtiden" vs
+ * "Framtidens BOS: Varför AI-agenter, Open Source och Öppna Vikters MCP leder
+ * Vägen" is Jaccard 0.40 (below any threshold that clears the false positives)
+ * but containment 0.67, against a worst false positive of 0.17.
+ *
+ * Stub titles (under three meaning-bearing words) fall back to Jaccard, since
+ * a two-word title is trivially contained in almost anything.
+ */
+export function titleSimilarity(a: string, b: string): number {
+  const ta = tokens(a);
+  const tb = tokens(b);
+  if (ta.size === 0 || tb.size === 0) return 0;
+  let shared = 0;
+  for (const t of ta) if (tb.has(t)) shared++;
+  const smaller = Math.min(ta.size, tb.size);
+  if (smaller < 3) return shared / (ta.size + tb.size - shared);
+  return shared / smaller;
+}
+
+/** Existing items whose title is at least `threshold` similar, most similar first. */
+export function findSimilarTitles(
+  candidate: string,
+  existing: ContentMemoryItem[],
+  threshold = 0.6,
+): Array<{ item: ContentMemoryItem; similarity: number }> {
+  return (existing || [])
+    .map((item) => ({ item, similarity: titleSimilarity(candidate, item.title) }))
+    .filter((m) => m.similarity >= threshold)
+    .sort((a, b) => b.similarity - a.similarity);
+}
+
+/** Newest blog output first — drafts included, since a queued draft is coverage too. */
+export async function loadRecentContent(
+  supabase: any,
+  opts: { limit?: number } = {},
+): Promise<ContentMemoryItem[]> {
+  const limit = opts.limit ?? 10;
+  try {
+    const { data } = await supabase
+      .from('blog_posts')
+      .select('title, status, published_at, created_at')
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    return (data || []).filter((p: ContentMemoryItem) => !!p?.title);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The prompt block. Empty string when there is nothing to remember, so callers
+ * can concatenate unconditionally.
+ */
+export function formatContentMemory(items: ContentMemoryItem[]): string {
+  if (!items?.length) return '';
+  const lines = items
+    .map((p) => `  - ${String(p.title || '').slice(0, 100)}`)
+    .join('\n');
+  return `\n\nALREADY PUBLISHED (newest first) — this site has covered these. New content MUST take a materially different angle, audience, format or sub-topic; never re-word one of these, and never re-publish the same argument in another language:\n${lines}`;
+}
+
+/** Load + format in one step, for callers that just want the prompt block. */
+export async function loadContentMemoryBlock(
+  supabase: any,
+  opts: { limit?: number } = {},
+): Promise<string> {
+  return formatContentMemory(await loadRecentContent(supabase, opts));
+}

--- a/supabase/functions/ai-task/tasks.ts
+++ b/supabase/functions/ai-task/tasks.ts
@@ -28,6 +28,7 @@
 import { z } from "https://esm.sh/zod@3.23.8";
 import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
 import type { AiTier } from "../_shared/ai-config.ts";
+import { loadContentMemoryBlock } from "../_shared/domains/content-memory.ts";
 
 export interface TaskSpec<I = unknown, O = unknown> {
   name: string;
@@ -486,8 +487,15 @@ const contentResearchTask: TaskSpec<z.infer<typeof contentResearchInput>, any> =
     "Deep content research for a topic — audience insights, content angles, hooks, competitive landscape, recommended structure, SEO. Returns a structured ContentResearch object.",
   tier: "reasoning",
   inputSchema: contentResearchInput,
-  system: () =>
-    `You are an expert content strategist. Produce deep, specific, non-generic research for the given brief and return it via the submit_content_research tool. Ground angles and hooks in real audience psychology; avoid filler and platitudes. Tailor angles to the requested channels.`,
+  // A cron automation hands this task the SAME topic every cycle. Without the
+  // site's own back-catalogue in the prompt, every cycle produces the same
+  // angles — 16 near-identical posts on flowwink.com. See
+  // _shared/domains/content-memory.ts.
+  load: async (_input, supabase) => ({
+    existing_coverage: await loadContentMemoryBlock(supabase, { limit: 15 }),
+  }),
+  system: (input) =>
+    `You are an expert content strategist. Produce deep, specific, non-generic research for the given brief and return it via the submit_content_research tool. Ground angles and hooks in real audience psychology; avoid filler and platitudes. Tailor angles to the requested channels.${(input as any).existing_coverage ?? ""}`,
   user: (input) =>
     `## Brief\n${JSON.stringify({
       topic: (input as any).topic,
@@ -608,8 +616,11 @@ const contentProposalTask: TaskSpec<z.infer<typeof contentProposalInput>, any> =
     "Generate a multi-channel content proposal from a topic — a pillar piece plus channel-adapted variants (blog, newsletter, linkedin, x). Returns pillar_content + channel_variants.",
   tier: "reasoning",
   inputSchema: contentProposalInput,
+  load: async (_input, supabase) => ({
+    existing_coverage: await loadContentMemoryBlock(supabase, { limit: 15 }),
+  }),
   system: (input) =>
-    `You are an expert multi-channel content strategist. From the brief, write ONE strong pillar piece and adapt it into native variants for ONLY the requested channels, returning everything via the submit_content_proposal tool. Match the brand voice and tone. Per channel shape: blog = {title, excerpt, body (markdown), seo_keywords[]}; newsletter = {subject, preview_text, content}; linkedin = {text, hashtags[]}; x = {thread[] (each item one tweet)}. Requested channels: ${JSON.stringify((input as any).target_channels ?? [])}. No filler or platitudes.`,
+    `You are an expert multi-channel content strategist. From the brief, write ONE strong pillar piece and adapt it into native variants for ONLY the requested channels, returning everything via the submit_content_proposal tool. Match the brand voice and tone. Per channel shape: blog = {title, excerpt, body (markdown), seo_keywords[]}; newsletter = {subject, preview_text, content}; linkedin = {text, hashtags[]}; x = {thread[] (each item one tweet)}. Requested channels: ${JSON.stringify((input as any).target_channels ?? [])}. No filler or platitudes.${(input as any).existing_coverage ?? ""}`,
   user: (input) =>
     `## Brief\n${JSON.stringify({
       topic: (input as any).topic,
@@ -678,8 +689,11 @@ const seoContentBriefTask: TaskSpec<z.infer<typeof seoBriefInput>, any> = {
     "SEO content brief for a topic — primary/secondary keywords, search intent, title options, meta description, a heading outline, People-Also-Ask questions, competitor gaps, and a word-count target.",
   tier: "reasoning",
   inputSchema: seoBriefInput,
-  system: () =>
-    `You are an expert SEO content strategist. From the topic, produce an actionable, specific content brief a writer can execute against, returning it via the submit_seo_content_brief tool. Ground keywords and questions in real search behavior; the outline must be logically ordered H2/H3s; competitor_gaps are angles competitors miss. No filler.`,
+  load: async (_input, supabase) => ({
+    existing_coverage: await loadContentMemoryBlock(supabase, { limit: 15 }),
+  }),
+  system: (input) =>
+    `You are an expert SEO content strategist. From the topic, produce an actionable, specific content brief a writer can execute against, returning it via the submit_seo_content_brief tool. Ground keywords and questions in real search behavior; the outline must be logically ordered H2/H3s; competitor_gaps are angles competitors miss. No filler.${(input as any).existing_coverage ?? ""}`,
   user: (input) =>
     `## Brief request\n${JSON.stringify({
       topic: (input as any).topic,

--- a/supabase/functions/flowpilot-heartbeat/index.ts
+++ b/supabase/functions/flowpilot-heartbeat/index.ts
@@ -24,6 +24,7 @@ import {
 } from "../_shared/agent-reason.ts";
 import { tryAcquireLock, releaseLock } from "../_shared/concurrency.ts";
 import { generateTraceId } from "../_shared/trace.ts";
+import { loadContentMemoryBlock } from "../_shared/domains/content-memory.ts";
 import type { TokenUsage } from "../_shared/types.ts";
 
 /**
@@ -78,21 +79,17 @@ async function loadSiteStats(supabase: any): Promise<string> {
 
   // Recent output titles — the operator must SEE what it already produced, or a
   // recurring content objective degenerates into the same artifact re-worded
-  // daily (observed in fast-sim: 6 near-identical blog titles in 6 days).
-  const { data: recentPosts } = await supabase
-    .from("blog_posts")
-    .select("title, created_at")
-    .order("created_at", { ascending: false })
-    .limit(10);
-  const recentTitles = (recentPosts || [])
-    .map((p: any) => `  - ${String(p.title || "").slice(0, 100)}`)
-    .join("\n");
+  // daily (observed in fast-sim: 6 near-identical blog titles in 6 days; then
+  // for real on flowwink.com, 16 in six weeks). Shared with the ai-task content
+  // path, which is where the real duplicates came from — see
+  // _shared/domains/content-memory.ts.
+  const contentMemory = await loadContentMemoryBlock(supabase, { limit: 10 });
 
   return `\n\nSite stats (7 days):
 - Page views: ${views.count ?? 0}
 - New leads: ${leads.count ?? 0}
 - Blog posts published: ${posts.count ?? 0}
-- Total confirmed subscribers: ${subscribers.count ?? 0}${recentTitles ? `\n\nYour recent blog output (newest first) — new content must take a DIFFERENT angle, audience or format than these; never re-word an existing one:\n${recentTitles}` : ""}`;
+- Total confirmed subscribers: ${subscribers.count ?? 0}${contentMemory}`;
 }
 
 async function loadLinkedAutomations(supabase: any): Promise<string> {

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -4,7 +4,7 @@
   "layers": {
     "schema": {
       "migration_head": "20260805090000",
-      "migrations_count": 290,
+      "migrations_count": 291,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1163,6 +1163,10 @@
           "name": "seed-role-module-access-defaults"
         },
         {
+          "version": "20260805003142",
+          "name": "e56aef5d-db4d-418f-b0d0-f54e80719265"
+        },
+        {
           "version": "20260805090000",
           "name": "kb-article-visibility"
         }
@@ -1175,13 +1179,13 @@
     },
     "edge_functions": {
       "count": 75,
-      "shared_hash": "sha256:ab90858a0c0f96af9caec616f9b0169b5f5cd70a1819b953c1af70daa3a259ea",
+      "shared_hash": "sha256:e6f55eb20e3ec24ebd8dd38c6271cd000497ea29ccfce098cddf62e584f5aa28",
       "functions": {
         "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
         "agent-execute": "sha256:82739d8e4bd4822d5e9e0bfd9529008df47b4c515b82c033fd6e577d07afbc97",
         "agent-operate": "sha256:72cdafe207ae2a5630e3263e6c993a55aade47c679f2cc200465cb3a17f30689",
-        "ai-task": "sha256:5cc0884b9c7ab08157ee79a5055f847433cb079732200a07bdae3ef2b666f1f6",
+        "ai-task": "sha256:6a0c6b21f9f0575650d9e478bc9184ce24541d3a18d00bb6c80c64a60f5e28aa",
         "automation-dispatcher": "sha256:c0ffa7a2c623209bf82030bd4b6feb1ed9ae92baa4ea5a08772eaa3fa912ea3e",
         "blog-rss": "sha256:dd57f6386804f1e0a4b8e0db3cdb83abc386c5790a677c7fdfe145067ae51be6",
         "browser-fetch": "sha256:762a956222c98ae99b4a361bec94c3d31fcbde6c0d96512755bd50caefa6d652",
@@ -1210,7 +1214,7 @@
         "event-dispatcher": "sha256:1226b1ce317cb70cfdae46441f59499f8559b159fd08ee5063105ebfd98e5aa0",
         "extract-pdf-text": "sha256:96f98e21532f261f3e41dc8843dee623e9a010a6106d4e40d3664d743df46304",
         "federation-invite-peer": "sha256:ea8c2c09c4f6cd1839da87a93932794086ff5a37f7e9419864b38928f5d61bac",
-        "flowpilot-heartbeat": "sha256:477a5bb13fdfad2125a628e2e211b3ac7ffe2be7c53482c2cca5118fa64f7cb0",
+        "flowpilot-heartbeat": "sha256:21acbb3522ba6b2d9a117ac63fbfb548bd21ea282715bc5d032047d9f9b310cd",
         "flowpilot-lifecycle": "sha256:01398e7de05ded81c439fa20d3fff9480aae9096fabe2c16add31a8c63c5c143",
         "gatewayapi-ingest": "sha256:9daeb71012e0b49d3eee1583d2511a50224cec4e1b69de46a471e1a63d7f066a",
         "generate-invoice-pdf": "sha256:7884b26bb71e22e6e89a1b4429fc9f47a9bac20826008abca71ad213fb365901",


### PR DESCRIPTION
## What was wrong

flowwink.com published **16 near-identical blog posts** between 8 Jun and 23 Jul 2026 — the same "MCP + open source AI agents + BOS" article, re-worded, across Swedish and English, one titled with a literal `(2)`.

The timestamps give away the mechanism: **00:00 and 12:00 UTC, twice a day**. That's a cron automation carrying a *static topic* through the default content chain (`research_content` → `generate_content_proposal` → `write_blog_post`, seeded in `src/data/flowpilotDefaults.ts:45-47`). The operator had no idea it had already answered that topic 15 times.

## Why the existing fix didn't catch it

Content memory already existed — fb223b553 (12 Jul) added recent titles to the prompt, with a comment citing "6 near-identical blog titles in 6 days" from fast-sim. But it was **inlined in `flowpilot-heartbeat`**, and the duplicates were coming from `automation-dispatcher → agent-execute → ai-task`, which never sees the heartbeat's prompt. Duplicates kept landing for another **11 days** after that fix.

The fix was homed in the consumer that noticed the problem rather than in the platform — the same mistake the Skill Relevance Engine note in CLAUDE.md warns about.

## What this changes

**`supabase/functions/_shared/domains/content-memory.ts` (new)** — content memory as a platform primitive:
- `loadRecentContent` / `formatContentMemory` / `loadContentMemoryBlock` — the prompt block, empty-string when there's nothing to remember so callers concatenate unconditionally
- `titleSimilarity` / `findSimilarTitles` — containment over diacritic-folded, stopword-stripped words. Calibrated against the real corpus: **duplicates score 0.67–1.00, worst false positive 0.17**. Containment rather than Jaccard because the real duplicates vary in length (the Swedish pair is Jaccard 0.40 — below any threshold that clears the false positives — but containment 0.67).

**Wired into every generative content path**, via each task's existing `load` hook:
- `content_research`, `content_proposal`, `seo_content_brief` (`ai-task/tasks.ts`) — this is the path that actually broke
- `flowpilot-heartbeat` now calls the shared helper instead of its private copy

The prompt block also forbids **re-publishing the same argument in another language**, which is half the observed corpus.

## Guardrails

`src/lib/__tests__/content-memory.test.ts` — 21 tests, the regression corpus is the real titles from the live RSS feed. Three of them are wiring assertions aimed squarely at how the first fix went half-wired:

| assertion | regression it catches |
|---|---|
| each content task calls `loadContentMemoryBlock` | a new content task ships without memory |
| ...**and** puts `existing_coverage` in its system prompt | memory loaded but never reaches the model |
| heartbeat uses the shared helper | someone regrows a private recent-titles query |

All three were negative-tested — each fails on its specific regression and passes clean. The pre-existing `flowpilot-hermes` guardrail asserted the *inline* query, so it was retargeted to the shared helper (same intent, correct target).

Full suite: **1362 passed, 4 skipped**. Manifest regenerated.

## Not in this PR — handed off

Both remaining fixes live in `agent-execute/index.ts`, which is local Claude's exclusive file. Written up with exact diffs in `docs/operators/session-memory.md`:

1. **`write_blog_post` has no sink-level duplicate check.** Worse, the one mechanism that could have caught it was repurposed to *permit* duplication — the slug loop appends `-2`, `-3` on collision so a re-run of the same title inserts cleanly. Prompt-level memory is advisory; a sink guard isn't. The suggested shape warns rather than hard-rejects (a deliberate rewrite is legitimate) and reuses `findSimilarTitles` — no new measure needed.

2. **Slugs drop every non-ASCII letter.** `replace(/[^a-z0-9]+/g, '-')` runs before any transliteration, so "Varför öppna vikters" → `varf-r-ppna-vikters`. On a Swedish-first product that's every slug on the site. 6 occurrences in `agent-execute`, 10 more in `src/` (mine, ready to ship with a shared `slugify()` on request).

Also flagged, not blocking: the seeded workflow passes `write_blog_post` a `proposal:` argument, but the skill takes `title` + `content` and rejects anything else — that chain can't have been working as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_