### PR TITLE
feat(ci): alert when main stays red

### DIFF
--- a/.github/workflows/main-red-alert.yml
+++ b/.github/workflows/main-red-alert.yml
@@ -1,0 +1,158 @@
+# main went red three times in ten days and every time it was found by the next
+# gate to run, not by anyone noticing. CI already runs on every push to main —
+# the result just goes unwatched.
+#
+# Required checks would close the gap too, but they also block the
+# direct-to-main flow Lovable uses, which is deliberate. Watching the result
+# costs nothing and changes nobody's workflow.
+#
+# Opens ONE issue when main has been red past the grace window, keeps it
+# current, and closes it the moment a run on main succeeds. The streak logic
+# lives in scripts/main-red-alert.mjs so it can be unit-tested
+# (src/lib/__tests__/main-red-alert.test.ts).
+name: main-red alert
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+    # Only CI runs whose head branch is main — a PR's CI says nothing about main.
+    branches: [main]
+  schedule:
+    # Safety net: catches a red that started while no push was happening, and
+    # re-checks a failure still inside its grace window.
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      grace_minutes:
+        description: 'Minutes main may stay red before alerting'
+        required: false
+        default: '30'
+
+permissions:
+  actions: read
+  issues: write
+
+# Never let two evaluations race to create the same issue.
+concurrency:
+  group: main-red-alert
+  cancel-in-progress: false
+
+jobs:
+  evaluate:
+    name: Evaluate main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (decision logic only)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/main-red-alert.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Evaluate and alert
+        uses: actions/github-script@v7
+        env:
+          GRACE_MINUTES: ${{ github.event.inputs.grace_minutes || '30' }}
+        with:
+          script: |
+            const { decide, issueBody } = await import(
+              `${process.env.GITHUB_WORKSPACE}/scripts/main-red-alert.mjs`
+            );
+
+            const LABEL = 'main-red';
+            const TITLE = '🔴 main is red';
+            const grace = Number(process.env.GRACE_MINUTES) || 30;
+
+            // Completed CI runs on main, newest first. Only push events —
+            // a PR run says nothing about the state of main itself.
+            const { data } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              branch: 'main',
+              event: 'push',
+              status: 'completed',
+              per_page: 30,
+            });
+
+            const verdict = decide(data.workflow_runs, Date.now(), grace);
+            core.info(`main is ${verdict.state}` +
+              (verdict.minutesRed !== null ? ` (${verdict.minutesRed} min, streak ${verdict.streak})` : ''));
+
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: LABEL,
+              per_page: 5,
+            });
+            const existing = open.data[0];
+
+            if (verdict.state === 'unknown') {
+              // An empty API response looks exactly like "all is well". Alerting
+              // on it would train everyone to ignore this issue.
+              core.info('No conclusive CI runs found — taking no action.');
+              return;
+            }
+
+            if (verdict.state === 'green') {
+              if (existing) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: existing.number,
+                  body: `✅ main is green again as of \`${verdict.sha}\`.\n\n${verdict.url}`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: existing.number, state: 'closed',
+                });
+                core.info(`Closed #${existing.number}.`);
+              }
+              return;
+            }
+
+            if (verdict.state === 'grace') {
+              core.info(`Red for ${verdict.minutesRed} min — inside the ${grace} min grace window, staying quiet.`);
+              return;
+            }
+
+            // state === 'red'
+            const body = issueBody(verdict);
+
+            if (!existing) {
+              // Create the label if it is missing. issues.create is documented
+              // to create unknown labels, but a colour and description make the
+              // issue list readable and this costs one call on first alert only.
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  name: LABEL, color: 'b60205',
+                  description: 'main has been failing CI past the grace window',
+                });
+              } catch (e) {
+                if (e.status !== 422) throw e; // 422 = already exists
+              }
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title: TITLE, body, labels: [LABEL],
+              });
+              core.info('Opened the alert issue.');
+              return;
+            }
+
+            // Keep the body current on every check, but only comment when a NEW
+            // commit landed and main is STILL red — that is news; a ticking
+            // clock is not.
+            const previouslyReported = /Latest failing commit: `([^`]+)`/.exec(existing.body || '')?.[1];
+            await github.rest.issues.update({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: existing.number, body,
+            });
+            if (previouslyReported && previouslyReported !== verdict.sha) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Still red after a new commit — \`${verdict.sha}\` also failed.\n\n${verdict.url}`,
+              });
+            }
+            core.info(`Updated #${existing.number}.`);

--- a/scripts/main-red-alert.mjs
+++ b/scripts/main-red-alert.mjs
@@ -1,0 +1,89 @@
+/**
+ * main-red alert — decide whether main has been broken long enough to be worth
+ * a human's attention.
+ *
+ * Context: main went red three times in ten days and each time it was found by
+ * the next gate to run, not by anyone noticing. CI already runs on every push
+ * to main (Lovable pushes land under the owner's identity, so the
+ * `lovable-dev[bot]` skip filter in ci.yml never fires) — the result just goes
+ * unwatched.
+ *
+ * Required checks would close the gap too, but they also block Lovable's
+ * direct-to-main flow, which is deliberate. Watching the result instead costs
+ * nothing and changes no workflow.
+ *
+ * The grace window is the whole point. On 5 Aug a run failed at 01:46 and the
+ * next commit fixed it at 01:47 — alerting on that would have been noise. Only
+ * a failure that SURVIVES the window is worth an issue.
+ *
+ * Pure function so the streak logic is testable; the workflow supplies the runs.
+ */
+
+/** Conclusions that say nothing about main's health — skipped when walking. */
+const INCONCLUSIVE = new Set(['cancelled', 'skipped', 'neutral', 'stale', null, undefined]);
+
+const GREEN = new Set(['success']);
+
+/**
+ * @param {Array<{conclusion: string|null, created_at: string, head_sha: string, html_url: string}>} runs
+ *   Completed CI runs on main, newest first.
+ * @param {number} nowMs
+ * @param {number} graceMinutes  How long main may stay red before we speak up.
+ * @returns {{state: 'green'|'grace'|'red'|'unknown', minutesRed: number|null,
+ *            sha: string|null, url: string|null, streak: number, redSince: string|null}}
+ */
+export function decide(runs, nowMs, graceMinutes = 30) {
+  const conclusive = (runs || []).filter((r) => !INCONCLUSIVE.has(r?.conclusion));
+
+  if (conclusive.length === 0) {
+    // No signal at all — do NOT alert. An empty API response looks identical to
+    // "everything is fine", and crying wolf on an outage teaches people to
+    // ignore the alert.
+    return { state: 'unknown', minutesRed: null, sha: null, url: null, streak: 0, redSince: null };
+  }
+
+  const latest = conclusive[0];
+  if (GREEN.has(latest.conclusion)) {
+    return { state: 'green', minutesRed: null, sha: latest.head_sha, url: latest.html_url, streak: 0, redSince: null };
+  }
+
+  // Walk back through consecutive failures to find when the streak began — a
+  // second failing commit does not reset the clock, otherwise a rapid series of
+  // broken pushes would hold the alert off forever.
+  let oldest = latest;
+  let streak = 0;
+  for (const run of conclusive) {
+    if (GREEN.has(run.conclusion)) break;
+    oldest = run;
+    streak++;
+  }
+
+  const redSinceMs = Date.parse(oldest.created_at);
+  const minutesRed = Number.isNaN(redSinceMs) ? 0 : Math.floor((nowMs - redSinceMs) / 60000);
+
+  return {
+    state: minutesRed >= graceMinutes ? 'red' : 'grace',
+    minutesRed,
+    sha: latest.head_sha,
+    url: latest.html_url,
+    streak,
+    redSince: oldest.created_at,
+  };
+}
+
+/** Issue body. Rebuilt on every check so the issue always shows current state. */
+export function issueBody({ minutesRed, sha, url, streak, redSince }) {
+  return [
+    `**main has been red for ~${minutesRed} minutes.**`,
+    '',
+    `- Failing since: \`${redSince}\` (${streak} consecutive failing run${streak === 1 ? '' : 's'})`,
+    `- Latest failing commit: \`${sha}\``,
+    `- Run: ${url}`,
+    '',
+    'This issue closes itself as soon as a CI run on main succeeds.',
+    '',
+    '<sub>Opened by `.github/workflows/main-red-alert.yml`. It watches the CI',
+    'result on main rather than blocking merges, so direct-to-main pushes keep',
+    'working.</sub>',
+  ].join('\n');
+}

--- a/src/lib/__tests__/main-red-alert.test.ts
+++ b/src/lib/__tests__/main-red-alert.test.ts
@@ -1,0 +1,139 @@
+/**
+ * The main-red alert's streak logic.
+ *
+ * Two failure modes matter more than the happy path: alerting on a red that
+ * someone fixes a minute later (noise, and people learn to ignore the alert),
+ * and staying quiet through a genuine outage because the API returned nothing.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs helper, consumed by the workflow via github-script
+import { decide, issueBody } from '../../../scripts/main-red-alert.mjs';
+
+const NOW = Date.parse('2026-08-05T12:00:00Z');
+const minutesAgo = (m: number) => new Date(NOW - m * 60000).toISOString();
+
+const run = (conclusion: string | null, mAgo: number, sha = 'abc1234') => ({
+  conclusion,
+  created_at: minutesAgo(mAgo),
+  head_sha: sha,
+  html_url: `https://github.com/o/r/actions/runs/${mAgo}`,
+});
+
+describe('decide — green', () => {
+  it('reports green when the newest conclusive run succeeded', () => {
+    const d = decide([run('success', 5), run('failure', 90)], NOW);
+    expect(d.state).toBe('green');
+    expect(d.minutesRed).toBeNull();
+  });
+
+  it('a fix on top of a long red streak is green immediately', () => {
+    const d = decide([run('success', 1), run('failure', 200), run('failure', 240)], NOW);
+    expect(d.state).toBe('green');
+    expect(d.streak).toBe(0);
+  });
+});
+
+describe('decide — the grace window', () => {
+  it('stays quiet for a failure younger than the window', () => {
+    // The real 5 Aug case: failed 01:46, fixed 01:47.
+    expect(decide([run('failure', 1)], NOW).state).toBe('grace');
+    expect(decide([run('failure', 29)], NOW).state).toBe('grace');
+  });
+
+  it('alerts once the failure survives the window', () => {
+    expect(decide([run('failure', 30)], NOW).state).toBe('red');
+    expect(decide([run('failure', 31)], NOW).state).toBe('red');
+  });
+
+  it('honours a custom window', () => {
+    expect(decide([run('failure', 10)], NOW, 5).state).toBe('red');
+    expect(decide([run('failure', 10)], NOW, 60).state).toBe('grace');
+  });
+});
+
+describe('decide — the streak clock does not reset', () => {
+  it('measures from the FIRST failure, not the newest one', () => {
+    // Broken at T-90; three more broken pushes since. Measuring from the newest
+    // would restart the 30-minute clock on every push and never alert.
+    const d = decide(
+      [run('failure', 2, 'newest'), run('failure', 40), run('failure', 90, 'oldest')],
+      NOW,
+    );
+    expect(d.state).toBe('red');
+    expect(d.minutesRed).toBe(90);
+    expect(d.streak).toBe(3);
+    expect(d.redSince).toBe(minutesAgo(90));
+  });
+
+  it('stops the walk at the last green run', () => {
+    const d = decide(
+      [run('failure', 45), run('failure', 60), run('success', 70), run('failure', 500)],
+      NOW,
+    );
+    expect(d.streak).toBe(2);
+    expect(d.minutesRed).toBe(60);
+  });
+
+  it('reports the NEWEST failing sha even though it dates the streak from the oldest', () => {
+    const d = decide([run('failure', 5, 'newest'), run('failure', 90, 'oldest')], NOW);
+    expect(d.sha).toBe('newest');
+    expect(d.redSince).toBe(minutesAgo(90));
+  });
+});
+
+describe('decide — inconclusive runs are not signal', () => {
+  it.each(['cancelled', 'skipped', 'neutral', 'stale', null])(
+    'skips %s when finding the newest real result',
+    (conclusion) => {
+      const d = decide([run(conclusion as string | null, 1), run('success', 10)], NOW);
+      expect(d.state).toBe('green');
+    },
+  );
+
+  it('a cancelled run in the middle does not break a failure streak', () => {
+    const d = decide([run('failure', 5), run('cancelled', 20), run('failure', 90)], NOW);
+    expect(d.streak).toBe(2);
+    expect(d.minutesRed).toBe(90);
+  });
+});
+
+describe('decide — no signal is not an alert', () => {
+  it('returns unknown for an empty or all-inconclusive list', () => {
+    expect(decide([], NOW).state).toBe('unknown');
+    expect(decide([run('cancelled', 5), run('skipped', 9)], NOW).state).toBe('unknown');
+  });
+
+  it('survives a missing or malformed list rather than throwing', () => {
+    expect(decide(undefined as never, NOW).state).toBe('unknown');
+    expect(decide(null as never, NOW).state).toBe('unknown');
+  });
+
+  it('does not report a red for an unparseable timestamp', () => {
+    const d = decide([{ conclusion: 'failure', created_at: 'not-a-date', head_sha: 'x', html_url: 'u' }], NOW);
+    expect(d.minutesRed).toBe(0);
+    expect(d.state).toBe('grace');
+  });
+});
+
+describe('issueBody', () => {
+  it('carries everything needed to act without opening the run', () => {
+    const body = issueBody({
+      minutesRed: 90,
+      sha: 'deadbee',
+      url: 'https://github.com/o/r/actions/runs/1',
+      streak: 3,
+      redSince: '2026-08-05T10:30:00Z',
+    });
+    expect(body).toContain('90 minutes');
+    expect(body).toContain('deadbee');
+    expect(body).toContain('https://github.com/o/r/actions/runs/1');
+    expect(body).toContain('3 consecutive failing runs');
+    expect(body).toContain('2026-08-05T10:30:00Z');
+  });
+
+  it('says "run" not "runs" for a single failure', () => {
+    const body = issueBody({ minutesRed: 31, sha: 'a', url: 'u', streak: 1, redSince: 'x' });
+    expect(body).toContain('1 consecutive failing run');
+    expect(body).not.toContain('failing runs');
+  });
+});


### PR DESCRIPTION
## Why

main went red three times in ten days, and every time it was found by *the next gate to run* — never by anyone noticing.

Worth correcting a guess I'd been carrying: I assumed CI was skipping Lovable's pushes, since `ci.yml` filters on `lovable-dev[bot]`. It isn't. Lovable's commits land under the owner's identity (`gpt-engineer-app[bot]` as committer, `magnusfroste` as actor), so that filter never fires and **CI coverage on main is already complete**. The gap is purely that the result goes unwatched.

Required checks would close it too, but they also block the direct-to-main flow Lovable uses, which is deliberate. Watching the result costs nothing and changes nobody's workflow.

## The grace window is the point

On 5 Aug a CI run failed at 01:46 and the next commit fixed it at 01:47. Alerting on that is how you teach everyone to ignore the alert. Only a failure that **survives 30 minutes** opens an issue.

The clock runs from the **first** failure in the streak, not the newest — otherwise a rapid series of broken pushes would keep resetting it and the alert would never fire.

## Behaviour

| situation | what happens |
|---|---|
| main green | closes the alert issue if one is open |
| red < 30 min | silence |
| red ≥ 30 min, no issue | opens one issue |
| still red, same commit | refreshes the body, no comment — a ticking clock is not news |
| still red, new commit | refreshes + comments (that *is* news) |
| API returns nothing | **no action** — an outage must not look like green *or* red |

Triggers on CI completion for main, plus a `*/15` cron as a safety net (a red can start while nothing is being pushed, and a failure inside its grace window needs re-checking). `workflow_dispatch` takes a `grace_minutes` input for testing.

## How it's verified

The streak logic lives in `scripts/main-red-alert.mjs` rather than inline in YAML **so it can be tested** — 19 unit tests covering the grace boundary (29 vs 30 min), the streak clock, `cancelled`/`skipped`/`neutral` runs not counting as signal, and the no-signal case.

The workflow's own branches were dry-run against a stubbed Octokit — all eight paths in the table above, plus the label-already-exists 422. The YAML was parsed and the embedded script syntax-checked as the async function `github-script` wraps it in.

Note: scheduled workflows only run from the default branch, so this becomes active on merge, not on this PR.

Full suite: **1415 passed, 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_