### PR TITLE
feat(contracts): the agreement can name itself, and point at the deal it came from

### DIFF
--- a/docs/operators/session-memory.md
+++ b/docs/operators/session-memory.md
@@ -250,6 +250,130 @@ where RLS allows and for `--no-verify-jwt` public functions.
 
 ## Open queue (next session starts here)
 
+### ⇄ Handoff to local Claude — lead→contract, rehearsed live (2026-08-06 evening, cloud session)
+
+Magnus demos the lead→contract process tomorrow, so the whole chain was run
+end to end against optic through the gateway — lead → deal → quote → sent →
+customer accept (anonymous) → contract from template — and the test rows
+deleted afterwards. **Read the "already fixed" list first so nothing is redone.**
+
+#### Already fixed and deployed — do NOT redo
+
+| what | where | state |
+|---|---|---|
+| supplier name / org.nr / address never reached the contract body | `20260808210000` | main + optic |
+| `contracts.quote_id` + `contract_number` (`AGR-YYYY-NNNNN`, trigger-assigned) | `20260808220000` | **#161 open**, applied to optic |
+| `create_contract_from_template` declared the wrong return type | `20260808210000` | main + optic |
+
+**The other four instances have neither migration.** Both are idempotent and
+forward-dated; `20260808210000` DROPs the function first, so it lands on either
+lineage.
+
+#### 1. `manage_deal` manufactures a junk lead and calls it success
+
+Its own parameter doc says *"lead_id: Required for create UNLESS company_id or
+company_name is supplied"*. Passing **none of the three** does not error:
+
+```
+{action:'create', title:'Kontraktstest', value_cents:100}
+→ status: success, auto_created_lead: true
+→ leads row: name "Auto-generated lead", email deal-auto-generated-lead-<ts>@auto.flowwink.local
+```
+
+This is where the `lead.created` placeholder rows in `agent_events` came from.
+In a CRM demo it shows up as rows nobody created on purpose. The fallback should
+fire only when `company_id`/`company_name` IS supplied — which is what the
+contract already promises. Same family as the flowtable `choices` bug: the guard
+exists in the description and nowhere in the code.
+
+#### 2. Two quote number series, and a comment that documents the past
+
+`manage_quote create` produced `QUO-0006` while the admin UI produces
+`QUO-2026-00006`. The generator in `agent-execute` carries this comment:
+
+> `// quotes.quote_number is NOT NULL with no default — the admin UI generates`
+> `// QUO-NNNN client-side, so the skill path must too or create always fails.`
+
+`grep -rn "QUO-" src/` returns **nothing**. The UI moved to
+`next_document_number('quote','QUO')` (→ `QUO-YYYY-NNNNN`) and the skill path
+was left behind, with the comment still asserting the old alignment — which is
+why it reads as correct.
+
+Worse than cosmetic: the skill path scans the last 50 rows for a trailing
+integer and adds one, **without touching `document_number_counters`**. So the
+agent and the UI hand out the same ordinal independently. Today the formats
+differ so they do not collide as strings; aligning the formats (the obvious
+"fix") would turn this into a hard duplicate. The real fix is to call
+`next_document_number` from the skill path too.
+
+#### 3. One line so the agent can link a contract to its quote
+
+`create_contract_from_template` now accepts `quote_id` in `p_overrides`, and the
+admin dialog passes it. `agent-execute` builds overrides from a fixed list:
+
+```ts
+for (const k of ['title', 'start_date', 'end_date', 'value_cents', 'currency'])
+```
+
+Add `'quote_id'` (and `'company_id'`, which the RPC has always accepted and the
+skill has never sent). The skill's `tool_definition` needs the parameter too.
+
+#### 4. Contract placeholders still unfilled — what each one actually needs
+
+25 bracket placeholders / 164 occurrences across the 15 templates. After
+`20260808210000` and `20260808220000`, what remains and why:
+
+- **`[BELOPP]` (15), `[ANTAL]` (34), `[MODELL]`, `[PRIS]`** — per-line figures in
+  fee and capacity tables, not the contract total (which already has
+  `{{value}}`). Needs a mapping from `quote_items` now that `quote_id` exists.
+  Guessing which line is "Etableringsavgift" puts wrong money in a signed
+  agreement, so this wants an explicit per-template line map, not heuristics.
+- **`[HUVUDAVTALETS NUMMER]`** — the DPA annex pointing at its PARENT agreement.
+  Needs a parent-contract link, a different relationship from `quote_id`.
+- **`[ORT]`, `[SN 0 / SN 1 / SN 2]`, `[A1/A2]`, `[STRÄCKANS BENÄMNING]`,
+  `[DATUM]`** — choices and measurements per deal. Data points nobody has
+  modelled; they belong on the deal/quote as structured attributes.
+- **`[BEVAKNINGSBOLAG]`, `[JOURBOLAG]`, `[STÄDBOLAG]`** — the same three
+  subcontractors for every customer. This is a GDPR subprocessor register. As
+  free text you cannot answer "which agreements name our old security provider"
+  when you switch.
+- **`[TITEL]`, `[MÅNAD ÅR]`** — deliberately NOT derived. The profile stores a
+  `ceo` name and no title, and the CPI base month usually but not always equals
+  the start month; a wrong number there silently changes what the customer pays
+  every year.
+
+#### 5. What worked, so nobody goes looking
+
+The public quote page renders anonymously with its lines; `accept_behavior:
+'contract'` correctly creates **no** invoice (first real run — the one accepted
+quote on optic predates the fix by five minutes); `{{terms_url}}` resolves to
+`https://www.optictunnels.eu/villkor` and that page serves 5 terms documents to
+an anonymous visitor.
+
+Also by design, not a bug: **accept does not create a contract.** "Draft
+contract" is a button in `QuoteDetailSheet`. Accept expresses intent, the
+signature binds.
+
+#### 6. Repo/live drift lesson worth keeping
+
+`20260808180000_terms-url-token.sql` declares
+`RETURNS TABLE(id uuid, title text, status text)`. The deployed function returns
+`TABLE(contract_id uuid, title text, status contract_status)`, and
+`agent-execute` reads `row?.contract_id`. So that migration **cannot apply to any
+existing instance** (`42P13: cannot change return type`) and on a fresh install
+would make `manage_contract` answer `contract_id: undefined`. Neither is visible
+in either file alone. `20260808210000` DROPs first and settles on the consumer's
+shape. When changing an RPC's signature, check what reads it — `pg_proc` on a
+live instance and the caller, not the migration you are editing.
+
+#### CI state as of this handoff
+
+GitHub Actions stopped running at **15:39** — no run on main or any branch
+since. The red on main (`e2589514`) is `Build` failing at step 1 "Set up job"
+(runner allocation), while all 13 real checks passed in the same run. The
+main-red alert opened **#160** correctly at 16:10, its first live firing. The
+cloud session's token cannot re-run jobs (403 on `rerun-failed-jobs`).
+
 ### ⇄ Handoff to local Claude — `manage_flowtable_field` accepts bad `choices` and reports success (2026-08-06, cloud session)
 
 **Your file (`agent-execute`), so untouched — but this is the highest-value fix

--- a/src/components/admin/contracts/NewContractDialog.tsx
+++ b/src/components/admin/contracts/NewContractDialog.tsx
@@ -15,8 +15,21 @@ interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   contract?: Contract;
-  /** Prefill when the contract starts from a quote or a lead. */
-  prefill?: { counterparty_name?: string; counterparty_email?: string; value_cents?: number; title?: string };
+  /**
+   * Prefill when the contract starts from a quote or a lead.
+   *
+   * `quote_id` is the link itself, not a convenience: before it existed the
+   * handoff copied values and encoded the origin as prose in the title
+   * (`Avtal — QUO-2026-00005`), so nothing downstream could answer which quote
+   * became which agreement.
+   */
+  prefill?: {
+    counterparty_name?: string;
+    counterparty_email?: string;
+    value_cents?: number;
+    title?: string;
+    quote_id?: string;
+  };
 }
 
 const NO_TEMPLATE = '__blank__';
@@ -147,6 +160,8 @@ export function NewContractDialog({ open, onOpenChange, contract, prefill }: Pro
             end_date: data.end_date || undefined,
             value_cents: Math.round(data.value_cents * 100),
             currency: data.currency,
+            // Carried through so the agreement records the quote it came from.
+            quote_id: prefill?.quote_id || undefined,
           },
         });
         if (error) throw error;

--- a/src/components/admin/quotes/QuoteDetailSheet.tsx
+++ b/src/components/admin/quotes/QuoteDetailSheet.tsx
@@ -437,6 +437,9 @@ export function QuoteDetailSheet({ quoteId, open, onOpenChange }: Props) {
           counterparty_email: quote.leads?.email || '',
           value_cents: quote.total_cents,
           title: `Avtal — ${quote.quote_number}`,
+          // The link, not just the label. The title has always mentioned the
+          // quote; nothing could query on it.
+          quote_id: quote.id,
         }}
       />
     </Sheet>

--- a/src/lib/__tests__/contract-quote-link.guardrails.test.ts
+++ b/src/lib/__tests__/contract-quote-link.guardrails.test.ts
@@ -1,0 +1,128 @@
+/**
+ * An agreement must know which quote it came from, and be able to name itself.
+ *
+ * Before this, `contracts` carried only `company_id`. The quote→contract
+ * handoff copied VALUES and encoded the origin as prose —
+ * `title: 'Avtal — ' || quote_number` — so nothing could query it, and none of
+ * the per-deal figures on the quote could ever reach the contract body. And
+ * every template asked for `[AVTALSNR]` while contracts had no number at all,
+ * though quotes and invoices had drawn from the same counter for months.
+ *
+ * Proven live on optic: a contract created from a template came back
+ * `AGR-2026-00002`, linked to `QUO-2026-00005`, with the number rendered inside
+ * its own body — and the originating lead (`onsdag@liteit.se`) reachable
+ * through the quote, which is why one link is enough and `deal_id`/`lead_id`
+ * were not added.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const sql = read('supabase/migrations/20260808220000_contracts-quote-link-and-number.sql');
+const quoteSheet = read('src/components/admin/quotes/QuoteDetailSheet.tsx');
+const contractDialog = read('src/components/admin/contracts/NewContractDialog.tsx');
+
+describe('the link survives what happens to the quote', () => {
+  it('nulls the link on quote deletion, never cascades', () => {
+    // CASCADE here would delete a SIGNED AGREEMENT because someone tidied up a
+    // quote. The contract outlives its origin by design.
+    expect(sql).toMatch(/quote_id uuid REFERENCES public\.quotes\(id\) ON DELETE SET NULL/);
+    expect(sql).not.toMatch(/quotes\(id\) ON DELETE CASCADE/);
+  });
+
+  it('indexes the link, since "which contract came from this quote" is the question', () => {
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS contracts_quote_id_idx/);
+  });
+});
+
+describe('the number is assigned in one place', () => {
+  it('assigns it by trigger, not inside one of the three creation paths', () => {
+    // A contract is born three ways — the template renderer, the direct create
+    // in manage_contract, and the admin dialog. A rule implemented in one of
+    // three places is the exact shape of bug this codebase keeps finding.
+    expect(sql).toMatch(/CREATE TRIGGER contracts_assign_number\s+BEFORE INSERT ON public\.contracts/);
+  });
+
+  it('only fills a NULL, so the renderer can pre-allocate', () => {
+    // The renderer needs the number BEFORE the row exists, because it goes
+    // inside the body. If the trigger overwrote, every rendered contract would
+    // show one number in its text and carry another in its column.
+    expect(sql).toMatch(/IF NEW\.contract_number IS NULL OR trim\(NEW\.contract_number\) = '' THEN/);
+  });
+
+  it('draws from the same counter as quotes and invoices', () => {
+    expect(sql).toMatch(/next_document_number\('contract', 'AGR'\)/);
+  });
+
+  it('is AGR, not CTR', () => {
+    // `CTR-YYYYMMDD-…` is already the invoice series for contract billing.
+    // Numbering the agreement CTR- too means an operator reading CTR-2026-00001
+    // cannot tell whether it is the agreement or one of its invoices.
+    expect(sql).not.toMatch(/next_document_number\('contract', 'CTR'\)/);
+  });
+
+  it('rejects a duplicate number', () => {
+    // Verified live: the second insert of the same number raises
+    // unique_violation rather than quietly creating a twin.
+    expect(sql).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS contracts_contract_number_key/);
+  });
+});
+
+describe('the backfill does not set up a collision', () => {
+  it('advances the counter past the rows it numbered', () => {
+    // Numbering existing contracts 1..N and leaving the counter at 0 would hand
+    // AGR-YYYY-00001 to the next new contract and collide with the backfill —
+    // caught by the unique index, as a failed insert in front of a user.
+    expect(sql).toMatch(/INSERT INTO public\.document_number_counters\(kind, prefix, last_value\)\s*\n\s*VALUES \('contract', 'AGR', v_max\)/);
+    expect(sql).toMatch(/GREATEST\(public\.document_number_counters\.last_value, EXCLUDED\.last_value\)/);
+  });
+});
+
+describe('the renderer resolves the number it just allocated', () => {
+  it('allocates before building the body', () => {
+    const alloc = sql.indexOf("v_number := public.next_document_number('contract', 'AGR')");
+    const body = sql.indexOf('v_body := v_tpl.body_markdown');
+    expect(alloc).toBeGreaterThan(-1);
+    expect(alloc).toBeLessThan(body);
+  });
+
+  it('fills both spellings of the number', () => {
+    expect(sql).toContain("replace(v_body, '{{contract.number}}', v_number)");
+    expect(sql).toContain("replace(v_body, '[AVTALSNR]', v_number)");
+  });
+
+  it('stores the same number it rendered', () => {
+    // Two allocations would put one number in the text and another in the row.
+    expect(sql).toMatch(/quote_id, contract_number, start_date/);
+    expect(sql).toMatch(/v_company_id, v_quote_id, v_number, v_start/);
+  });
+
+  it('accepts contract.number when authoring a template', () => {
+    const allowlist = sql.slice(sql.indexOf('_contract_template_unrendered_tokens'));
+    expect(allowlist).toContain("'contract.number'");
+  });
+});
+
+describe('the link actually reaches the database from the UI', () => {
+  // The half that is easy to forget: a column nothing populates. Before this,
+  // the quote passed its NUMBER as part of a title string and no id at all.
+  it('the quote hands its id to the contract dialog', () => {
+    const prefill = quoteSheet.slice(quoteSheet.indexOf('<NewContractDialog'));
+    const block = prefill.slice(0, prefill.indexOf('/>'));
+    expect(block).toMatch(/quote_id: quote\.id/);
+  });
+
+  it('the dialog declares it, so a caller cannot pass it silently wrong', () => {
+    expect(contractDialog).toMatch(/quote_id\?: string;/);
+  });
+
+  it('the dialog forwards it into the RPC overrides', () => {
+    // Scoped to the overrides object: a bare /quote_id/ also matches the prop
+    // declaration and would pass while the field never reached the call — the
+    // same trap that let a visibility picker ship without a payload field.
+    const call = contractDialog.slice(contractDialog.indexOf('p_overrides: {'));
+    const overrides = call.slice(0, call.indexOf('},'));
+    expect(overrides).toMatch(/quote_id: prefill\?\.quote_id \|\| undefined/);
+  });
+});

--- a/supabase/migrations/20260808220000_contracts-quote-link-and-number.sql
+++ b/supabase/migrations/20260808220000_contracts-quote-link-and-number.sql
@@ -1,0 +1,293 @@
+-- The agreement could not name itself, and could not point at the deal it came from.
+--
+-- Two gaps found classifying why a rendered contract still showed placeholders:
+--
+--   1. `contracts` carried no `quote_id`, `deal_id` or `lead_id` — only
+--      `company_id`. The quote→contract handoff copied VALUES (name, email,
+--      amount) and encoded the link as prose: `title: 'Avtal — ' || quote_number`.
+--      So nothing downstream could answer "which quote became this agreement",
+--      and none of the per-deal figures on the quote's line items could ever
+--      reach the contract body.
+--   2. `contracts` had no number at all, while quotes and invoices both draw
+--      from `next_document_number`. Every template asks for `[AVTALSNR]`
+--      (8 occurrences) and nothing could answer.
+--
+-- PREFIX IS `AGR`, NOT `CTR`. `CTR-YYYYMMDD-…` is already the invoice series for
+-- contract billing (`generate_contract_invoice`). Numbering the agreement CTR-
+-- too would mean an operator reading `CTR-2026-00001` cannot tell whether it is
+-- the agreement or one of its invoices. `AGR` is unused and reads in both
+-- languages; the counter row stores the prefix, so an instance can change it.
+--
+-- THE NUMBER IS ASSIGNED BY A TRIGGER, not by the one function that renders
+-- templates. There are three ways a contract is born — the template renderer,
+-- the direct create in `manage_contract`, and the admin dialog — and a rule
+-- implemented in one of three places is precisely the shape of bug this
+-- codebase keeps finding. The trigger only fills a NULL, so the renderer can
+-- still allocate the number first (it needs it INSIDE the body).
+--
+-- STILL OUT OF SCOPE, deliberately: `[BELOPP]` and `[ANTAL]` appear in fee and
+-- capacity TABLES — per-line figures, not the contract total, which already has
+-- `{{value}}`. Feeding them needs a per-line mapping from `quote_items`, and
+-- guessing which line is "Etableringsavgift" would put wrong money in a signed
+-- agreement. `[HUVUDAVTALETS NUMMER]` is the DPA annex pointing at its PARENT
+-- agreement — that needs a parent link, which is a separate relationship from
+-- the one added here.
+
+-- ── the link ───────────────────────────────────────────────────────────────
+-- ON DELETE SET NULL, never CASCADE: deleting a quote must not delete a signed
+-- agreement. The contract outlives its origin by design.
+ALTER TABLE public.contracts
+  ADD COLUMN IF NOT EXISTS quote_id uuid REFERENCES public.quotes(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS contract_number text;
+
+CREATE INDEX IF NOT EXISTS contracts_quote_id_idx
+  ON public.contracts (quote_id) WHERE quote_id IS NOT NULL;
+
+COMMENT ON COLUMN public.contracts.quote_id IS
+  'The quote this agreement was drafted from, when there was one. Reaches deal_id and lead_id through quotes, so one link is enough. Nullable: contracts are also written directly.';
+COMMENT ON COLUMN public.contracts.contract_number IS
+  'AGR-YYYY-NNNNN from next_document_number(''contract'', ''AGR''). Assigned by trigger on insert when not supplied. NOT the CTR- series, which numbers contract BILLING invoices.';
+
+-- ── the number ─────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.assign_contract_number()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+BEGIN
+  IF NEW.contract_number IS NULL OR trim(NEW.contract_number) = '' THEN
+    NEW.contract_number := public.next_document_number('contract', 'AGR');
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS contracts_assign_number ON public.contracts;
+CREATE TRIGGER contracts_assign_number
+  BEFORE INSERT ON public.contracts
+  FOR EACH ROW EXECUTE FUNCTION public.assign_contract_number();
+
+-- Existing agreements get numbers in the order they were created, and the
+-- counter is advanced past them — otherwise the next new contract would be
+-- handed AGR-YYYY-00001 again and collide with the backfill.
+DO $$
+DECLARE v_max bigint;
+BEGIN
+  WITH numbered AS (
+    SELECT id, row_number() OVER (ORDER BY created_at, id) AS n
+    FROM public.contracts WHERE contract_number IS NULL
+  )
+  UPDATE public.contracts c
+  SET contract_number = 'AGR-' || to_char(COALESCE(c.created_at, now()), 'YYYY')
+                        || '-' || lpad(numbered.n::text, 5, '0')
+  FROM numbered WHERE numbered.id = c.id;
+
+  SELECT count(*) INTO v_max FROM public.contracts;
+  IF v_max > 0 THEN
+    INSERT INTO public.document_number_counters(kind, prefix, last_value)
+    VALUES ('contract', 'AGR', v_max)
+    ON CONFLICT (kind) DO UPDATE
+      SET last_value = GREATEST(public.document_number_counters.last_value, EXCLUDED.last_value),
+          prefix = EXCLUDED.prefix;
+  END IF;
+END $$;
+
+-- Unique, but only over rows that have one — the partial predicate keeps the
+-- index honest if a future path ever inserts without the trigger.
+CREATE UNIQUE INDEX IF NOT EXISTS contracts_contract_number_key
+  ON public.contracts (contract_number) WHERE contract_number IS NOT NULL;
+
+-- ── the renderer ───────────────────────────────────────────────────────────
+-- Same body as 20260808210000 plus: the number is allocated BEFORE the body is
+-- built (it has to appear inside it), the quote link is stored, and
+-- `{{contract.number}}` / `[AVTALSNR]` resolve.
+DROP FUNCTION IF EXISTS public.create_contract_from_template(uuid, text, text, jsonb);
+
+CREATE OR REPLACE FUNCTION public.create_contract_from_template(
+  p_template_id uuid,
+  p_counterparty_name text,
+  p_counterparty_email text DEFAULT NULL,
+  p_overrides jsonb DEFAULT '{}'::jsonb
+)
+RETURNS TABLE(contract_id uuid, title text, status public.contract_status)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_tpl public.contract_templates%ROWTYPE;
+  v_body text;
+  v_new_id uuid;
+  v_start date;
+  v_end date;
+  v_value bigint;
+  v_currency text;
+  v_title text;
+  v_company_id uuid;
+  v_quote_id uuid;
+  v_number text;
+  v_org text;
+  v_site_url text;
+  v_profile jsonb;
+  v_sup_name text;
+  v_sup_org text;
+  v_sup_addr text;
+  v_sup_phone text;
+  v_sup_email text;
+  v_sup_signer text;
+  v_cp_addr text;
+BEGIN
+  SELECT * INTO v_tpl FROM public.contract_templates WHERE id = p_template_id;
+  IF v_tpl.id IS NULL THEN
+    RAISE EXCEPTION 'Template not found: %', p_template_id;
+  END IF;
+
+  v_start := COALESCE((p_overrides->>'start_date')::date, CURRENT_DATE);
+  v_end := NULLIF(p_overrides->>'end_date', '')::date;
+  v_value := COALESCE((p_overrides->>'value_cents')::bigint, v_tpl.default_value_cents);
+  v_currency := COALESCE(p_overrides->>'currency', v_tpl.default_currency);
+  v_title := COALESCE(p_overrides->>'title', v_tpl.name || ' — ' || p_counterparty_name);
+
+  v_quote_id := CASE WHEN (p_overrides->>'quote_id') ~* '^[0-9a-f-]{36}$'
+                     THEN (p_overrides->>'quote_id')::uuid END;
+
+  v_company_id := CASE WHEN (p_overrides->>'company_id') ~* '^[0-9a-f-]{36}$'
+                       THEN (p_overrides->>'company_id')::uuid END;
+  IF v_company_id IS NULL THEN
+    SELECT id INTO v_company_id FROM public.companies
+    WHERE lower(name) = lower(trim(p_counterparty_name)) LIMIT 1;
+  END IF;
+
+  v_org := COALESCE(
+    NULLIF(trim(p_overrides->>'org_number'), ''),
+    (SELECT org_number FROM public.companies WHERE id = v_company_id)
+  );
+  SELECT NULLIF(trim(address), '') INTO v_cp_addr
+  FROM public.companies WHERE id = v_company_id;
+
+  -- Allocated here rather than left to the trigger: the number has to appear
+  -- inside the body, and the body is built before the row exists. The trigger
+  -- only fills a NULL, so this wins and nothing is double-counted.
+  v_number := public.next_document_number('contract', 'AGR');
+
+  -- The canonical public URL — the setting FlowPilot and the MCP skills
+  -- already use for absolute links.
+  SELECT NULLIF(trim(value->>'siteUrl'), '') INTO v_site_url
+  FROM public.site_settings WHERE key = 'general';
+
+  -- ── the supplier's own master data ──────────────────────────────────────
+  -- Same store the About page, the invoice footer and FlowPilot's identity all
+  -- read. Registered name is preferred over display name: an agreement names
+  -- the legal entity.
+  SELECT value INTO v_profile FROM public.site_settings WHERE key = 'company_profile';
+  v_sup_name  := COALESCE(NULLIF(trim(v_profile->>'legal_name'), ''),
+                          NULLIF(trim(v_profile->>'company_name'), ''));
+  v_sup_org   := NULLIF(trim(v_profile->>'org_number'), '');
+  v_sup_phone := NULLIF(trim(v_profile->>'contact_phone'), '');
+  v_sup_email := NULLIF(trim(v_profile->>'contact_email'), '');
+  v_sup_signer := NULLIF(trim(v_profile->>'ceo'), '');
+  -- Street, postal code and city are three fields and one line on paper.
+  v_sup_addr := NULLIF(trim(concat_ws(', ',
+    NULLIF(trim(v_profile->>'address'), ''),
+    NULLIF(trim(concat_ws(' ', NULLIF(trim(v_profile->>'postal_code'), ''),
+                               NULLIF(trim(v_profile->>'city'), ''))), ''),
+    NULLIF(trim(v_profile->>'country'), '')
+  )), '');
+
+  v_body := v_tpl.body_markdown;
+  v_body := replace(v_body, '{{counterparty.name}}', p_counterparty_name);
+  v_body := replace(v_body, '{{counterparty.email}}', COALESCE(p_counterparty_email, ''));
+  v_body := replace(v_body, '{{today}}', to_char(CURRENT_DATE, 'YYYY-MM-DD'));
+  v_body := replace(v_body, '{{start_date}}', to_char(v_start, 'YYYY-MM-DD'));
+  v_body := replace(v_body, '{{end_date}}', COALESCE(to_char(v_end, 'YYYY-MM-DD'), 'TBD'));
+  v_body := replace(v_body, '{{value}}', to_char(v_value / 100.0, 'FM999G999G999D00'));
+  v_body := replace(v_body, '{{currency}}', v_currency);
+  v_body := replace(v_body, '{{title}}', v_title);
+
+  -- The agreement can finally name itself.
+  v_body := replace(v_body, '{{contract.number}}', v_number);
+  v_body := replace(v_body, '[AVTALSNR]', v_number);
+
+  IF v_org IS NOT NULL THEN
+    v_body := replace(v_body, '{{counterparty.org_number}}', v_org);
+    v_body := replace(v_body, '[KUNDENS ORGNR]', v_org);
+  END IF;
+  v_body := replace(v_body, '{{counterparty.org_number}}', '[KUNDENS ORGNR]');
+
+  IF v_cp_addr IS NOT NULL THEN
+    v_body := replace(v_body, '{{counterparty.address}}', v_cp_addr);
+    v_body := replace(v_body, '[KUNDENS ADRESS]', v_cp_addr);
+  END IF;
+  v_body := replace(v_body, '{{counterparty.address}}', '[KUNDENS ADRESS]');
+
+  -- Supplier side. Each guarded on its own: a profile filled in halfway should
+  -- contribute the half it has, not nothing.
+  IF v_sup_name IS NOT NULL THEN
+    v_body := replace(v_body, '{{supplier.name}}', v_sup_name);
+    v_body := replace(v_body, '[LEVERANTÖRENS FIRMA]', v_sup_name);
+  END IF;
+  IF v_sup_org IS NOT NULL THEN
+    v_body := replace(v_body, '{{supplier.org_number}}', v_sup_org);
+    v_body := replace(v_body, '[ORGNR]', v_sup_org);
+  END IF;
+  IF v_sup_addr IS NOT NULL THEN
+    v_body := replace(v_body, '{{supplier.address}}', v_sup_addr);
+    v_body := replace(v_body, '[ADRESS]', v_sup_addr);
+  END IF;
+  IF v_sup_phone IS NOT NULL THEN
+    v_body := replace(v_body, '{{supplier.phone}}', v_sup_phone);
+    v_body := replace(v_body, '[TELEFON]', v_sup_phone);
+  END IF;
+  IF v_sup_email IS NOT NULL THEN
+    v_body := replace(v_body, '{{supplier.email}}', v_sup_email);
+    v_body := replace(v_body, '[E-POST]', v_sup_email);
+  END IF;
+  IF v_sup_signer IS NOT NULL THEN
+    v_body := replace(v_body, '{{supplier.signatory}}', v_sup_signer);
+    v_body := replace(v_body, '[NAMN]', v_sup_signer);
+  END IF;
+
+  -- Anything still unresolved keeps its placeholder rather than going blank —
+  -- the whole point. A signer must be able to see what is missing.
+  v_body := replace(v_body, '{{supplier.name}}', '[LEVERANTÖRENS FIRMA]');
+  v_body := replace(v_body, '{{supplier.org_number}}', '[ORGNR]');
+  v_body := replace(v_body, '{{supplier.address}}', '[ADRESS]');
+  v_body := replace(v_body, '{{supplier.phone}}', '[TELEFON]');
+  v_body := replace(v_body, '{{supplier.email}}', '[E-POST]');
+  v_body := replace(v_body, '{{supplier.signatory}}', '[NAMN]');
+
+  IF v_site_url IS NOT NULL THEN
+    v_body := replace(v_body, '{{terms_url}}', rtrim(v_site_url, '/') || '/villkor');
+    v_body := replace(v_body, '{{site_url}}', rtrim(v_site_url, '/'));
+  END IF;
+  -- Unset site URL: readable prose, never leftover markup.
+  v_body := replace(v_body, '{{terms_url}}', 'Leverantörens webbplats');
+  v_body := replace(v_body, '{{site_url}}', 'Leverantörens webbplats');
+
+  INSERT INTO public.contracts
+    (title, counterparty_name, counterparty_email, contract_type, status,
+     company_id, quote_id, contract_number, start_date, end_date, value_cents, currency,
+     renewal_type, renewal_notice_days,
+     body_markdown, body_updated_at, template_id, version)
+  VALUES
+    (v_title, p_counterparty_name, p_counterparty_email, v_tpl.contract_type, 'draft',
+     v_company_id, v_quote_id, v_number, v_start, v_end, v_value, v_currency,
+     v_tpl.default_renewal_type, v_tpl.default_renewal_notice_days,
+     v_body, now(), p_template_id, 1)
+  RETURNING id INTO v_new_id;
+
+  RETURN QUERY SELECT c.id, c.title, c.status FROM public.contracts c WHERE c.id = v_new_id;
+END;
+$$;
+
+-- One token list, shared by the authoring skill and the renderer.
+CREATE OR REPLACE FUNCTION public._contract_template_unrendered_tokens(p_body text)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  SELECT COALESCE(jsonb_agg(DISTINCT t[1]), '[]'::jsonb)
+  FROM regexp_matches(p_body, '\{\{([^}]+)\}\}', 'g') AS t
+  WHERE t[1] NOT IN ('counterparty.name','counterparty.email','today',
+                     'start_date','end_date','value','currency','title',
+                     'counterparty.org_number','counterparty.address',
+                     'supplier.name','supplier.org_number','supplier.address',
+                     'supplier.phone','supplier.email','supplier.signatory',
+                     'contract.number','terms_url','site_url');
+$$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260808210000",
-      "migrations_count": 315,
+      "migration_head": "20260808220000",
+      "migrations_count": 316,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1265,6 +1265,10 @@
         {
           "version": "20260808210000",
           "name": "contract-supplier-tokens"
+        },
+        {
+          "version": "20260808220000",
+          "name": "contracts-quote-link-and-number"
         }
       ]
     },


### PR DESCRIPTION
The two structural gaps behind the placeholders that `#159` deliberately left.

## `contracts` did not know where it came from

It carried `company_id` and nothing else. The quote→contract handoff copied **values** and encoded the origin as prose:

```ts
title: `Avtal — ${quote.quote_number}`
```

So "which quote became this agreement" was unanswerable, and no per-deal figure on the quote's line items could ever reach the contract body.

**One link, not three.** `quotes` already carries `lead_id` and `deal_id`, so `quote_id` reaches the whole chain. Verified live — the originating lead (`onsdag@liteit.se`) came back through the quote with no extra column.

**`ON DELETE SET NULL`, never CASCADE.** Deleting a quote must not delete a signed agreement. The contract outlives its origin by design.

## `contracts` could not name itself

Quotes and invoices have drawn from `next_document_number` for months. Contracts had no number, and every template asks for `[AVTALSNR]` (8 occurrences).

**Assigned by a BEFORE INSERT trigger, not inside the renderer.** A contract is born three ways — the template renderer, the direct create in `manage_contract`, and the admin dialog. A rule living in one of three places is the exact shape of bug this codebase keeps finding. The trigger only fills a NULL, so the renderer can still allocate first — it has to, because the number goes *inside* the body it is building.

**Prefix `AGR`, not `CTR`.** `CTR-YYYYMMDD-…` is already the invoice series for contract billing. An operator reading `CTR-2026-00001` should not have to guess whether it is the agreement or one of its invoices.

**The backfill advances the counter** past the rows it numbered — otherwise the next new contract is handed `AGR-YYYY-00001` again and collides, surfacing as a failed insert in front of a user.

## Verified live on optic

| check | result |
|---|---|
| contract from template | `AGR-2026-00002`, linked to `QUO-2026-00005` |
| number inside its own body | `**Avtalsnummer:** AGR-2026-00002` |
| lead reachable via the quote | `onsdag@liteit.se` |
| direct path (no template) | trigger assigns `…00003`, `…00004` sequentially |
| explicit number supplied | respected, not overwritten |
| duplicate number | `unique_violation` |

Test rows deleted; `contracts` back to 0. The consumed numbers were **not** reused — same monotonic principle as the invoice series.

## Still out of scope, deliberately

`[BELOPP]` and `[ANTAL]` are per-line figures in fee and capacity tables, not the contract total (which already has `{{value}}`). Feeding them needs a per-line mapping from `quote_items`, and guessing which line is "Etableringsavgift" would put wrong money in a signed agreement. `[HUVUDAVTALETS NUMMER]` is the DPA annex pointing at its **parent** agreement — a different relationship from the one added here.

## One thing I could not do

`agent-execute` builds its overrides from a fixed list (`title`, `start_date`, `end_date`, `value_cents`, `currency`), so **the agent path cannot set `quote_id` yet** — the RPC accepts it, the caller does not send it. That file is local Claude's; it is one line and it is written up for them.

15 guardrails, negative-tested: dropping the quote id from the handoff, switching to CASCADE, or letting the trigger overwrite each fails one. Full suite **1582 passed**, `tsc` clean, forward-dating guard passes. Migration applied to optic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_