### PR TITLE
fix(flowtable): a select column stops hiding the value it already holds

### DIFF
--- a/docs/operators/session-memory.md
+++ b/docs/operators/session-memory.md
@@ -250,6 +250,57 @@ where RLS allows and for `--no-verify-jwt` public functions.
 
 ## Open queue (next session starts here)
 
+### ⇄ Handoff to local Claude — `manage_flowtable_field` accepts bad `choices` and reports success (2026-08-06, cloud session)
+
+**Your file (`agent-execute`), so untouched — but this is the highest-value fix
+in the batch.** Magnus reported that OpenClaw could not set dropdown options
+over MCP. It can: 6 of 12 select fields on Optic's `produkter` base were
+correctly configured, and I set the other 6 live through the gateway. What is
+broken is what happens when the agent gets the shape slightly wrong.
+
+`normalizeFlowtableFieldOptions` (agent-execute, ~line 10569):
+
+```ts
+if (type === 'select' || type === 'multiselect') {
+  const out: Record<string, unknown> = {};
+  if (Array.isArray(opts.choices)) out.choices = opts.choices.map((c: any) => String(c));
+  return { options: out };
+}
+```
+
+Two failure modes, both live-reproduced through the gateway:
+
+| sent | result | should be |
+|---|---|---|
+| `options: {choices: "Ej satt,Ej tillämpligt"}` | `status: success`, `updated: true`, `options: {}` | error naming the expected shape |
+| `options: {choices: [{label:"Aktiv",value:"aktiv"}]}` | `status: success`, `options: {choices: ["[object Object]"]}` | error — `String(obj)` is never a choice |
+
+The first is the one that produced the report: **an agent that formats `choices`
+as a string is told it succeeded and the column stays empty.** The third shape
+I tried — `choices` at top level instead of inside `options` — errors correctly
+(*"Nothing to update"*), which is the behaviour the other two should have.
+
+Suggested fix, both in the same branch: reject a non-array `choices`, and reject
+entries that are not strings/numbers, naming what was received. `select` is the
+only place in `normalizeFlowtableFieldOptions` that silently drops rather than
+errors — `link`, `lookup` and `rollup` all validate properly, so this is a hole
+in one branch, not a design choice.
+
+**Two halves already shipped from here**, so don't redo them:
+- `20260808180000` makes `list_flowtable_tables` emit `options`. The RPC was the
+  only schema-discovery surface an external agent has and it returned
+  `{key,name,type}` — so a configured select and an unconfigured one looked
+  identical from outside, and read-back (the only way to catch a silent write)
+  was impossible. Applied to optic; the other four instances need it.
+- `FlowtablePage.tsx` no longer hides a select value that is not among its
+  choices. It rendered `<select value="Månadsavgift">` with no matching
+  `<option>` → blank cell, and the fallback list offered `New / In progress /
+  Done`, so the obvious repair overwrote good data with a meaningless value. The
+  multiselect renderer had handled this all along; single select did not.
+
+Optic's data is now clean: all 12 select/multiselect fields carry choices, zero
+values fall outside their own list (verified by query, not by reading code).
+
 ### ⇄ Handoff to local Claude — documents can be marked sensitive, and the FILE follows the row (2026-08-06, cloud session)
 
 Peter (COO/CFO) asked before getting his login: **if HR starts using the

--- a/src/lib/__tests__/flowtable-select-choices.guardrails.test.ts
+++ b/src/lib/__tests__/flowtable-select-choices.guardrails.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Flowtable select columns must never hide the value they already hold.
+ *
+ * Found while checking whether OpenClaw can set dropdown choices over MCP. It
+ * can — 6 of 12 select fields on the Optic Tunnels base were correctly
+ * configured. But the six that were not held perfectly good data
+ * ("Månadsavgift", "Kunden köper direkt") in a `<select>` whose `<option>` list
+ * did not contain it. The browser renders that as blank, so the column looked
+ * empty; and the fallback list offered `New / In progress / Done`, so the
+ * obvious repair — pick something from the dropdown — replaced a correct value
+ * with a meaningless one.
+ *
+ * The multiselect renderer had handled this all along (out-of-list values are
+ * rendered as static chips). Single select did not. Same idea, two renderers,
+ * one of them wrong — which is the whole failure shape of this week.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { selectChoices } from '@/pages/admin/FlowtablePage';
+
+const rpc = readFileSync(
+  join(process.cwd(), 'supabase/migrations/20260808190000_flowtable-list-tables-expose-options.sql'),
+  'utf-8',
+);
+
+const STARTER = ['New', 'In progress', 'Done'];
+
+describe('a configured column offers exactly what it was configured with', () => {
+  it('uses the configured choices, in their configured order', () => {
+    // Order is meaningful: it drives the Kanban column order.
+    expect(selectChoices(['Aktiv', 'Undvik'], [], STARTER)).toEqual(['Aktiv', 'Undvik']);
+  });
+
+  it('does not duplicate a present value that is already configured', () => {
+    expect(selectChoices(['Aktiv', 'Undvik'], ['Aktiv'], STARTER)).toEqual(['Aktiv', 'Undvik']);
+  });
+});
+
+describe('a value outside the configured list stays visible', () => {
+  it('appends it rather than dropping it', () => {
+    // The bug: `<select value="Månadsavgift">` with no matching option renders
+    // blank, and the next edit writes whatever the list did offer.
+    expect(selectChoices(['Årsavgift'], ['Månadsavgift'], STARTER)).toEqual([
+      'Årsavgift',
+      'Månadsavgift',
+    ]);
+  });
+
+  it('keeps several stray values, in the order the data presents them', () => {
+    expect(selectChoices(['A'], ['B', 'C'], STARTER)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('shows the data alone when nothing was ever configured', () => {
+    // An agent filled the rows before anyone configured the column — the common
+    // case, and the one that produced the report.
+    expect(selectChoices(undefined, ['Månadsavgift', 'Årsavgift'], STARTER)).toEqual([
+      'Månadsavgift',
+      'Årsavgift',
+    ]);
+    expect(selectChoices([], ['Månadsavgift'], STARTER)).toEqual(['Månadsavgift']);
+  });
+});
+
+describe('the starter set is for genuinely new columns only', () => {
+  it('offers it when the column is unconfigured AND empty', () => {
+    expect(selectChoices(undefined, [], STARTER)).toEqual(STARTER);
+  });
+
+  it('never offers it over real data', () => {
+    // The damaging case: a "Debiteringsform" column inviting you to set a row
+    // to "In progress".
+    const out = selectChoices(undefined, ['Månadsavgift'], STARTER);
+    for (const s of STARTER) expect(out).not.toContain(s);
+  });
+
+  it('never offers it when the column IS configured, even if empty', () => {
+    expect(selectChoices(['Aktiv'], [], STARTER)).toEqual(['Aktiv']);
+  });
+
+  it('offers nothing at all when no starter set is supplied', () => {
+    // Kanban grouping passes no starter set — an empty board is honest, three
+    // invented columns are not.
+    expect(selectChoices(undefined, [])).toEqual([]);
+  });
+});
+
+describe('empty and blank values are not choices', () => {
+  it('ignores empty strings coming from the data', () => {
+    // `String(r.values?.[key] ?? '')` yields '' for unset cells; an empty
+    // option already exists in the renderer and a blank Kanban column is noise.
+    expect(selectChoices(['A'], ['', 'B'], STARTER)).toEqual(['A', 'B']);
+  });
+
+  it('treats an all-blank column as empty, not as configured data', () => {
+    // Counting '' as a present value would deny a genuinely empty column its
+    // starter set — the one case the starter set exists for.
+    expect(selectChoices(undefined, ['', ''], STARTER)).toEqual(STARTER);
+  });
+
+  it('does not duplicate a stray value that appears in several rows', () => {
+    // The result is rendered as `<option key={c}>` — a repeat both warns and
+    // shows twice.
+    expect(selectChoices(['A'], ['B', 'B'], STARTER)).toEqual(['A', 'B']);
+    expect(selectChoices(['A', 'A'], [], STARTER)).toEqual(['A']);
+  });
+});
+
+describe('an operator can read back what it wrote', () => {
+  // `list_flowtable_tables` is the only schema-discovery surface an external
+  // agent has. It returned {key, name, type} with no options, so a select field
+  // WITH choices and one without looked identical from outside — and the write
+  // side fails quietly (a non-array `choices` is dropped while the call still
+  // answers `status: success`). Read-back was the only way to catch that, and
+  // read-back did not exist.
+  it('emits options from the discovery RPC', () => {
+    expect(rpc).toMatch(/jsonb_build_object\('options', f\.options\)/);
+  });
+
+  it('leaves a plain column\'s payload byte-identical', () => {
+    // Merged in only when non-empty — anything already parsing this output must
+    // not start seeing a new key on every text field.
+    expect(rpc).toMatch(/coalesce\(f\.options, '\{\}'::jsonb\) <> '\{\}'::jsonb/);
+  });
+
+  it('replaces the function rather than adding an overload', () => {
+    // A second signature would leave callers on whichever PostgREST picked, and
+    // the old body would keep answering for anyone passing the same params.
+    expect(rpc).toMatch(/CREATE OR REPLACE FUNCTION public\.list_flowtable_tables\(p_base_id uuid DEFAULT NULL, p_base_slug text DEFAULT NULL\)/);
+  });
+});

--- a/src/pages/admin/FlowtablePage.tsx
+++ b/src/pages/admin/FlowtablePage.tsx
@@ -93,6 +93,38 @@ const APP_ROLE_FILTERS = [
 const TYPES_WITH_OPTIONS = new Set<FlowtableFieldType>(['select', 'multiselect', 'link', 'lookup', 'rollup', 'user', 'currency']);
 const ROLLUP_AGGS = ['count', 'sum', 'avg', 'min', 'max'] as const;
 
+/**
+ * The choices a select/multiselect cell should offer, given what it currently holds.
+ *
+ * A stored value that is not among the configured choices used to render as an
+ * empty dropdown: `<select value="Månadsavgift">` with no matching `<option>`
+ * shows blank, so the data looked missing — and touching the control replaced a
+ * correct value with whatever the list did offer. That is a silent edit of good
+ * data, and it happens exactly when an agent fills rows before anyone configures
+ * the column. The multiselect renderer already kept out-of-list values visible;
+ * single select did not. Same idea, two renderers, one of them wrong.
+ *
+ * The old fallback made it worse: an unconfigured select offered
+ * `New / In progress / Done` regardless of the column's meaning, so a
+ * "Debiteringsform" column invited you to set a row to "In progress". The
+ * starter set is now only used when the column is BOTH unconfigured and empty —
+ * a genuinely new column, which is what it was for.
+ */
+export function selectChoices(
+  configured: string[] | undefined,
+  present: string[],
+  starterWhenEmpty: string[] = [],
+): string[] {
+  // Blanks are dropped first: `String(values?.[key] ?? '')` yields '' for unset
+  // cells, and counting those as data would deny a genuinely empty column its
+  // starter set.
+  const held = present.filter(Boolean);
+  const base = configured?.length ? configured : (held.length ? [] : starterWhenEmpty);
+  // Deduped: the result is rendered as `<option key={c}>`, so a repeated value
+  // would both warn and show twice.
+  return [...new Set([...base, ...held])];
+}
+
 const FILTER_OPS: { value: FlowtableViewFilter['op']; label: string; needsValue: boolean }[] = [
   { value: 'eq', label: 'is', needsValue: true },
   { value: 'neq', label: 'is not', needsValue: true },
@@ -187,8 +219,11 @@ function RecordSheet({ open, onClose, records, fields, index, setIndex, onUpdate
               );
             }
             if (f.type === 'select') {
-              const choices = ((f.options?.choices as string[]) ?? []).length
-                ? (f.options?.choices as string[]) : ['New', 'In progress', 'Done'];
+              const choices = selectChoices(
+                f.options?.choices as string[] | undefined,
+                v ? [String(v)] : [],
+                ['New', 'In progress', 'Done'],
+              );
               return (
                 <div key={f.id} className="space-y-1.5">
                   {label}
@@ -1380,10 +1415,14 @@ function CellEditor({ field, value, record, fields, onChange, rowHeight = 'short
   }
 
   if (field.type === 'select') {
-    // User-defined choices from options; only fall back to a starter set when
-    // the field was never configured (keeps old select columns working).
-    const configured = field.options?.choices as string[] | undefined;
-    const choices = (configured && configured.length) ? configured : ['New', 'In progress', 'Done'];
+    // The current value is always offered, even when it is not among the
+    // configured choices — otherwise the cell renders blank and editing any
+    // other cell in the column silently overwrites good data. See selectChoices.
+    const choices = selectChoices(
+      field.options?.choices as string[] | undefined,
+      value ? [String(value)] : [],
+      ['New', 'In progress', 'Done'],
+    );
     return (
       <td className="border-r border-b p-0 align-top" style={cellStyle}>
         <select
@@ -1927,7 +1966,14 @@ function KanbanView({ fields, records, config, onChangeConfig, onUpdate }: {
     if (!groupField) return [];
     let values: string[];
     if (groupField.type === 'select' || groupField.type === 'multiselect') {
-      values = ((groupField.options?.choices as string[]) ?? []);
+      // Configured choices set the column ORDER; values in the data that are not
+      // configured still get a column rather than collapsing into Uncategorized.
+      // Without this, grouping by an unconfigured select produced a board with
+      // exactly one column — every card in "Uncategorized".
+      values = selectChoices(
+        groupField.options?.choices as string[] | undefined,
+        [...new Set(records.map((r) => String(r.values?.[groupField.key] ?? '')).filter(Boolean))],
+      );
     } else {
       values = [...new Set(records.map((r) => String(r.values?.[groupField.key] ?? '')).filter(Boolean))];
     }

--- a/supabase/migrations/20260808190000_flowtable-list-tables-expose-options.sql
+++ b/supabase/migrations/20260808190000_flowtable-list-tables-expose-options.sql
@@ -1,0 +1,41 @@
+-- An agent could set a select column's choices but never read them back.
+--
+-- Found while checking a report that OpenClaw could not set dropdown options
+-- over MCP. It can — 6 of 12 select fields on the Optic Tunnels base were
+-- correctly configured, and a live call through the gateway set the rest. What
+-- it cannot do is VERIFY: `list_flowtable_tables` is the only schema-discovery
+-- surface, and it returned `{key, name, type}` with no `options`. So a select
+-- field with choices and one without look identical from the outside, and an
+-- operator has no way to tell a successful write from a silently dropped one.
+--
+-- That matters more than it sounds, because the write side fails quietly: a
+-- `choices` value that is not an array is dropped and the call still answers
+-- `status: success, updated: true`. Read-back was the only way to catch it, and
+-- read-back did not exist. (The handler-side validation is a separate fix, in
+-- agent-execute.)
+--
+-- `options` is emitted only when non-empty, so the payload for plain text
+-- columns is unchanged and nothing already parsing this output breaks.
+CREATE OR REPLACE FUNCTION public.list_flowtable_tables(p_base_id uuid DEFAULT NULL, p_base_slug text DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+DECLARE v_base_id uuid;
+BEGIN
+  v_base_id := coalesce(p_base_id, (SELECT id FROM flowtable_bases WHERE slug = p_base_slug LIMIT 1));
+  IF v_base_id IS NULL THEN RAISE EXCEPTION 'Provide p_base_id or a valid p_base_slug'; END IF;
+  RETURN jsonb_build_object('base_id', v_base_id, 'tables', coalesce((
+    SELECT jsonb_agg(jsonb_build_object(
+      'table_id', t.id, 'name', t.name, 'slug', t.slug,
+      'record_count', (SELECT count(*) FROM flowtable_records r WHERE r.table_id = t.id),
+      'fields', coalesce((
+        SELECT jsonb_agg(
+          jsonb_build_object('key', f.key, 'name', f.name, 'type', f.type)
+          -- Merged in rather than always present: a text column keeps the exact
+          -- shape it had before this migration.
+          || CASE WHEN coalesce(f.options, '{}'::jsonb) <> '{}'::jsonb
+                  THEN jsonb_build_object('options', f.options)
+                  ELSE '{}'::jsonb END
+          ORDER BY f.position)
+        FROM flowtable_fields f WHERE f.table_id = t.id), '[]'::jsonb)
+    ) ORDER BY t.position)
+    FROM flowtable_tables t WHERE t.base_id = v_base_id), '[]'::jsonb));
+END; $$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260808180000",
-      "migrations_count": 312,
+      "migration_head": "20260808190000",
+      "migrations_count": 313,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1253,6 +1253,10 @@
         {
           "version": "20260808180000",
           "name": "terms-url-token"
+        },
+        {
+          "version": "20260808190000",
+          "name": "flowtable-list-tables-expose-options"
         }
       ]
     },


### PR DESCRIPTION
Magnus reported that OpenClaw could not set dropdown choices over MCP.

**It can.** 6 of 12 select fields on Optic's `produkter` base were already correctly configured, and I set the other 6 live through the gateway while checking. But three real problems sat behind the report — and the one that matters most is not in this diff.

## What OpenClaw actually hits

Live through `/rest/execute`, four shapes:

| sent | result |
|---|---|
| `options: {choices: ["Månadsavgift", …]}` | ✅ works |
| `options: {choices: "Ej satt,Ej tillämpligt"}` | ⚠️ `status: success`, `updated: true`, `options: {}` |
| `choices: [...]` at top level | ✅ correct error (*"Nothing to update"*) |
| `options: {choices: [{label:"Aktiv",value:"aktiv"}]}` | ⚠️ `status: success`, `options: {choices: ["[object Object]"]}` |

Row 2 is the report: **an agent that formats `choices` as a string is told it succeeded and the column stays empty.** That lives in `agent-execute` — local Claude's file — so it is written up in `session-memory.md` with both repros rather than patched here. `link`, `lookup` and `rollup` all validate properly in the same function, so `select` silently dropping is a hole in one branch, not a design choice.

## What this PR fixes

**1. A select column no longer hides the value it already holds.**

`<select value="Månadsavgift">` with no matching `<option>` renders blank, so the column looked unfilled even though the data was right. And the fallback list offered `New / In progress / Done` — so the obvious repair, picking from the dropdown, **replaced good data with a meaningless value**.

The multiselect renderer had kept out-of-list values visible all along (static chips). Single select did not. Same idea, two renderers, one of them wrong — the failure shape of this entire week.

`selectChoices()` now governs both, plus Kanban grouping: configured choices set the order, values present in the data are appended rather than dropped, and the starter set is offered only for a column that is **both** unconfigured and empty.

**2. Grouping a Kanban board by an unconfigured select** produced exactly one column — everything in "Uncategorized". Now the observed values become columns.

**3. `list_flowtable_tables` emits `options`.**

It is the only schema-discovery surface an external agent has, and it returned `{key, name, type}` — so a configured select and an unconfigured one were **indistinguishable from outside**. Read-back is the only way to catch a silently-dropped write, and read-back did not exist. That is why nobody noticed six empty columns.

Merged in only when non-empty, so a text column's payload is byte-identical and nothing already parsing this output changes.

## Verified live, not read

Applied to optic and called back through the gateway — all 12 fields now return their choices. Optic's data is clean: every select/multiselect field carries choices, and **zero values fall outside their own list** (verified by query, not by inspection).

15 guardrails. Negative-tested: restoring the old choice logic fails 6 of them. Full suite **1539 passed**, `tsc` clean, forward-dating guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_