### PR TITLE
fix(slugs): one slug generator, and Swedish letters survive it

### DIFF
--- a/docs/operators/session-memory.md
+++ b/docs/operators/session-memory.md
@@ -316,9 +316,28 @@ plus the heartbeat. Guardrails in `src/lib/__tests__/content-memory.test.ts`.
     .replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')
    ```
 
-   (Nordic pairs first: `å`/`ä`/`ö` decompose to `a`/`a`/`o` under NFD anyway,
-   but `ø` and `æ` do not.) Changing existing slugs breaks live URLs — apply to
-   **new** slugs only, or pair it with a redirect.
+   **Update (same day): the frontend half shipped.** `src/lib/slugify.ts` is now
+   the single generator — transliterate the non-decomposing letters (ø æ ß þ ð
+   ł đ), NFKD-decompose the rest, drop combining marks, *then* collapse to
+   ASCII. Doing the ASCII collapse first is what threw the information away.
+   Nineteen call sites in `src/` now import it (the first grep found nine; a
+   guardrail found ten more, including four blog/KB pages that each had their
+   own partial å/ä/ö-only variant). Import it in `agent-execute` too rather
+   than re-deriving:
+
+   ```ts
+   import { slugify } from '../_shared/…';  // or copy src/lib/slugify.ts logic
+   const baseSlug = slugify(resolvedTitle, { fallback: `post-${Date.now()}` });
+   ```
+
+   Changing existing slugs breaks live URLs — apply to **new** slugs only, or
+   pair it with a redirect.
+
+3. **`src/lib/modules/helpers.ts` `generateSlug()` has the same bug**
+   (`.replace(/[^a-z0-9\s-]/g, '')` with no transliteration). That file is in
+   your exclusive territory so it is grandfathered in
+   `src/lib/__tests__/slugify.test.ts` rather than fixed — swap it for
+   `slugify` from `@/lib/slugify` and drop the GRANDFATHERED entry.
 
 **Also worth a look, not blocking:** the default workflow in
 `flowpilotDefaults.ts:47` passes `write_blog_post` a `proposal:` argument. The

--- a/src/components/admin/ProductCategoryManager.tsx
+++ b/src/components/admin/ProductCategoryManager.tsx
@@ -23,6 +23,7 @@ import {
   type CostingMethod,
 } from '@/hooks/useProductCategories';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { slugify } from '@/lib/slugify';
 
 interface CategoryForm {
   name: string;
@@ -38,9 +39,6 @@ const emptyForm: CategoryForm = {
   name: '', slug: '', description: '', image_url: '', is_active: true, sort_order: 0, costing_method: 'average',
 };
 
-function slugify(s: string) {
-  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
-}
 
 export function ProductCategoryManager() {
   const { data: categories = [], isLoading } = useProductCategories();

--- a/src/components/admin/blocks/BlockAnchorControl.tsx
+++ b/src/components/admin/blocks/BlockAnchorControl.tsx
@@ -8,6 +8,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { slugify } from '@/lib/slugify';
 
 interface BlockAnchorControlProps {
   anchorId?: string;
@@ -23,12 +24,7 @@ export function BlockAnchorControl({ anchorId, onChange }: BlockAnchorControlPro
 
   // Sanitize anchor ID: lowercase, no spaces, no special chars except hyphens
   const sanitizeAnchorId = (value: string): string => {
-    return value
-      .toLowerCase()
-      .replace(/\s+/g, '-')
-      .replace(/[^a-z0-9-]/g, '')
-      .replace(/--+/g, '-')
-      .replace(/^-|-$/g, '');
+    return slugify(value);
   };
 
   const handleChange = (value: string) => {

--- a/src/components/admin/blog/BlogCategoriesTab.tsx
+++ b/src/components/admin/blog/BlogCategoriesTab.tsx
@@ -16,9 +16,10 @@ import {
   useBlogCategories, useCreateBlogCategory, useUpdateBlogCategory, useDeleteBlogCategory,
 } from "@/hooks/useBlogCategories";
 import type { BlogCategory } from "@/types/cms";
+import { slugify } from '@/lib/slugify';
 
 function generateSlug(name: string): string {
-  return name.toLowerCase().replace(/[åä]/g, "a").replace(/ö/g, "o").replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  return slugify(name);
 }
 
 export default function BlogCategoriesTab() {

--- a/src/components/admin/blog/BlogTagsTab.tsx
+++ b/src/components/admin/blog/BlogTagsTab.tsx
@@ -14,9 +14,10 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useBlogTags, useCreateBlogTag, useUpdateBlogTag, useDeleteBlogTag } from "@/hooks/useBlogTags";
 import type { BlogTag } from "@/types/cms";
+import { slugify } from '@/lib/slugify';
 
 function generateSlug(name: string): string {
-  return name.toLowerCase().replace(/[åä]/g, "a").replace(/ö/g, "o").replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  return slugify(name);
 }
 
 export default function BlogTagsTab() {

--- a/src/components/admin/kb/KbCategoryDialog.tsx
+++ b/src/components/admin/kb/KbCategoryDialog.tsx
@@ -22,6 +22,7 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { useKbCategories, useCreateKbCategory, useUpdateKbCategory } from "@/hooks/useKnowledgeBase";
+import { slugify } from '@/lib/slugify';
 
 const formSchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -82,12 +83,7 @@ export function KbCategoryDialog({ open, onOpenChange, categoryId }: KbCategoryD
   const watchName = form.watch("name");
   useEffect(() => {
     if (!isEditing && watchName) {
-      const slug = watchName
-        .toLowerCase()
-        .replace(/[åä]/g, "a")
-        .replace(/ö/g, "o")
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/^-|-$/g, "");
+      const slug = slugify(watchName);
       form.setValue("slug", slug);
     }
   }, [watchName, isEditing, form]);

--- a/src/components/admin/recruitment/NewJobDialog.tsx
+++ b/src/components/admin/recruitment/NewJobDialog.tsx
@@ -15,13 +15,8 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useCreateJobPosting } from '@/hooks/useRecruitment';
 import { Plus } from 'lucide-react';
+import { slugify } from '@/lib/slugify';
 
-const slugify = (s: string) =>
-  s
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
 
 export function NewJobDialog({ open: controlledOpen, onOpenChange }: { open?: boolean; onOpenChange?: (o: boolean) => void } = {}) {
   const [internalOpen, setInternalOpen] = useState(false);

--- a/src/hooks/useBlogTags.ts
+++ b/src/hooks/useBlogTags.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import type { BlogTag } from '@/types/cms';
 import { useToast } from '@/hooks/use-toast';
+import { slugify } from '@/lib/slugify';
 
 export function useBlogTags() {
   return useQuery({
@@ -144,11 +145,7 @@ export function useGetOrCreateBlogTag() {
   
   return useMutation({
     mutationFn: async (name: string) => {
-      const slug = name.toLowerCase()
-        .replace(/[åä]/g, 'a')
-        .replace(/ö/g, 'o')
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-|-$/g, '');
+      const slug = slugify(name);
       
       // Check if tag exists
       const { data: existing } = await supabase

--- a/src/hooks/useCopilot.ts
+++ b/src/hooks/useCopilot.ts
@@ -9,6 +9,7 @@ import { useUpdateFooterBlock } from '@/hooks/useGlobalBlocks';
 import { toast } from 'sonner';
 import type { ContentBlock, ContentBlockType } from '@/types/cms';
 import { extractImageUrls, updateBlockAtPath, isExternalUrl } from '@/lib/image-extraction';
+import { slugify } from '@/lib/slugify';
 
 // Block-to-Module mapping for auto-enabling modules
 const BLOCK_MODULE_MAP: Record<string, keyof ModulesSettings> = {
@@ -395,12 +396,9 @@ export function useCopilot(): UseCopilotReturn {
           const path = new URL(url).pathname;
           const segments = path.split('/').filter(Boolean);
           const lastSegment = segments[segments.length - 1] || 'home';
-          pageSlug = lastSegment
-            .replace(/\.(html|php|aspx?)$/i, '')
-            .toLowerCase()
-            .replace(/[^a-z0-9-]/g, '-')
-            .replace(/-+/g, '-')
-            .replace(/^-|-$/g, '') || 'home';
+          pageSlug = slugify(lastSegment.replace(/\.(html|php|aspx?)$/i, ''), {
+            fallback: 'home',
+          });
         } catch {
           pageSlug = 'page';
         }
@@ -509,14 +507,7 @@ export function useCopilot(): UseCopilotReturn {
 
   // Helper: Generate slug from title
   const generateSlug = (title: string): string => {
-    return title
-      .toLowerCase()
-      .replace(/[äå]/g, 'a')
-      .replace(/ö/g, 'o')
-      .replace(/[^a-z0-9\s-]/g, '')
-      .trim()
-      .replace(/\s+/g, '-')
-      .replace(/-+/g, '-');
+    return slugify(title);
   };
 
   const approveMigrationBlock = useCallback(async () => {

--- a/src/hooks/useEntityTags.ts
+++ b/src/hooks/useEntityTags.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { slugify } from '@/lib/slugify';
 
 const sb = supabase as unknown as {
   from: (table: string) => any;
@@ -88,7 +89,7 @@ export function useCreateTag() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (input: { name: string; color?: string; scope?: string }) => {
-      const slug = input.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+      const slug = slugify(input.name);
       const { data, error } = await sb
         .from('tags')
         .insert({ name: input.name, slug, color: input.color ?? '#64748b', scope: input.scope ?? '*' })

--- a/src/hooks/useFlowtable.ts
+++ b/src/hooks/useFlowtable.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { slugify as sharedSlugify, fieldKey as sharedFieldKey } from '@/lib/slugify';
 
 export type FlowtableFieldType =
   | 'text'
@@ -109,22 +110,10 @@ export interface FlowtableRecord {
 }
 
 export const slugify = (s: string) =>
-  s
-    .toLowerCase()
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '')
-    .slice(0, 60) || `item-${Date.now().toString(36)}`;
+  sharedSlugify(s, { maxLength: 60, fallback: `item-${Date.now().toString(36)}` });
 
 export const fieldKeyify = (s: string) =>
-  s
-    .toLowerCase()
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9_]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 40) || `field_${Math.random().toString(36).slice(2, 6)}`;
+  sharedFieldKey(s, { maxLength: 40, fallback: `field_${Math.random().toString(36).slice(2, 6)}` });
 
 // ---------- Bases ----------
 export function useFlowtableBases() {

--- a/src/lib/__tests__/slugify.test.ts
+++ b/src/lib/__tests__/slugify.test.ts
@@ -1,0 +1,168 @@
+/**
+ * The single slug generator.
+ *
+ * The bug this replaces: `title.toLowerCase().replace(/[^a-z0-9]+/g, '-')` with
+ * no transliteration first, which deletes every non-ASCII letter. On a
+ * Swedish-first product that mangles a large share of all titles.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { slugify, fieldKey } from '../slugify';
+
+describe('slugify — Nordic characters survive', () => {
+  it.each([
+    ['Varför öppna vikters', 'varfor-oppna-vikters'],
+    ['Så förändrar AI-agenter framtiden', 'sa-forandrar-ai-agenter-framtiden'],
+    ['Öppna Vikters Modeller', 'oppna-vikters-modeller'],
+    ['Blåbærsyltetøy', 'blabaersyltetoy'],
+    ['Ångström & Ö', 'angstrom-o'],
+    ['Grüße aus München', 'grusse-aus-munchen'],
+    ['Þórshöfn', 'thorshofn'],
+    ['Łódź', 'lodz'],
+    ['Café Crème', 'cafe-creme'],
+  ])('%s -> %s', (input, expected) => {
+    expect(slugify(input)).toBe(expected);
+  });
+
+  it('is what the old implementation got wrong', () => {
+    const old = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+    expect(old('Varför öppna vikters')).toBe('varf-r-ppna-vikters'); // the live bug
+    expect(slugify('Varför öppna vikters')).toBe('varfor-oppna-vikters');
+  });
+});
+
+describe('slugify — basic shaping', () => {
+  it.each([
+    ['Hello World', 'hello-world'],
+    ['  leading and trailing  ', 'leading-and-trailing'],
+    ['multiple   spaces', 'multiple-spaces'],
+    ['Punctuation!!! Everywhere???', 'punctuation-everywhere'],
+    ['already-slugged', 'already-slugged'],
+    ['--edges--', 'edges'],
+    ['CAPS LOCK', 'caps-lock'],
+    ['numbers 123 kept', 'numbers-123-kept'],
+  ])('%s -> %s', (input, expected) => {
+    expect(slugify(input)).toBe(expected);
+  });
+
+  it('never emits doubled or edge separators', () => {
+    for (const input of ['a -- b', '!!!a!!!b!!!', '   ', '- - -', 'a/b\\c']) {
+      const out = slugify(input, { fallback: 'x' });
+      expect(out).not.toMatch(/--/);
+      expect(out).not.toMatch(/^-|-$/);
+    }
+  });
+});
+
+describe('slugify — degenerate input', () => {
+  it('returns the fallback rather than an empty slug', () => {
+    expect(slugify('🎉🎉🎉', { fallback: 'post' })).toBe('post');
+    expect(slugify('', { fallback: 'post' })).toBe('post');
+    expect(slugify('!!!', { fallback: 'post' })).toBe('post');
+  });
+
+  it('returns empty string when no fallback is given, never undefined', () => {
+    expect(slugify('🎉')).toBe('');
+    expect(slugify(null as unknown as string)).toBe('');
+    expect(slugify(undefined as unknown as string)).toBe('');
+  });
+
+  it('collapses scripts it cannot transliterate instead of throwing', () => {
+    expect(() => slugify('日本語のタイトル')).not.toThrow();
+    expect(slugify('日本語のタイトル', { fallback: 'post' })).toBe('post');
+  });
+});
+
+describe('slugify — maxLength', () => {
+  it('truncates and does not leave a trailing separator', () => {
+    // 'a-very-long-title-that' is 22 chars; cutting at 20 lands mid-word.
+    const out = slugify('a very long title that keeps going', { maxLength: 20 });
+    expect(out.length).toBeLessThanOrEqual(20);
+    expect(out).not.toMatch(/-$/);
+  });
+
+  it('leaves short slugs untouched', () => {
+    expect(slugify('short', { maxLength: 60 })).toBe('short');
+  });
+
+  it('falls back when truncation would leave nothing', () => {
+    expect(slugify('!!!!!!!!!!', { maxLength: 5, fallback: 'item' })).toBe('item');
+  });
+});
+
+describe('fieldKey — identifier form', () => {
+  it('uses underscores and still transliterates', () => {
+    expect(fieldKey('Antal Öppna Ärenden')).toBe('antal_oppna_arenden');
+    expect(fieldKey('  spaced  out  ')).toBe('spaced_out');
+    expect(fieldKey('a--b')).toBe('a_b');
+  });
+
+  it('honours maxLength and fallback like slugify', () => {
+    expect(fieldKey('x'.repeat(50), { maxLength: 40 })).toHaveLength(40);
+    expect(fieldKey('🎉', { fallback: 'field' })).toBe('field');
+  });
+});
+
+describe('slugify is stable', () => {
+  it('is idempotent — slugging a slug changes nothing', () => {
+    for (const input of ['Varför öppna vikters', 'Café Crème', 'Hello World', 'Þórshöfn']) {
+      const once = slugify(input);
+      expect(slugify(once)).toBe(once);
+    }
+  });
+});
+
+// ─── Guardrail ──────────────────────────────────────────────────────────────
+// Five hand-rolled copies existed before this module, three of them dropping
+// Swedish characters. Assert no new one appears: the giveaway is an ASCII-only
+// character class applied to a lowercased string with no transliteration first.
+describe('no hand-rolled slug generators in src/', () => {
+  const ASCII_STRIP = /replace\(\s*\/\[\^a-z0-9[^\]]*\]\+?\/g/;
+
+  const GRANDFATHERED = new Set([
+    // slugify itself, and the test that proves the old behaviour was wrong.
+    'src/lib/slugify.ts',
+    'src/lib/__tests__/slugify.test.ts',
+    // Mirrors agent-execute's slug logic byte for byte; it must keep matching
+    // the backend, not this module. Drop it when the backend adopts slugify().
+    'src/lib/__tests__/manage-deal-auto-lead.test.ts',
+    // Not a slug generator — a search tokenizer that deliberately KEEPS å/ä/ö
+    // as meaningful characters rather than folding them.
+    'src/components/public/blocks/ConsultantMatcherBlock.tsx',
+    // src/lib/modules/* is local Claude's exclusive territory. generateSlug()
+    // there has the same non-ASCII bug; reported in session-memory.md, not
+    // touched here.
+    'src/lib/modules/helpers.ts',
+  ]);
+
+  function walk(dir: string, out: string[] = []): string[] {
+    for (const entry of readdirSync(dir)) {
+      if (entry === 'node_modules') continue;
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full, out);
+      else if (/\.(ts|tsx)$/.test(entry)) out.push(relative(process.cwd(), full));
+    }
+    return out;
+  }
+
+  it('every remaining ASCII-strip site is grandfathered', () => {
+    const offenders: string[] = [];
+    for (const rel of walk(join(process.cwd(), 'src'))) {
+      if (GRANDFATHERED.has(rel)) continue;
+      if (ASCII_STRIP.test(readFileSync(join(process.cwd(), rel), 'utf-8'))) offenders.push(rel);
+    }
+    expect(
+      offenders,
+      `hand-rolled slug generator(s) found — import { slugify } from '@/lib/slugify' instead:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('the grandfathered list has no stale entries', () => {
+    for (const rel of GRANDFATHERED) {
+      if (rel === 'src/lib/slugify.ts' || rel === 'src/lib/__tests__/slugify.test.ts') continue;
+      const src = readFileSync(join(process.cwd(), rel), 'utf-8');
+      expect(ASCII_STRIP.test(src), `${rel} no longer strips ASCII — drop it from GRANDFATHERED`).toBe(true);
+    }
+  });
+});

--- a/src/lib/slugify.ts
+++ b/src/lib/slugify.ts
@@ -1,0 +1,81 @@
+/**
+ * One slug generator for the whole app.
+ *
+ * Before this there were five, and they disagreed. A tag named "Öppna vikter"
+ * became `oppna-vikter` in blog tags, `-ppna-vikter` in entity tags, and
+ * `oppna-vikter` again in Flowtable — the same word, three slugs, depending on
+ * which screen you happened to be on. The plain-ASCII variants
+ * (`replace(/[^a-z0-9]+/g, '-')` with no transliteration first) silently delete
+ * every non-ASCII letter, so on a Swedish-first product "Varför öppna vikters"
+ * came out as `varf-r-ppna-vikters`.
+ *
+ * The order below is the whole trick: transliterate the letters that do NOT
+ * decompose (ø, æ, ß, þ, ð, ł, đ), then NFKD-decompose the rest and drop the
+ * combining marks, and only then collapse to ASCII. Doing the ASCII collapse
+ * first — as every previous copy did — throws the information away before
+ * anything can preserve it.
+ *
+ * Scope: this generates slugs for NEW records. Existing stored slugs are not
+ * rewritten — that would break live URLs. A record keeps whatever slug it was
+ * born with.
+ */
+
+/** Letters NFKD leaves alone, so they need an explicit mapping. */
+const TRANSLITERATIONS: Array<[RegExp, string]> = [
+  [/ø/g, 'o'],
+  [/æ/g, 'ae'], // the ligature spells out; ä/å still fold to 'a' via NFKD
+  [/œ/g, 'oe'],
+  [/ß/g, 'ss'],
+  [/þ/g, 'th'],
+  [/ð/g, 'd'],
+  [/đ/g, 'd'],
+  [/ł/g, 'l'],
+  [/ħ/g, 'h'],
+  [/ŧ/g, 't'],
+  [/ı/g, 'i'],
+  [/·/g, ''],
+];
+
+export interface SlugifyOptions {
+  /** Truncate to this many characters (trailing separators trimmed after). */
+  maxLength?: number;
+  /** Word separator. `-` for URLs, `_` for identifiers/field keys. */
+  separator?: string;
+  /** Returned when the input yields nothing usable (e.g. an emoji-only title). */
+  fallback?: string;
+}
+
+/**
+ * URL/identifier-safe slug, diacritics preserved as their base letters.
+ *
+ *   slugify('Varför öppna vikters')  // 'varfor-oppna-vikters'
+ *   slugify('Blåbærsyltetøy')        // 'blabaersyltetoy'
+ *   slugify('Grüße', { separator: '_' }) // 'gruesse' -> 'grusse'
+ */
+export function slugify(input: string, options: SlugifyOptions = {}): string {
+  const { maxLength, separator = '-', fallback = '' } = options;
+
+  let s = String(input ?? '').toLowerCase();
+  for (const [pattern, replacement] of TRANSLITERATIONS) s = s.replace(pattern, replacement);
+
+  // NFKD splits å → a + ring, ﬁ → fi, ① → 1; the combining marks then go.
+  s = s.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+
+  // Anything still not [a-z0-9] becomes a separator; runs collapse; ends trim.
+  const sepClass = separator.replace(/[.*+?^${}()|[\]\\-]/g, '\\$&');
+  s = s
+    .replace(/[^a-z0-9]+/g, separator)
+    .replace(new RegExp(`${sepClass}{2,}`, 'g'), separator)
+    .replace(new RegExp(`^${sepClass}+|${sepClass}+$`, 'g'), '');
+
+  if (maxLength && s.length > maxLength) {
+    s = s.slice(0, maxLength).replace(new RegExp(`${sepClass}+$`), '');
+  }
+
+  return s || fallback;
+}
+
+/** Identifier form — underscores instead of hyphens (Flowtable field keys). */
+export function fieldKey(input: string, options: Omit<SlugifyOptions, 'separator'> = {}): string {
+  return slugify(input, { ...options, separator: '_' });
+}

--- a/src/lib/template-importer.ts
+++ b/src/lib/template-importer.ts
@@ -8,6 +8,7 @@
 import { StarterTemplate, TemplatePage, TemplateBlogPost } from '@/data/templates/types';
 import { validateJsonTemplate } from '@/lib/template-json-loader';
 import { ContentBlock } from '@/types/cms';
+import { slugify } from '@/lib/slugify';
 
 export interface ImportResult {
   success: boolean;
@@ -168,10 +169,7 @@ export function modifyTemplate(
  * Generate a unique ID for an imported template
  */
 export function generateTemplateId(baseName: string): string {
-  const slug = baseName
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
+  const slug = slugify(baseName);
   
   const timestamp = Date.now().toString(36).slice(-4);
   return `${slug}-${timestamp}`;

--- a/src/lib/template-validator.ts
+++ b/src/lib/template-validator.ts
@@ -7,6 +7,7 @@
 
 import { StarterTemplate, TemplatePage, TemplateBlogPost } from '@/data/templates';
 import { ContentBlock, ContentBlockType } from '@/types/cms';
+import { slugify } from '@/lib/slugify';
 
 export interface ValidationResult {
   valid: boolean;
@@ -136,7 +137,7 @@ export function validateTemplate(template: Partial<StarterTemplate>): Validation
     errors.push({
       path: 'id',
       message: 'Template ID must be lowercase with dashes only',
-      suggestion: `Use "${template.id.toLowerCase().replace(/[^a-z0-9-]/g, '-')}"`,
+      suggestion: `Use "${slugify(template.id)}"`,
     });
   }
 
@@ -262,7 +263,7 @@ function validatePage(page: TemplatePage, path: string): ValidationResult {
     errors.push({
       path: `${path}.slug`,
       message: 'Page slug must be lowercase with dashes only',
-      suggestion: `Use "${page.slug.toLowerCase().replace(/[^a-z0-9-]/g, '-')}"`,
+      suggestion: `Use "${slugify(page.slug)}"`,
     });
   }
 

--- a/src/pages/BlogAuthorPage.tsx
+++ b/src/pages/BlogAuthorPage.tsx
@@ -8,6 +8,7 @@ import { SeoHead } from '@/components/public/SeoHead';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { BlogPostCard } from '@/components/public/BlogPostCard';
 import NotFound from './NotFound';
+import { slugify } from '@/lib/slugify';
 
 interface AuthorProfile {
   id: string;
@@ -19,13 +20,6 @@ interface AuthorProfile {
   show_as_author?: boolean | null;
 }
 
-function slugify(v: string): string {
-  return v
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
 
 function useAuthorBySlug(slug: string | undefined) {
   return useQuery({

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -16,6 +16,7 @@ import { useBlogSettings } from "@/hooks/useSiteSettings";
 import { usePageViewTracker } from "@/hooks/usePageViewTracker";
 import { isTiptapDocument, renderToHtml } from "@/lib/tiptap-utils";
 import NotFound from "./NotFound";
+import { slugify } from '@/lib/slugify';
 
 export default function BlogPostPage() {
   const t = useUiText();
@@ -216,7 +217,7 @@ export default function BlogPostPage() {
                 <Link
                   to={`/blog/author/${
                     post.author.full_name
-                      ? post.author.full_name.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+                      ? slugify(post.author.full_name)
                       : post.author.id
                   }`}
                   className="text-sm text-primary hover:underline"

--- a/src/pages/admin/BlogCategoriesPage.tsx
+++ b/src/pages/admin/BlogCategoriesPage.tsx
@@ -33,14 +33,10 @@ import {
   useDeleteBlogCategory,
 } from "@/hooks/useBlogCategories";
 import type { BlogCategory } from "@/types/cms";
+import { slugify } from '@/lib/slugify';
 
 function generateSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[åä]/g, "a")
-    .replace(/ö/g, "o")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
+  return slugify(name);
 }
 
 export default function BlogCategoriesPage() {

--- a/src/pages/admin/BlogPostEditorPage.tsx
+++ b/src/pages/admin/BlogPostEditorPage.tsx
@@ -42,14 +42,10 @@ import { useBlogCategories } from "@/hooks/useBlogCategories";
 import { useBlogTags, useGetOrCreateBlogTag } from "@/hooks/useBlogTags";
 import { useBlogSettings, useGeneralSettings } from "@/hooks/useSiteSettings";
 import type { PageStatus, BlogPostMeta, TiptapDocument } from "@/types/cms";
+import { slugify } from '@/lib/slugify';
 
 function generateSlug(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[åä]/g, "a")
-    .replace(/ö/g, "o")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
+  return slugify(title);
 }
 
 export default function BlogPostEditorPage() {

--- a/src/pages/admin/BlogTagsPage.tsx
+++ b/src/pages/admin/BlogTagsPage.tsx
@@ -33,14 +33,10 @@ import {
   useDeleteBlogTag,
 } from "@/hooks/useBlogTags";
 import type { BlogTag } from "@/types/cms";
+import { slugify } from '@/lib/slugify';
 
 function generateSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[åä]/g, "a")
-    .replace(/ö/g, "o")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
+  return slugify(name);
 }
 
 export default function BlogTagsPage() {

--- a/src/pages/admin/KbArticleEditorPage.tsx
+++ b/src/pages/admin/KbArticleEditorPage.tsx
@@ -35,6 +35,7 @@ import { AITextAssistant } from "@/components/admin/AITextAssistant";
 import { KbVersionHistoryCard } from "@/components/admin/kb/KbVersionHistoryCard";
 import { Toggle } from "@/components/ui/toggle";
 import { Separator } from "@/components/ui/separator";
+import { slugify } from '@/lib/slugify';
 
 export default function KbArticleEditorPage() {
   const { id } = useParams();
@@ -108,12 +109,7 @@ export default function KbArticleEditorPage() {
   // Auto-generate slug from title
   useEffect(() => {
     if (isNew && formData.title) {
-      const slug = formData.title
-        .toLowerCase()
-        .replace(/[åä]/g, "a")
-        .replace(/ö/g, "o")
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/^-|-$/g, "");
+      const slug = slugify(formData.title);
       setFormData(prev => ({ ...prev, slug }));
     }
   }, [formData.title, isNew]);

--- a/src/pages/admin/NewPagePage.tsx
+++ b/src/pages/admin/NewPagePage.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { useCreatePage } from '@/hooks/usePages';
 import { z } from 'zod';
 import { useToast } from '@/hooks/use-toast';
+import { slugify } from '@/lib/slugify';
 
 const pageSchema = z.object({
   title: z.string().min(2, 'Title must be at least 2 characters'),
@@ -24,15 +25,7 @@ export default function NewPagePage() {
   const createPage = useCreatePage();
   const { toast } = useToast();
 
-  const generateSlug = (text: string) => {
-    return text
-      .toLowerCase()
-      .replace(/å/g, 'a')
-      .replace(/ä/g, 'a')
-      .replace(/ö/g, 'o')
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-|-$/g, '');
-  };
+  const generateSlug = (text: string) => slugify(text);
 
   const handleTitleChange = (value: string) => {
     setTitle(value);


### PR DESCRIPTION
Follow-up to #145, which flagged this. The frontend half.

## What was wrong

There were **five hand-rolled slug generators** in `src/`, and they disagreed. A tag named "Öppna vikter" became:

| screen | slug |
|---|---|
| blog tags | `oppna-vikter` |
| entity tags | `-ppna-vikter` |
| Flowtable | `oppna-vikter` |

Same word, three slugs, depending on which screen you happened to be on.

The plain-ASCII variants ran `.replace(/[^a-z0-9]+/g, '-')` with **no transliteration first**, which silently deletes every non-ASCII letter. On a Swedish-first product that means "Varför öppna vikters" ships as `varf-r-ppna-vikters` — which is exactly what happened to the real blog posts in #145. Four more copies handled å/ä/ö but nothing else, so é, ü, ø and æ still vanished.

## The fix

`src/lib/slugify.ts` is now the only one. The **order** is the whole trick:

1. transliterate the letters NFKD leaves alone — ø æ ß þ ð ł đ
2. NFKD-decompose the rest and drop the combining marks
3. *then* collapse to ASCII

Doing the ASCII collapse first — as every previous copy did — throws the information away before anything can preserve it.

```ts
slugify('Varför öppna vikters')  // 'varfor-oppna-vikters'  (was 'varf-r-ppna-vikters')
slugify('Blåbærsyltetøy')        // 'blabaersyltetoy'
slugify('Grüße aus München')     // 'grusse-aus-munchen'
slugify('🎉', { fallback: 'post' })  // 'post'
fieldKey('Antal Öppna Ärenden')  // 'antal_oppna_arenden'
```

Options cover the variations each old copy hand-rolled: `maxLength`, `separator` (`fieldKey()` for identifiers), and a `fallback` so an emoji-only title never yields an empty slug.

## 19 call sites converted

My first grep found nine. **The guardrail found ten more** — including four blog/KB pages that had each independently grown their own partial å/ä/ö-only variant. That's the argument for having the guardrail rather than trusting a grep: it fails on any new `[^a-z0-9]` strip in `src/` outside a small grandfathered list, and a second test prunes the list when an entry stops matching. Both negative-tested.

Grandfathered rather than fixed, each with a reason in the test:
- `ConsultantMatcherBlock` — a search tokenizer that *deliberately* keeps å/ä/ö as meaningful characters
- `manage-deal-auto-lead.test.ts` — mirrors `agent-execute` byte for byte; it must track the backend, not this module
- `src/lib/modules/helpers.ts` — same bug, but that's local Claude's exclusive file; reported in `session-memory.md` with the diff

## Scope and safety

**New slugs only.** Stored slugs are not rewritten — a record keeps whatever slug it was born with, so no live URL changes. The one pair that derives slugs at render time on both sides (`BlogPostPage` builds the author link, `BlogAuthorPage` resolves it) was changed together, so they stay in lockstep.

Full suite: **1393 passed, 4 skipped**. 30 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_