### PR TITLE
fix(automations): send-webhook now matches the event key the seeds actually write

### DIFF
--- a/src/lib/__tests__/event-key-parity.guardrails.test.ts
+++ b/src/lib/__tests__/event-key-parity.guardrails.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Event automations die silently when a dispatcher and the seeds disagree on
+ * the trigger_config key. Seeds and the admin UI write `{event: ...}`; older
+ * docs said `{event_name: ...}`. event-dispatcher was fixed to accept both —
+ * with a comment noting that before the fix NO event automation ever matched.
+ * Its twin, send-webhook, carries the same matcher and was missed for months:
+ * six seeded event automations per instance looked enabled and matched nothing.
+ *
+ * This pins every event-automation matcher to the dual-key form, so the next
+ * dispatcher (or a refactor of these two) can't reintroduce the split. The
+ * failure mode is invisible in production — an unmatched event is
+ * indistinguishable from no event — which is exactly why it's pinned at source
+ * level instead.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const read = (p: string) => readFileSync(resolve(__dirname, '../../..', p), 'utf-8');
+
+// Every edge function that matches incoming events against agent_automations
+// rows with trigger_type='event'. Grep for `trigger_type', 'event'` /
+// `trigger_type", "event"` under supabase/functions to find candidates when
+// adding one.
+const DISPATCHERS = [
+  'supabase/functions/send-webhook/index.ts',
+  'supabase/functions/event-dispatcher/index.ts',
+];
+
+// The dual-key read: event_name with a fallback to event (any spacing/variable).
+const DUAL_KEY = /event_name\s*\?\?\s*\w+\??\.\s*event\b/;
+// The bug shape: comparing trigger_config's event_name directly, no fallback.
+const BARE_EVENT_NAME = /trigger_config\?\.\s*event_name\s*===/;
+
+describe('event-automation key parity across dispatchers', () => {
+  it.each(DISPATCHERS)('%s accepts both {event} and {event_name}', (file) => {
+    const src = read(file);
+    expect(
+      DUAL_KEY.test(src),
+      `${file} matches event automations without the event_name ?? event fallback — ` +
+        `seeds write {event: ...}, so a bare event_name matcher fires on nothing`,
+    ).toBe(true);
+    expect(
+      BARE_EVENT_NAME.test(src),
+      `${file} still contains a bare trigger_config?.event_name === comparison`,
+    ).toBe(false);
+  });
+
+  it('the seeds really do write {event: ...} — the reason the fallback must exist', () => {
+    // If this ever flips to event_name across the board, the fallback becomes
+    // vestigial rather than load-bearing; update the comment, keep the guard.
+    const seedFiles = [
+      'src/lib/modules/crm-module.ts',
+      'src/lib/modules/forms-module.ts',
+      'src/lib/modules/email-module.ts',
+    ];
+    const hits = seedFiles.filter((f) => /trigger_config:\s*{\s*event:/.test(read(f)));
+    expect(hits.length, 'no module seed writes trigger_config {event: ...} any more').toBeGreaterThan(0);
+  });
+
+  it('send-webhook has both matchers fixed, not just one', () => {
+    // The file matches event automations in TWO places (the no-webhooks early
+    // path and the main path). Half-fixing it is this bug all over again.
+    const src = read('supabase/functions/send-webhook/index.ts');
+    const matcherCount = (src.match(/trigger_type',\s*'event'/g) || []).length;
+    const dualKeyCount = (src.match(new RegExp(DUAL_KEY.source, 'g')) || []).length;
+    expect(dualKeyCount, `send-webhook filters event automations ${matcherCount}x but carries the dual-key read only ${dualKeyCount}x`).toBeGreaterThanOrEqual(matcherCount);
+  });
+});

--- a/supabase/functions/send-webhook/index.ts
+++ b/supabase/functions/send-webhook/index.ts
@@ -224,7 +224,12 @@ Deno.serve(async (req) => {
           .eq('trigger_type', 'event')
 
         const matching = (eventAutomations || []).filter((a: any) => {
-          return a.trigger_config?.event_name === event
+          // Seeds and the admin UI write {event: ...}; older docs said
+          // {event_name: ...} — accept both, same fix event-dispatcher already
+          // carries. Before this, NO seeded event automation ever matched here.
+          const cfg = a.trigger_config as any
+          const cfgEvent = cfg?.event_name ?? cfg?.event
+          return cfgEvent === event
         })
 
         for (const auto of matching) {
@@ -290,8 +295,12 @@ Deno.serve(async (req) => {
         .eq('trigger_type', 'event')
 
       const matching = (eventAutomations || []).filter((a: any) => {
-        const eventName = a.trigger_config?.event_name
-        return eventName === event
+        // Seeds and the admin UI write {event: ...}; older docs said
+        // {event_name: ...} — accept both, same fix event-dispatcher already
+        // carries. Before this, NO seeded event automation ever matched here.
+        const cfg = a.trigger_config as any
+        const cfgEvent = cfg?.event_name ?? cfg?.event
+        return cfgEvent === event
       })
 
       if (matching.length > 0) {

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1242,7 +1242,7 @@
         "run-autonomy-tests": "sha256:d326b88ef0d263ed7604ba1eb75a770126d785e26211888b2093fcb325cc8c22",
         "run-platform-tests": "sha256:5e6f5077b9516d47a6f8d0619d3af8f85c927c58ca25d824b364375fad13e04c",
         "score-visitor-intent": "sha256:c45442de0d34a5f9660a75a15c269aa5988ca7dbc2631e476418c66e58e6f79e",
-        "send-webhook": "sha256:32dfe4c3c613760f0e64a523404057f5fdf5e2e41af56535f0a66b1bc4d38679",
+        "send-webhook": "sha256:cc64c3fbaa4e36628bd87661bafaf9c1a5e71b151b4d02703bb792779d44de28",
         "setup-database": "sha256:49f03dc85ea4d48cd53b7760b0a68f4e2a628a217207b0fe4590d931f594e56e",
         "signal-dispatcher": "sha256:a76e992430f13d05003a0e00ba622c239006fc853531400d88a1f238310c90dc",
         "signal-ingest": "sha256:1e8edbe511e8b048df1a7b1419aa14a410c83487ed911e0f599871e3b67a752d",


### PR DESCRIPTION
The other kill switch on event automations — the one that stays even after the vault is filled.

## Two independent kill switches, found the same day

Event automations reach their skills through two lanes, and both were dead for different reasons:

1. **DB-trigger lane**: `dispatch_automation_event` reads its keys from `vault.decrypted_secrets`, which is empty on every instance — every event dies with a WARNING nobody sees. *(Local Claude's finding, handled in their round.)*
2. **Client lane** (this PR): `send-webhook` matches automations on `trigger_config.event_name` — while every seed and the admin UI write `{event: ...}`.

`event-dispatcher` got the dual-key fix long ago; its comment notes that **before it, no event automation ever matched**. `send-webhook` carries the *same matcher in two places* and was missed. Result: the six seeded event automations per instance (`inbound_email_to_ticket`, `order.paid → allocate_picking`, invoice matching, MRP, service orders, approval notifications) look enabled and match nothing on the client-emitted path.

## The fix

The same line `event-dispatcher` already carries, applied to both matcher sites:

```ts
const cfgEvent = cfg?.event_name ?? cfg?.event
```

## The guardrail is the real content

An unmatched event is **indistinguishable from no event** — this bug class is invisible in production, which is exactly how it survived while its twin got fixed. `event-key-parity.guardrails.test.ts`:

| assertion | regression it catches |
|---|---|
| every dispatcher carries `event_name ?? event` | a new dispatcher reintroduces the split |
| the bare `trigger_config?.event_name ===` form is rejected | someone "simplifies" the fallback away |
| dual-key count ≥ matcher count in send-webhook | **a half-fix** — the file filters in two places, and fixing one is this bug all over again |
| seeds still write `{event: ...}` | documents why the fallback is load-bearing |

Negative-tested: reverting one of the two matchers trips both the bare-form and the count assertion.

Full suite: **1419 passed, 4 skipped**. Manifest regenerated.

**Deploy note:** takes effect per instance on `supabase functions deploy send-webhook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_