### PR TITLE
feat(contracts): the template asked for what the platform already knew

### DIFF
--- a/docs/operators/session-memory.md
+++ b/docs/operators/session-memory.md
@@ -286,17 +286,47 @@ only place in `normalizeFlowtableFieldOptions` that silently drops rather than
 errors — `link`, `lookup` and `rollup` all validate properly, so this is a hole
 in one branch, not a design choice.
 
+**Re-probe it yourself before and after — the whole point is the response, not
+the stored row.** Against any instance, `POST /functions/v1/mcp-server/rest/execute`
+with `{"tool":"manage_flowtable_field","arguments":{…}}`:
+
+| `arguments` | today | wanted |
+|---|---|---|
+| `{action:'update', table:…, key:…, options:{choices:['A','B']}}` | ✅ works | unchanged |
+| `{…, options:{choices:'A,B'}}` | `success`, `options:{}` | error |
+| `{…, options:{choices:[{label:'A',value:'a'}]}}` | `success`, `choices:['[object Object]']` | error |
+| `{…, choices:['A','B']}` (outside `options`) | ✅ `"Nothing to update"` | unchanged — this is the model |
+
+**STATUS 2026-08-06 (later the same day): not urgent, still real.** OpenClaw
+went back and set the remaining fields itself, correctly — it even improved two
+of my guesses (`prissatt` → `Satt / Ej satt / Ej tillämpligt`, and it knew the
+right order for `produkt`). Optic is verified clean: **0** orphaned select
+values, **0** multiselect values outside their list, **0** fields with empty or
+`[object Object]` options. So nothing is on fire.
+
+What that does NOT change: the handler still answers `success` for a wrong
+shape. OpenClaw got it right this time; the next agent that guesses gets the
+same silent confirmation, and the only thing that caught it was a human noticing
+empty dropdowns. Fix the response, not the data.
+
 **Two halves already shipped from here**, so don't redo them:
-- `20260808180000` makes `list_flowtable_tables` emit `options`. The RPC was the
-  only schema-discovery surface an external agent has and it returned
-  `{key,name,type}` — so a configured select and an unconfigured one looked
-  identical from outside, and read-back (the only way to catch a silent write)
-  was impossible. Applied to optic; the other four instances need it.
+- `20260808190000_flowtable-list-tables-expose-options.sql` makes
+  `list_flowtable_tables` emit `options`. The RPC was the only schema-discovery
+  surface an external agent has and it returned `{key,name,type}` — so a
+  configured select and an unconfigured one looked identical from outside, and
+  read-back (the only way to catch a silent write) was impossible. **Applied to
+  optic only; the other four instances need it.** (Renumbered from `…180000`
+  late — main had picked up `20260808180000_terms-url-token.sql` with the same
+  stamp. Timestamp collisions between the three of us are now a real thing;
+  `scripts/check-migration-forward-dated.ts` catches them.)
 - `FlowtablePage.tsx` no longer hides a select value that is not among its
   choices. It rendered `<select value="Månadsavgift">` with no matching
   `<option>` → blank cell, and the fallback list offered `New / In progress /
   Done`, so the obvious repair overwrote good data with a meaningless value. The
   multiselect renderer had handled this all along; single select did not.
+  Guardrails in `src/lib/__tests__/flowtable-select-choices.guardrails.test.ts`
+  (negative-tested: restoring the old logic fails 6 of 15).
+
 
 Optic's data is now clean: all 12 select/multiselect fields carry choices, zero
 values fall outside their own list (verified by query, not by reading code).

--- a/src/lib/__tests__/contract-supplier-tokens.guardrails.test.ts
+++ b/src/lib/__tests__/contract-supplier-tokens.guardrails.test.ts
@@ -1,0 +1,134 @@
+/**
+ * A contract must never invent, and must never quietly omit.
+ *
+ * Found rehearsing the lead→contract chain the evening before a demo: every
+ * `{{token}}` rendered correctly, and the agreement still read
+ * `Leverantör: [LEVERANTÖRENS FIRMA], org.nr [ORGNR], [ADRESS]` — because the
+ * templates carry 25 bracket placeholders across 164 occurrences that nothing
+ * filled, while `company_profile` held all three values.
+ *
+ * Two properties are worth holding forever, and they pull in opposite
+ * directions: fill everything the platform genuinely knows, and leave a VISIBLE
+ * placeholder for everything it does not. A blank in a signed agreement is
+ * worse than an obvious gap — it looks finished and is not.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const sql = read('supabase/migrations/20260808210000_contract-supplier-tokens.sql');
+const agentExecute = read('supabase/functions/agent-execute/index.ts');
+
+/** The body of the render function, comments stripped. */
+const fn = (() => {
+  const from = sql.slice(sql.indexOf('CREATE OR REPLACE FUNCTION public.create_contract_from_template'));
+  return from.slice(0, from.indexOf('$$;')).replace(/--[^\n]*/g, '');
+})();
+
+const SUPPLIER = [
+  ['supplier.name', 'LEVERANTÖRENS FIRMA'],
+  ['supplier.org_number', 'ORGNR'],
+  ['supplier.address', 'ADRESS'],
+  ['supplier.phone', 'TELEFON'],
+  ['supplier.email', 'E-POST'],
+  ['supplier.signatory', 'NAMN'],
+] as const;
+
+describe('what the platform knows reaches the page', () => {
+  it.each(SUPPLIER)('fills %s, in both spellings', (token, bracket) => {
+    // `{{token}}` for templates written from here on; the bracket form for the
+    // 15 already written. Supporting only one would mean a data migration on
+    // every instance, and a second thing to keep in sync.
+    expect(fn).toContain(`'{{${token}}}', v_sup_`);
+    expect(fn).toContain(`'[${bracket}]', v_sup_`);
+  });
+
+  it('reads the supplier from the same store as the rest of the platform', () => {
+    expect(fn).toMatch(/site_settings WHERE key = 'company_profile'/);
+  });
+
+  it('prefers the registered name over the display name', () => {
+    // An agreement names the legal entity, not the brand.
+    expect(fn).toMatch(/COALESCE\(NULLIF\(trim\(v_profile->>'legal_name'\), ''\),\s*NULLIF\(trim\(v_profile->>'company_name'\), ''\)\)/);
+  });
+
+  it('fills the customer side from company master data too', () => {
+    expect(fn).toContain(`'[KUNDENS ORGNR]', v_org`);
+    expect(fn).toContain(`'[KUNDENS ADRESS]', v_cp_addr`);
+  });
+});
+
+describe('what it does not know stays visible', () => {
+  it.each(SUPPLIER)('leaves %s as a placeholder rather than blank', (token, bracket) => {
+    // The unconditional pass runs AFTER the guarded ones and maps the token
+    // back to its bracket. Verified live: `contact_phone` and `contact_email`
+    // are empty on the instance this was written for, and the rendered contract
+    // still reads "…på [TELEFON] / [E-POST]" — not "…på  / ".
+    expect(fn).toContain(`replace(v_body, '{{${token}}}', '[${bracket}]')`);
+  });
+
+  it('guards every supplier substitution on the value existing', () => {
+    // A half-filled profile should contribute the half it has. Each field gets
+    // its own IF — one combined guard would make a missing phone number blank
+    // out the company name.
+    for (const v of ['v_sup_name', 'v_sup_org', 'v_sup_addr', 'v_sup_phone', 'v_sup_email', 'v_sup_signer']) {
+      expect(fn).toContain(`IF ${v} IS NOT NULL THEN`);
+    }
+  });
+
+  it('does not guess a signatory title', () => {
+    // The profile stores a `ceo` NAME and no title. Inferring "VD" from the
+    // field's own name is a guess, and a signature block is the last place
+    // software should guess.
+    expect(fn).not.toContain('[TITEL]');
+  });
+
+  it('does not guess the CPI base month', () => {
+    // It usually equals the start month, but not always — and a wrong number in
+    // an indexation clause silently changes what the customer pays every year.
+    expect(fn).not.toContain('[MÅNAD ÅR]');
+  });
+});
+
+describe('the shape the caller actually reads', () => {
+  // The bug this caught on the way in: `20260808180000` declares
+  // `TABLE(id uuid, …)` while the deployed function returns
+  // `TABLE(contract_id uuid, …)`. On an existing instance that migration cannot
+  // apply at all (42P13); on a fresh install it would apply and make
+  // `manage_contract` answer `contract_id: undefined`. Neither is visible in
+  // either file alone — only in the pair.
+  it('declares contract_id, because agent-execute reads contract_id', () => {
+    expect(agentExecute).toContain('contract_id: row?.contract_id');
+    expect(sql).toMatch(/RETURNS TABLE\(contract_id uuid, title text, status public\.contract_status\)/);
+  });
+
+  it('drops before creating, since the return type changes', () => {
+    const dropAt = sql.indexOf('DROP FUNCTION IF EXISTS public.create_contract_from_template');
+    const createAt = sql.indexOf('CREATE OR REPLACE FUNCTION public.create_contract_from_template');
+    expect(dropAt).toBeGreaterThan(-1);
+    expect(dropAt).toBeLessThan(createAt);
+  });
+});
+
+describe('the validator and the renderer agree on the token list', () => {
+  // The original migration says it in its own comment — "one token list, shared
+  // by the authoring skill and the renderer" — so a new token must land in both
+  // or `manage_contract_template` rejects a template that renders perfectly.
+  const allowlist = sql.slice(sql.indexOf('_contract_template_unrendered_tokens'));
+
+  it.each(SUPPLIER.map(([t]) => t).concat(['counterparty.address']))(
+    'accepts %s when authoring a template',
+    (token) => {
+      expect(allowlist).toContain(`'${token}'`);
+    },
+  );
+
+  it('keeps every token the renderer already handled', () => {
+    for (const t of ['counterparty.name', 'counterparty.email', 'today', 'start_date',
+                     'end_date', 'value', 'currency', 'title', 'counterparty.org_number',
+                     'terms_url', 'site_url']) {
+      expect(allowlist).toContain(`'${t}'`);
+    }
+  });
+});

--- a/supabase/migrations/20260808210000_contract-supplier-tokens.sql
+++ b/supabase/migrations/20260808210000_contract-supplier-tokens.sql
@@ -1,0 +1,243 @@
+-- The template asked for what the platform already knew.
+--
+-- Rehearsing the lead→contract chain live the evening before a demo, the
+-- rendered agreement read:
+--
+--     Leverantör: [LEVERANTÖRENS FIRMA], org.nr [ORGNR], [ADRESS]
+--     Kund: Demo Testkund AB, org.nr [KUNDENS ORGNR]
+--
+-- Every `{{token}}` had rendered correctly. The problem is that the templates
+-- also carry 25 distinct BRACKET placeholders across 164 occurrences, and
+-- nothing filled them — while `site_settings.company_profile` holds the
+-- supplier's registered name, org number, address, postal code, city and CEO,
+-- and `companies.address` holds the customer's.
+--
+-- This is the same finding as `20260807…` ("mallen bad om det plattformen redan
+-- visste"), which fixed exactly one field. Roughly half of all placeholder
+-- occurrences are pure derivation from data already stored.
+--
+-- DELIBERATELY NOT A TEMPLATE REWRITE. The previous author already set the
+-- precedent inside this function:
+--
+--     v_body := replace(v_body, '[KUNDENS ORGNR]', v_org);
+--
+-- Following it means every template — the 15 that exist, and every one an
+-- operator writes later, on every instance — is fixed by deploying this, with
+-- no data migration and nothing to keep in sync. Both spellings are accepted:
+-- `{{supplier.org_number}}` for templates authored from here on, and the
+-- bracket form for the ones already written.
+--
+-- MISSING VALUES KEEP THEIR PLACEHOLDER, they do not become blank. A contract
+-- that says `[TELEFON]` is visibly incomplete; one that says
+-- "Felanmälan tas emot dygnet runt på  / " is a document that looks finished
+-- and is not. On the instance this was written for, `contact_phone` and
+-- `contact_email` are empty — so that path is the live case, not a hypothetical.
+--
+-- TWO THAT COULD HAVE BEEN DERIVED AND DELIBERATELY WERE NOT:
+--   [TITEL] — the profile stores a `ceo` name but no title. Inferring "VD" from
+--     the field's own name is a guess, and a signature block is the last place
+--     software should guess. It stays a placeholder until a title is stored.
+--   [MÅNAD ÅR] — the CPI base month in the indexation clause. It usually equals
+--     the start month, but not always, and getting it wrong silently changes
+--     what the customer pays every year. A visible placeholder is cheaper than
+--     a wrong number in a price clause.
+--
+-- IT ALSO CORRECTS THE RETURN TYPE, which is a separate bug found on the way in.
+-- `20260808180000` declares `TABLE(id uuid, title text, status text)`. The
+-- function that is actually deployed returns
+-- `TABLE(contract_id uuid, title text, status contract_status)` — and
+-- `agent-execute` reads `row?.contract_id`. So the repo's shape would make
+-- `manage_contract` answer `contract_id: undefined` on any fresh install, and
+-- on an existing instance that migration cannot apply at all:
+--
+--     ERROR 42P13: cannot change return type of existing function
+--
+-- which is how it was found. This one DROPs first, so it lands on either
+-- lineage, and settles on the shape the consumer reads.
+--
+-- OUT OF SCOPE, and worth stating so nobody thinks it was missed: the amounts,
+-- quantities and hardware models ([BELOPP], [ANTAL], [MODELL] — 40% of
+-- occurrences) live on the quote's line items, and `contracts` carries no
+-- `quote_id`, `deal_id` or `lead_id` at all — only `company_id`. The agreement
+-- cannot reach the deal it came from. That is a schema change, not a rendering
+-- one.
+
+DROP FUNCTION IF EXISTS public.create_contract_from_template(uuid, text, text, jsonb);
+
+CREATE OR REPLACE FUNCTION public.create_contract_from_template(
+  p_template_id uuid,
+  p_counterparty_name text,
+  p_counterparty_email text DEFAULT NULL,
+  p_overrides jsonb DEFAULT '{}'::jsonb
+)
+RETURNS TABLE(contract_id uuid, title text, status public.contract_status)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_tpl public.contract_templates%ROWTYPE;
+  v_body text;
+  v_new_id uuid;
+  v_start date;
+  v_end date;
+  v_value bigint;
+  v_currency text;
+  v_title text;
+  v_company_id uuid;
+  v_org text;
+  v_site_url text;
+  v_profile jsonb;
+  v_sup_name text;
+  v_sup_org text;
+  v_sup_addr text;
+  v_sup_phone text;
+  v_sup_email text;
+  v_sup_signer text;
+  v_cp_addr text;
+BEGIN
+  SELECT * INTO v_tpl FROM public.contract_templates WHERE id = p_template_id;
+  IF v_tpl.id IS NULL THEN
+    RAISE EXCEPTION 'Template not found: %', p_template_id;
+  END IF;
+
+  v_start := COALESCE((p_overrides->>'start_date')::date, CURRENT_DATE);
+  v_end := NULLIF(p_overrides->>'end_date', '')::date;
+  v_value := COALESCE((p_overrides->>'value_cents')::bigint, v_tpl.default_value_cents);
+  v_currency := COALESCE(p_overrides->>'currency', v_tpl.default_currency);
+  v_title := COALESCE(p_overrides->>'title', v_tpl.name || ' — ' || p_counterparty_name);
+
+  v_company_id := CASE WHEN (p_overrides->>'company_id') ~* '^[0-9a-f-]{36}$'
+                       THEN (p_overrides->>'company_id')::uuid END;
+  IF v_company_id IS NULL THEN
+    SELECT id INTO v_company_id FROM public.companies
+    WHERE lower(name) = lower(trim(p_counterparty_name)) LIMIT 1;
+  END IF;
+
+  v_org := COALESCE(
+    NULLIF(trim(p_overrides->>'org_number'), ''),
+    (SELECT org_number FROM public.companies WHERE id = v_company_id)
+  );
+  SELECT NULLIF(trim(address), '') INTO v_cp_addr
+  FROM public.companies WHERE id = v_company_id;
+
+  -- The canonical public URL — the setting FlowPilot and the MCP skills
+  -- already use for absolute links.
+  SELECT NULLIF(trim(value->>'siteUrl'), '') INTO v_site_url
+  FROM public.site_settings WHERE key = 'general';
+
+  -- ── the supplier's own master data ──────────────────────────────────────
+  -- Same store the About page, the invoice footer and FlowPilot's identity all
+  -- read. Registered name is preferred over display name: an agreement names
+  -- the legal entity.
+  SELECT value INTO v_profile FROM public.site_settings WHERE key = 'company_profile';
+  v_sup_name  := COALESCE(NULLIF(trim(v_profile->>'legal_name'), ''),
+                          NULLIF(trim(v_profile->>'company_name'), ''));
+  v_sup_org   := NULLIF(trim(v_profile->>'org_number'), '');
+  v_sup_phone := NULLIF(trim(v_profile->>'contact_phone'), '');
+  v_sup_email := NULLIF(trim(v_profile->>'contact_email'), '');
+  v_sup_signer := NULLIF(trim(v_profile->>'ceo'), '');
+  -- Street, postal code and city are three fields and one line on paper.
+  v_sup_addr := NULLIF(trim(concat_ws(', ',
+    NULLIF(trim(v_profile->>'address'), ''),
+    NULLIF(trim(concat_ws(' ', NULLIF(trim(v_profile->>'postal_code'), ''),
+                               NULLIF(trim(v_profile->>'city'), ''))), ''),
+    NULLIF(trim(v_profile->>'country'), '')
+  )), '');
+
+  v_body := v_tpl.body_markdown;
+  v_body := replace(v_body, '{{counterparty.name}}', p_counterparty_name);
+  v_body := replace(v_body, '{{counterparty.email}}', COALESCE(p_counterparty_email, ''));
+  v_body := replace(v_body, '{{today}}', to_char(CURRENT_DATE, 'YYYY-MM-DD'));
+  v_body := replace(v_body, '{{start_date}}', to_char(v_start, 'YYYY-MM-DD'));
+  v_body := replace(v_body, '{{end_date}}', COALESCE(to_char(v_end, 'YYYY-MM-DD'), 'TBD'));
+  v_body := replace(v_body, '{{value}}', to_char(v_value / 100.0, 'FM999G999G999D00'));
+  v_body := replace(v_body, '{{currency}}', v_currency);
+  v_body := replace(v_body, '{{title}}', v_title);
+
+  IF v_org IS NOT NULL THEN
+    v_body := replace(v_body, '{{counterparty.org_number}}', v_org);
+    v_body := replace(v_body, '[KUNDENS ORGNR]', v_org);
+  END IF;
+  v_body := replace(v_body, '{{counterparty.org_number}}', '[KUNDENS ORGNR]');
+
+  IF v_cp_addr IS NOT NULL THEN
+    v_body := replace(v_body, '{{counterparty.address}}', v_cp_addr);
+    v_body := replace(v_body, '[KUNDENS ADRESS]', v_cp_addr);
+  END IF;
+  v_body := replace(v_body, '{{counterparty.address}}', '[KUNDENS ADRESS]');
+
+  -- Supplier side. Each guarded on its own: a profile filled in halfway should
+  -- contribute the half it has, not nothing.
+  IF v_sup_name IS NOT NULL THEN
+    v_body := replace(v_body, '{{supplier.name}}', v_sup_name);
+    v_body := replace(v_body, '[LEVERANTÖRENS FIRMA]', v_sup_name);
+  END IF;
+  IF v_sup_org IS NOT NULL THEN
+    v_body := replace(v_body, '{{supplier.org_number}}', v_sup_org);
+    v_body := replace(v_body, '[ORGNR]', v_sup_org);
+  END IF;
+  IF v_sup_addr IS NOT NULL THEN
+    v_body := replace(v_body, '{{supplier.address}}', v_sup_addr);
+    v_body := replace(v_body, '[ADRESS]', v_sup_addr);
+  END IF;
+  IF v_sup_phone IS NOT NULL THEN
+    v_body := replace(v_body, '{{supplier.phone}}', v_sup_phone);
+    v_body := replace(v_body, '[TELEFON]', v_sup_phone);
+  END IF;
+  IF v_sup_email IS NOT NULL THEN
+    v_body := replace(v_body, '{{supplier.email}}', v_sup_email);
+    v_body := replace(v_body, '[E-POST]', v_sup_email);
+  END IF;
+  IF v_sup_signer IS NOT NULL THEN
+    v_body := replace(v_body, '{{supplier.signatory}}', v_sup_signer);
+    v_body := replace(v_body, '[NAMN]', v_sup_signer);
+  END IF;
+
+  -- Anything still unresolved keeps its placeholder rather than going blank —
+  -- the whole point. A signer must be able to see what is missing.
+  v_body := replace(v_body, '{{supplier.name}}', '[LEVERANTÖRENS FIRMA]');
+  v_body := replace(v_body, '{{supplier.org_number}}', '[ORGNR]');
+  v_body := replace(v_body, '{{supplier.address}}', '[ADRESS]');
+  v_body := replace(v_body, '{{supplier.phone}}', '[TELEFON]');
+  v_body := replace(v_body, '{{supplier.email}}', '[E-POST]');
+  v_body := replace(v_body, '{{supplier.signatory}}', '[NAMN]');
+
+  IF v_site_url IS NOT NULL THEN
+    v_body := replace(v_body, '{{terms_url}}', rtrim(v_site_url, '/') || '/villkor');
+    v_body := replace(v_body, '{{site_url}}', rtrim(v_site_url, '/'));
+  END IF;
+  -- Unset site URL: readable prose, never leftover markup.
+  v_body := replace(v_body, '{{terms_url}}', 'Leverantörens webbplats');
+  v_body := replace(v_body, '{{site_url}}', 'Leverantörens webbplats');
+
+  INSERT INTO public.contracts
+    (title, counterparty_name, counterparty_email, contract_type, status,
+     company_id, start_date, end_date, value_cents, currency,
+     renewal_type, renewal_notice_days,
+     body_markdown, body_updated_at, template_id, version)
+  VALUES
+    (v_title, p_counterparty_name, p_counterparty_email, v_tpl.contract_type, 'draft',
+     v_company_id, v_start, v_end, v_value, v_currency,
+     v_tpl.default_renewal_type, v_tpl.default_renewal_notice_days,
+     v_body, now(), p_template_id, 1)
+  RETURNING id INTO v_new_id;
+
+  RETURN QUERY SELECT c.id, c.title, c.status FROM public.contracts c WHERE c.id = v_new_id;
+END;
+$$;
+
+-- One token list, shared by the authoring skill and the renderer — the comment
+-- on the original said it, so the new tokens go in the same place rather than
+-- letting the validator reject a template that renders perfectly well.
+CREATE OR REPLACE FUNCTION public._contract_template_unrendered_tokens(p_body text)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  SELECT COALESCE(jsonb_agg(DISTINCT t[1]), '[]'::jsonb)
+  FROM regexp_matches(p_body, '\{\{([^}]+)\}\}', 'g') AS t
+  WHERE t[1] NOT IN ('counterparty.name','counterparty.email','today',
+                     'start_date','end_date','value','currency','title',
+                     'counterparty.org_number','counterparty.address',
+                     'supplier.name','supplier.org_number','supplier.address',
+                     'supplier.phone','supplier.email','supplier.signatory',
+                     'terms_url','site_url');
+$$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260808200000",
-      "migrations_count": 314,
+      "migration_head": "20260808210000",
+      "migrations_count": 315,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1261,6 +1261,10 @@
         {
           "version": "20260808200000",
           "name": "profile-preferences"
+        },
+        {
+          "version": "20260808210000",
+          "name": "contract-supplier-tokens"
         }
       ]
     },


### PR DESCRIPTION
Two commits. The first is the flowtable-validation handoff; the second is the one that matters before a demo.

## The template asked for what the platform already knew

Rehearsing the lead→contract chain live, the rendered agreement read:

```
Leverantör: [LEVERANTÖRENS FIRMA], org.nr [ORGNR], [ADRESS]
Kund: Demo Testkund AB, org.nr [KUNDENS ORGNR]
```

Every `{{token}}` had rendered correctly. But the templates also carry **25 distinct bracket placeholders across 164 occurrences**, and nothing filled them — while `company_profile` held the registered name, org number, address, postal code and city, and `companies.address` held the customer's.

Classifying all 25 against what is actually stored:

| | placeholders | occurrences | what was missing |
|---|---|---|---|
| **already in the platform** | 11 | 77 (47%) | just the tokens — **this PR** |
| **exists, but the contract cannot reach it** | 6 | 65 (40%) | `contracts` has no `quote_id` |
| **unmodelled business choices** | 5 | 19 (12%) | fields nobody defined |
| **subprocessor register** | 3 | 3 (2%) | a register |

## Not a template rewrite

The previous author already set the precedent inside the render function:

```sql
v_body := replace(v_body, '[KUNDENS ORGNR]', v_org);
```

Following it fixes **every template** — the 15 that exist and every one an operator writes later, on every instance — with no data migration and nothing to keep in sync. Both spellings are accepted: `{{supplier.org_number}}` going forward, the bracket form for what is already written.

## Missing values keep their placeholder

This is the property worth holding forever, and it pulls against the first one. `contact_phone` and `contact_email` are **empty** on the instance this was written for, so it is the live case, not a hypothetical:

```
…Felanmälan tas emot dygnet runt i samtliga nivåer på [TELEFON] / [E-POST].
```

not `…på  / `. A document that looks finished and is not is worse than an obvious gap.

**Two that could have been derived and deliberately were not.** `[TITEL]` — the profile stores a `ceo` *name* and no title; inferring "VD" from the field's own name is a guess, and a signature block is the last place software should guess. `[MÅNAD ÅR]` — the CPI base month; it usually equals the start month, but a wrong number in an indexation clause silently changes what the customer pays every year.

## A second bug, found on the way in

`20260808180000` declares `TABLE(id uuid, title text, status text)`. The deployed function returns `TABLE(contract_id uuid, title text, status contract_status)` — and `agent-execute` reads `row?.contract_id`.

So that migration **cannot apply to an existing instance at all**:

```
ERROR 42P13: cannot change return type of existing function
```

which is exactly how it surfaced. On a fresh install it *would* apply, and `manage_contract` would answer `contract_id: undefined`. Neither is visible in either file alone — only in the pair. This one DROPs first and settles on the shape the consumer reads.

## Verified live, then cleaned up

Through the gateway on optic, the same path the demo takes:

| check | result |
|---|---|
| supplier side | `Optic Tunnels Sweden AB, org.nr 559511-2417, Sollidsbacken 1B, 115 21 Stockholm, Sverige` |
| customer with master data | `Liteit, org.nr 556616-1658` |
| customer without an address | keeps `[KUNDENS ADRESS]` |
| empty `contact_phone` / `contact_email` | keeps `[TELEFON] / [E-POST]` |
| blank holes / dangling commas | none |

Verification contracts deleted afterwards; `contracts` back to 0.

**28 guardrails, negative-tested** — removing a fallback fails one, restoring the repo's return type fails another. Full suite **1567 passed**, `tsc` clean, forward-dating guard passes (`> 20260808200000`).

Migration applied to optic. The other four instances get it on the next pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5