### PR TITLE
feat(contracts): the agreement number reaches the screen

### DIFF
--- a/src/components/admin/contracts/ContractDetailDialog.tsx
+++ b/src/components/admin/contracts/ContractDetailDialog.tsx
@@ -32,6 +32,11 @@ export function ContractDetailDialog({ contract, open, onOpenChange }: Props) {
       <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <div className="flex items-center gap-2 flex-wrap">
+            {contract.contract_number && (
+              <span className="font-mono text-xs text-muted-foreground shrink-0">
+                {contract.contract_number}
+              </span>
+            )}
             <DialogTitle className="truncate">{contract.title}</DialogTitle>
             <Badge variant="outline" className={STATUS_COLORS[contract.status]}>
               {contract.status.replace("_", " ")}

--- a/src/components/admin/contracts/ContractsList.tsx
+++ b/src/components/admin/contracts/ContractsList.tsx
@@ -108,6 +108,13 @@ export function ContractsList({ statusFilter }: Props) {
                   <div className="flex items-start justify-between">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 mb-1 flex-wrap">
+                        {/* The agreement's own number, ahead of the title: it is
+                            what people quote to each other on the phone. */}
+                        {contract.contract_number && (
+                          <span className="font-mono text-xs text-muted-foreground shrink-0">
+                            {contract.contract_number}
+                          </span>
+                        )}
                         <h3 className="font-semibold truncate">{contract.title}</h3>
                         <Badge variant="outline" className={STATUS_COLORS[contract.status]}>
                           {contract.status.replace('_', ' ')}
@@ -125,6 +132,8 @@ export function ContractsList({ statusFilter }: Props) {
                       <p className="text-sm text-muted-foreground mb-2">
                         {contract.counterparty_name}
                         {contract.counterparty_email && ` · ${contract.counterparty_email}`}
+                        {/* Where it came from, as data rather than a title string. */}
+                        {contract.quotes?.quote_number && ` · från ${contract.quotes.quote_number}`}
                       </p>
 
                       <div className="flex items-center gap-4 text-xs text-muted-foreground">

--- a/src/hooks/useContracts.ts
+++ b/src/hooks/useContracts.ts
@@ -22,6 +22,12 @@ export interface Contract {
   created_by: string | null;
   created_at: string;
   updated_at: string;
+  /** AGR-YYYY-NNNNN, assigned on insert. Null only on rows predating the series. */
+  contract_number: string | null;
+  /** The quote this was drafted from, when there was one. */
+  quote_id: string | null;
+  /** Joined, not stored — the quote's own number, for showing the origin. */
+  quotes?: { quote_number: string | null } | null;
 }
 
 export interface ContractDocument {
@@ -41,7 +47,9 @@ export function useContracts(statusFilter?: string) {
     queryFn: async () => {
       let query = supabase
         .from('contracts')
-        .select('*')
+        // The quote is joined so a contract can show where it came from. Before
+        // `quote_id` existed the origin lived only as prose in the title.
+        .select('*, quotes(quote_number)')
         .order('updated_at', { ascending: false });
       if (statusFilter && statusFilter !== 'all') {
         query = query.eq('status', statusFilter as 'draft' | 'pending_signature' | 'active' | 'expired' | 'terminated');

--- a/src/lib/__tests__/contract-quote-link.guardrails.test.ts
+++ b/src/lib/__tests__/contract-quote-link.guardrails.test.ts
@@ -126,3 +126,36 @@ describe('the link actually reaches the database from the UI', () => {
     expect(overrides).toMatch(/quote_id: prefill\?\.quote_id \|\| undefined/);
   });
 });
+
+describe('the number and the origin are visible to a human', () => {
+  // The dual-surface law from CLAUDE.md: a capability needs the agent skill AND
+  // an admin surface. `contract_number` shipped in the database and was rendered
+  // nowhere — the `Contract` type did not even declare it, so the two places
+  // that referenced `c.contract_number` (the field-service and consultant
+  // pickers) had been reading `undefined` since before the column existed.
+  const list = read('src/components/admin/contracts/ContractsList.tsx');
+  const detail = read('src/components/admin/contracts/ContractDetailDialog.tsx');
+  const hook = read('src/hooks/useContracts.ts');
+
+  it('declares both new columns on the type', () => {
+    expect(hook).toMatch(/contract_number: string \| null;/);
+    expect(hook).toMatch(/quote_id: string \| null;/);
+  });
+
+  it('joins the quote so a contract can show where it came from', () => {
+    // Verified against the live PostgREST embed, not just the string:
+    // AGR-2026-00015 → QUO-2026-00008, while the pre-link AGR-2026-00004
+    // correctly returns nothing.
+    expect(hook).toMatch(/\.select\('\*, quotes\(quote_number\)'\)/);
+  });
+
+  it('renders the number in the list and in the detail header', () => {
+    expect(list).toMatch(/\{contract\.contract_number\}/);
+    expect(detail).toMatch(/\{contract\.contract_number\}/);
+  });
+
+  it('renders the originating quote number, not just the title string', () => {
+    // The title has always said "Avtal — QUO-…". That is prose; this is the row.
+    expect(list).toMatch(/contract\.quotes\?\.quote_number/);
+  });
+});


### PR DESCRIPTION
Answering "does the agreement number show in the admin view?" — **it did not.**

`contract_number` shipped in the database with #161 and was rendered nowhere. The `Contract` type did not even declare it. The tell: two unrelated files already referenced `c.contract_number` —

```tsx
// ServiceOrderDetailDialog.tsx, AssignmentsTab.tsx
label: c.title ?? c.contract_number ?? c.id.slice(0, 8)
```

— so they had been reading `undefined` since before the column existed, and started working by accident when it landed.

This is the **dual-surface law** from `CLAUDE.md`: a capability needs the agent skill *and* an admin surface to count as done. The skill half shipped; this is the other half.

## What changed

The list row and the detail header show the number in monospace, ahead of the title — it is what people quote to each other on the phone, and the title is not.

The list also shows the **originating quote**, joined rather than parsed. The title has always read `Avtal — QUO-2026-00005`; that is prose. `.select('*, quotes(quote_number)')` makes it a row.

## Verified against the live embed, not the string

Exactly the query the frontend issues, run against optic:

| contract | title | joined quote |
|---|---|---|
| `AGR-2026-00015` | Avtal — QUO-2026-00008 | `QUO-2026-00008` |
| `AGR-2026-00009` | Avtal — QUO-2026-00007 | `QUO-2026-00007` |
| `AGR-2026-00004` | Avtal — QUO-2026-00005 | — |

`AGR-2026-00004` was created at 20:08, before the link existed; the two after it carry real links. Old and new behaviour side by side in Magnus's own data.

## Note on the chain check that found this

Ran the whole lead→contract chain against optic again after today's merges. Everything holds: both creation paths, the number rendered inside the contract body, the anonymous quote page, the anonymous terms page (5 documents), both document-visibility policies, 12/12 flowtable fields with choices, `accept_behavior: contract`.

Two things changed on optic since this evening, both good: the company profile now has `contact_email` and `contact_phone` (so `[TELEFON]`/`[E-POST]` render), and it has a `legal_name` — which the renderer prefers over the display name, so agreements now name **Optic Tunnels Networks Nordic AB** rather than the brand. Correct for a contract, worth seeing before a demo.

4 guardrails. Full suite **1633 passed**, `tsc` clean. No migration — frontend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_