### PR TITLE
fix(automations): a non-enum event name no longer crashes send-webhook before automations run

### DIFF
--- a/src/lib/__tests__/event-key-parity.guardrails.test.ts
+++ b/src/lib/__tests__/event-key-parity.guardrails.test.ts
@@ -58,6 +58,27 @@ describe('event-automation key parity across dispatchers', () => {
     expect(hits.length, 'no module seed writes trigger_config {event: ...} any more').toBeGreaterThan(0);
   });
 
+  it('the webhooks lookup cannot gate the automations lane', () => {
+    // webhooks.events is an ENUM array (webhook_event, 31 CMS/commerce names).
+    // Any event outside it — email.received, vendor.created, every custom
+    // event — fails the PostgREST cast. send-webhook used to `throw
+    // webhooksError` (a plain object, so the top catch said 500 "Unknown
+    // error") BEFORE reaching automations: kill switch #3, found live on optic
+    // when a selftest event 500'd with the #148 matcher fix already deployed.
+    // Automations accept arbitrary event names by design; only outbound
+    // webhooks are enum-gated. The lookup failure must degrade to "no
+    // webhooks", never crash the request.
+    const src = read('supabase/functions/send-webhook/index.ts');
+    expect(
+      /^\s*throw\s+webhooksError/m.test(src),
+      'send-webhook throws on the webhooks lookup again — any non-enum event name 500s before automations dispatch',
+    ).toBe(false);
+    expect(
+      /webhooksError\s*\|\|\s*!webhooks/.test(src),
+      'a failed webhooks lookup must fall through to the no-webhooks path so automations still run',
+    ).toBe(true);
+  });
+
   it('send-webhook has both matchers fixed, not just one', () => {
     // The file matches event automations in TWO places (the no-webhooks early
     // path and the main path). Half-fixing it is this bug all over again.

--- a/supabase/functions/send-webhook/index.ts
+++ b/supabase/functions/send-webhook/index.ts
@@ -207,11 +207,18 @@ Deno.serve(async (req) => {
       .contains('events', [event])
 
     if (webhooksError) {
-      console.error('[send-webhook] Error fetching webhooks:', webhooksError)
-      throw webhooksError
+      // webhooks.events is webhook_event[] — an ENUM of 31 CMS/commerce names.
+      // Any event outside it (email.received, vendor.created, purchase_order.*,
+      // every custom event) makes PostgREST reject the cast, and this used to
+      // `throw webhooksError` — a plain object, not an Error, so the top-level
+      // catch answered 500 "Unknown error" BEFORE the automations lane ran.
+      // Event automations accept arbitrary event names by design; only outbound
+      // webhooks are enum-gated. Treat the failed lookup as "no webhooks
+      // subscribed" and keep going.
+      console.warn(`[send-webhook] Webhooks lookup failed for "${event}" (likely non-enum event name) — continuing to automations:`, webhooksError.message ?? webhooksError)
     }
 
-    if (!webhooks || webhooks.length === 0) {
+    if (webhooksError || !webhooks || webhooks.length === 0) {
       console.log(`[send-webhook] No webhooks registered for event: ${event}`)
       
       // Still check for event automations even if no webhooks

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1242,7 +1242,7 @@
         "run-autonomy-tests": "sha256:d326b88ef0d263ed7604ba1eb75a770126d785e26211888b2093fcb325cc8c22",
         "run-platform-tests": "sha256:5e6f5077b9516d47a6f8d0619d3af8f85c927c58ca25d824b364375fad13e04c",
         "score-visitor-intent": "sha256:c45442de0d34a5f9660a75a15c269aa5988ca7dbc2631e476418c66e58e6f79e",
-        "send-webhook": "sha256:cc64c3fbaa4e36628bd87661bafaf9c1a5e71b151b4d02703bb792779d44de28",
+        "send-webhook": "sha256:a8748b5e344f2dee419bb739707e938d093a3cc5ed0a43f3b69cb9de7dc76741",
         "setup-database": "sha256:49f03dc85ea4d48cd53b7760b0a68f4e2a628a217207b0fe4590d931f594e56e",
         "signal-dispatcher": "sha256:a76e992430f13d05003a0e00ba622c239006fc853531400d88a1f238310c90dc",
         "signal-ingest": "sha256:1e8edbe511e8b048df1a7b1419aa14a410c83487ed911e0f599871e3b67a752d",


### PR DESCRIPTION
Kill switch **#3** on event automations — found during the live verification of #148 on optic.

## How it surfaced

With #148 merged and deployed (send-webhook v9 on optic), I fired a selftest event at the function. Answer: **500 "Unknown error"** — before the automations lane ever ran.

## Root cause

`webhooks.events` is `webhook_event[]` — an **enum** of 31 CMS/commerce names (`page.published`, `form.submitted`, `order.paid`, …). Any event outside it makes PostgREST reject the cast, and send-webhook did:

```ts
if (webhooksError) throw webhooksError   // plain object, not an Error
```

→ top-level catch → `500 "Unknown error"`, request dead before automations dispatch.

The kicker: **exactly the events the six seeded automations listen on are outside the enum** — `email.received`, `invoice.registered`, `mo.shortage_detected`, `service_order.completed`, `approval.assigned`. So are the events `agent-execute` emits fire-and-forget (`vendor.created`, `purchase_order.*`, `goods_receipt.created`) — all of those calls have been dying silently.

Three independent kill switches on the same lane, each invisible on its own:
1. matcher key mismatch (#148 — fixed, verified live)
2. empty vault secrets on the DB-trigger lane (local Claude's round)
3. this one

## The fix

Event automations accept arbitrary event names by design; only outbound webhooks are enum-gated. A failed webhooks lookup now logs and **degrades to "no webhooks subscribed"** — the request continues into automations dispatch instead of crashing.

## Verified live on optic

After deploying #148, with a selftest automation using the `{event: ...}` key on an enum-valid event:

```
fire event → automations_dispatched: 1
DB: run_count: 1, last_triggered_at set, last_error: null
```

(selftest automation deleted afterwards). The non-enum path is what this PR fixes; redeploying send-webhook after merge completes the lane.

## Guardrail

Added beside the #148 assertions in `event-key-parity.guardrails.test.ts`: the statement-form `throw webhooksError` is rejected, and the fallthrough `webhooksError || !webhooks` into the no-webhooks path is pinned. Negative-tested — reintroducing the throw trips it.

Full suite: **1420 passed, 4 skipped**. Manifest regenerated.

**Deploy note:** `supabase functions deploy send-webhook` per instance (I can redeploy optic via the Management API on merge, same as #148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_