### PR TITLE
fix(users): deletion detaches both FK families, and the flowtable cascade is defused

### DIFF
--- a/docs/operators/session-memory.md
+++ b/docs/operators/session-memory.md
@@ -250,6 +250,74 @@ where RLS allows and for `--no-verify-jwt` public functions.
 
 ## Open queue (next session starts here)
 
+### ⇄ Handoff to local Claude — user deletion, both FK families (2026-08-07 evening, cloud session)
+
+**⚠️ First: a force-push ate a merged commit.** `848e93ae4` (PR #163, the
+`auth.users` FK map) was on main and is gone — this file's history now jumps
+from #161 straight past it. Content restored here. When branching, branch from
+fresh `origin/main` and never force-push a branch that was cut before your own
+latest merge; this doc has a history-rewrite scar from July for the same reason.
+
+**Second: your sweep numbers were right and my retraction was wrong.** I
+measured 0/7 leads for the sales role, then withdrew it as a measurement
+artifact because `user_roles` was being rewritten under me (your delete tests).
+Your `20260808280000` found the real cause — 64 tables gating on `approver`, a
+legacy role zero users hold. The finding stood; my retraction did not.
+
+#### delete-user: the gap, and the fix that shipped (20260808290000)
+
+Your detach list — `leads.assigned_to`, `project_tasks.created_by`,
+`support_escalations.resolved_by` — is exactly the 3 NO ACTION columns that
+reference **profiles**: 3 of 3 for that family. But there are two families.
+**27 more NO ACTION columns reference `auth.users` directly**, none handled.
+Live on optic while reviewing: the admin held `contract_versions.created_by=2`,
+`projects.created_by=1` — deleting any colleague who had actually worked failed
+on an FK error. Deleting one who never created anything succeeded, which is how
+the gap survives testing.
+
+Shipped from here, live-verified on optic in rolled-back transactions:
+
+- **`detach_user_references(p_user_id)`** walks `pg_constraint` at execution
+  time — every NO ACTION FK to `auth.users` or `profiles`, nulled when
+  nullable (all 30 are today), reported **by name** when NOT NULL. No list to
+  drift. Guarded `service_role OR admin`, no postgres escape hatch;
+  negative-tested live (sales claims → rejected).
+- **`delete-user` now calls it** instead of the three hardcoded detaches.
+  Deployed to optic as **v2**; other instances get it on function deploy.
+- **The flowtable cascade is defused.** `flowtable_bases.owner_id` was NOT NULL
+  + ON DELETE CASCADE → tables → fields/records: deleting optic's admin would
+  have silently destroyed the Produkter base (3 tables, 24 rows) the sales
+  conversation reads from. Now nullable + SET NULL, and the owner-only
+  UPDATE/DELETE policies gained the admin path (an ownerless base was
+  unmanageable — the old policies had no admin clause at all).
+- E2E proof: detach → real `DELETE FROM auth.users` → both bases survive
+  ownerless, 25 rows and 3 contracts intact → rollback restores everything.
+
+**Open decision for you:** authorship is NULLED, never reassigned (history
+keeps the row, loses the name). If a future column arrives NOT NULL, the
+function names it and blocks — that error is the prompt for a schema decision,
+not a bug.
+
+#### The rest of the auth.users map, for reference
+
+16 CASCADE (15 correct: auth internals, profiles, user_roles, wishlist,
+project_members, customer_addresses — the 16th was flowtable_bases, fixed
+above). 32 already SET NULL. `documents.uploaded_by` has **no FK at all** —
+after deletion a `private` document becomes admin-only (probably right, but it
+is a decision, not an accident), and the uploader-folder clause in the storage
+policy points at a uid that no longer exists (file stays reachable via the
+documents row / admin).
+
+#### Ownership groundwork ("Mina/Alla")
+
+Both sessions measured this independently the same evening and converged —
+same numbers (0/7, 0/5, 0/2), same order (assign → backfill → lens defaulting
+to "all"). The full write-up is your own "Ownership scoping" section at the
+bottom of this file; the one thing to carry over from this side: Magnus wants
+the lens in query filters + `profiles.preferences`, **never in RLS** — and no
+one should start it while the other is mid-role-sweep; two agents in the same
+role tables produced false findings twice today.
+
 ### ⇄ Handoff to local Claude — lead→contract, rehearsed live (2026-08-06 evening, cloud session)
 
 Magnus demos the lead→contract process tomorrow, so the whole chain was run

--- a/src/lib/__tests__/detach-user-references.guardrails.test.ts
+++ b/src/lib/__tests__/detach-user-references.guardrails.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Deleting a user must detach every reference — not the ones someone listed.
+ *
+ * The first delete-user detached exactly the 3 NO ACTION columns referencing
+ * `profiles`: a complete list for that family, while 27 more NO ACTION columns
+ * referencing `auth.users` directly went unhandled. Live case on optic: the
+ * admin held contract_versions.created_by=2 and projects.created_by=1, so
+ * deleting any colleague who had actually worked failed on an FK error —
+ * and deleting a user who never created anything succeeded, which is exactly
+ * how the gap survives testing.
+ *
+ * Proven live in a rolled-back transaction: detach nulled both families in one
+ * pass, the auth.users DELETE went through, and both flowtable bases survived
+ * ownerless with all 25 rows — where the old CASCADE would have destroyed them
+ * silently.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const sql = read('supabase/migrations/20260808290000_detach-user-references.sql');
+const fn = read('supabase/functions/delete-user/index.ts');
+
+describe('the detach walks the catalog, not a list', () => {
+  it('derives the columns from pg_constraint at execution time', () => {
+    // A hardcoded list was right on the day it was written and wrong by review
+    // time. Every new created_by column re-opens the gap silently.
+    expect(sql).toMatch(/FROM pg_constraint c/);
+    expect(sql).toMatch(/c\.confdeltype = 'a'/);
+  });
+
+  it('covers both families — auth.users AND profiles', () => {
+    // The original bug in one line: one family handled completely, the other
+    // not at all. Completeness within the wrong scope reads as correctness.
+    expect(sql).toMatch(/c\.confrelid IN \('auth\.users'::regclass, 'public\.profiles'::regclass\)/);
+  });
+
+  it('reports NOT NULL columns by name instead of failing generically', () => {
+    expect(sql).toMatch(/User has NOT NULL references that cannot be detached: %/);
+  });
+
+  it('nulls authorship, never reassigns it', () => {
+    // History keeps the row and loses the name. Reassigning would claim the
+    // deleting admin authored a departed colleague's contracts.
+    expect(sql).toMatch(/UPDATE %s SET %I = NULL WHERE %I = \$1/);
+    expect(sql).not.toMatch(/SET %I = auth\.uid\(\)/);
+  });
+});
+
+describe('the function cannot be turned against the platform', () => {
+  it('requires service role or admin', () => {
+    // SECURITY DEFINER + callable by authenticated = any logged-in user could
+    // strip ownership columns platform-wide without this.
+    expect(sql).toMatch(/auth\.role\(\) = 'service_role'\s*\n?\s*OR public\.has_role\(auth\.uid\(\), 'admin'/);
+  });
+
+  it('has no postgres escape hatch', () => {
+    // A superuser bypasses RLS anyway; an extra OR-clause is one more branch a
+    // probe cannot exercise. Verified live: sales-role claims are rejected.
+    expect(sql).not.toMatch(/session_user\s*=\s*'postgres'/);
+  });
+
+  it('revokes from anon', () => {
+    expect(sql).toMatch(/REVOKE ALL ON FUNCTION public\.detach_user_references\(uuid\) FROM PUBLIC, anon/);
+  });
+});
+
+describe('the cascade is defused', () => {
+  it('rewrites flowtable_bases.owner_id to SET NULL', () => {
+    // The old CASCADE ran on through tables to fields and records: deleting
+    // optic's admin would have silently destroyed the Produkter base the whole
+    // sales conversation reads from. A base is a shared workspace artifact
+    // that happens to record who created it.
+    expect(sql).toMatch(/FOREIGN KEY \(owner_id\) REFERENCES auth\.users\(id\) ON DELETE SET NULL/);
+  });
+
+  it('only rewrites when the constraint is still CASCADE', () => {
+    // Re-running the migration must not drop and recreate a constraint that is
+    // already correct — idempotence is the fleet contract.
+    expect(sql).toMatch(/confdeltype = 'c'\s+-- only rewrite if still CASCADE/);
+  });
+
+  it('makes the column nullable, since SET NULL needs somewhere to go', () => {
+    expect(sql).toMatch(/ALTER COLUMN owner_id DROP NOT NULL/);
+  });
+
+  it('gives an orphaned base an admin management path', () => {
+    // The old policies were owner-only. Fine while every base had an owner —
+    // a dead end the moment one does not.
+    const upd = sql.slice(sql.indexOf('"flowtable_bases owner update"\n  ON'));
+    const del = sql.slice(sql.indexOf('"flowtable_bases owner delete"\n  ON'));
+    expect(upd.slice(0, upd.indexOf(';'))).toMatch(/owner_id = auth\.uid\(\) OR public\.has_role\(auth\.uid\(\), 'admin'/);
+    expect(del.slice(0, del.indexOf(';'))).toMatch(/owner_id = auth\.uid\(\) OR public\.has_role\(auth\.uid\(\), 'admin'/);
+  });
+});
+
+describe('delete-user actually uses it', () => {
+  it('calls the RPC', () => {
+    expect(fn).toMatch(/admin\.rpc\(\s*"detach_user_references",\s*\{ p_user_id: user_id \}/);
+  });
+
+  it('carries no hardcoded detach list any more', () => {
+    // Two detach mechanisms would mean the list version quietly wins for its
+    // three columns and the dynamic one for the rest — one mechanism, one truth.
+    expect(fn).not.toMatch(/await detach\(/);
+  });
+
+  it('fails the deletion honestly when detach fails', () => {
+    expect(fn).toMatch(/Detach failed: \$\{detachErr\.message\}/);
+  });
+});

--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -76,19 +76,25 @@ serve(async (req: Request) => {
 
     // Detach business references. The rows are business history and are KEPT
     // — the link to the person is what goes. NO ACTION constraints make the
-    // deletion fail otherwise; SET NULL/CASCADE columns handle themselves.
-    const detached: Record<string, number> = {};
-    const detach = async (table: string, column: string) => {
-      const { count } = await admin
-        .from(table)
-        .update({ [column]: null })
-        .eq(column, user_id)
-        .select("*", { count: "exact", head: false });
-      if (count) detached[`${table}.${column}`] = count;
-    };
-    await detach("leads", "assigned_to");
-    await detach("project_tasks", "created_by");
-    await detach("support_escalations", "resolved_by");
+    // deletion fail otherwise.
+    //
+    // Not a hardcoded list. The first version detached exactly the 3 columns
+    // referencing `profiles` — correct for that family, while 27 more NO ACTION
+    // columns referencing `auth.users` directly went unhandled (live case:
+    // contract_versions.created_by=2, projects.created_by=1 on the reviewing
+    // instance's admin — deleting any colleague who had actually worked failed
+    // on an FK error). detach_user_references() walks pg_constraint at
+    // execution time, so a new created_by column can never silently re-open
+    // the gap; NOT NULL columns are reported by name instead of failing
+    // generically. Migration: 20260808290000.
+    const { data: detachedData, error: detachErr } = await admin.rpc(
+      "detach_user_references",
+      { p_user_id: user_id },
+    );
+    if (detachErr) {
+      return json({ error: `Detach failed: ${detachErr.message}` }, 500);
+    }
+    const detached = (detachedData ?? {}) as Record<string, number>;
 
     // Orphan cleanup — these tables have no FK to auth.users, so nothing
     // cascades. Explicit, in dependency order.

--- a/supabase/migrations/20260808290000_detach-user-references.sql
+++ b/supabase/migrations/20260808290000_detach-user-references.sql
@@ -1,0 +1,125 @@
+-- User deletion: one family of references was detached, the other was not.
+--
+-- `delete-user` (defdbe167) detaches exactly the 3 NO ACTION columns that
+-- reference `profiles` — a correct and complete list FOR THAT FAMILY. But there
+-- are two families: 27 more NO ACTION columns reference `auth.users` directly,
+-- and none of them were handled. Live on optic while reviewing: the admin
+-- account holds `contract_versions.created_by = 2` and `projects.created_by= 1`,
+-- so deleting any colleague who has actually worked fails on an FK error.
+-- Deleting a user who never created anything succeeds — which is how the gap
+-- survives testing.
+--
+-- A HARDCODED LIST IS THE WRONG SHAPE for this. The first list was right on the
+-- day it was written and wrong by review time; every new `created_by` column
+-- silently re-opens the gap. So the detach walks pg_constraint at execution
+-- time: every NO ACTION FK pointing at auth.users or profiles, nulled when
+-- nullable, and reported by name when NOT NULL — an honest error beats a
+-- generic FK failure. Today all 27 + 3 are nullable, so the blocker branch is
+-- future-proofing, not a live path.
+--
+-- Authorship columns are NULLED, never reassigned. A contract does not stop
+-- existing because its salesperson left, but it also was not authored by the
+-- admin who pressed delete. History keeps the row and loses the name.
+--
+-- AND THE CASCADE IS DEFUSED. `flowtable_bases.owner_id` was NOT NULL with
+-- ON DELETE CASCADE, which cascades on through tables to fields and records:
+-- deleting optic's admin would have silently destroyed the Produkter base
+-- (3 tables, 24 rows) the whole sales conversation reads from. A base is a
+-- shared workspace artifact that happens to record who created it — the
+-- creator's departure must orphan it, not erase it. SET NULL requires the
+-- column to be nullable, and an ownerless base needs someone able to manage
+-- it, so the owner-only UPDATE/DELETE policies gain the admin path every other
+-- table already has.
+
+-- ── the cascade ────────────────────────────────────────────────────────────
+ALTER TABLE public.flowtable_bases ALTER COLUMN owner_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'flowtable_bases_owner_id_fkey'
+      AND conrelid = 'public.flowtable_bases'::regclass
+      AND confdeltype = 'c'  -- only rewrite if still CASCADE
+  ) THEN
+    ALTER TABLE public.flowtable_bases DROP CONSTRAINT flowtable_bases_owner_id_fkey;
+    ALTER TABLE public.flowtable_bases
+      ADD CONSTRAINT flowtable_bases_owner_id_fkey
+      FOREIGN KEY (owner_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- An orphaned base must be manageable. The old policies were owner-only with
+-- no admin clause at all — fine while every base had an owner, a dead end the
+-- moment one does not.
+DROP POLICY IF EXISTS "flowtable_bases owner update" ON public.flowtable_bases;
+CREATE POLICY "flowtable_bases owner update"
+  ON public.flowtable_bases FOR UPDATE
+  USING (owner_id = auth.uid() OR public.has_role(auth.uid(), 'admin'::public.app_role));
+
+DROP POLICY IF EXISTS "flowtable_bases owner delete" ON public.flowtable_bases;
+CREATE POLICY "flowtable_bases owner delete"
+  ON public.flowtable_bases FOR DELETE
+  USING (owner_id = auth.uid() OR public.has_role(auth.uid(), 'admin'::public.app_role));
+
+-- ── the detach ─────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.detach_user_references(p_user_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  r record;
+  v_count bigint;
+  v_out jsonb := '{}'::jsonb;
+  v_blockers text := '';
+BEGIN
+  -- Service role (the delete-user function) or an admin. Without this guard
+  -- any authenticated user could strip ownership columns platform-wide — the
+  -- function is SECURITY DEFINER. No postgres escape hatch: a superuser
+  -- bypasses RLS anyway, and an extra OR-clause is one more thing a probe
+  -- cannot exercise. (Direct-DB callers: SET LOCAL request.jwt.claims with
+  -- role=service_role, as the rolled-back live test does.)
+  IF NOT (auth.role() = 'service_role'
+          OR public.has_role(auth.uid(), 'admin'::public.app_role)) THEN
+    RAISE EXCEPTION 'detach_user_references: admin or service role required';
+  END IF;
+
+  FOR r IN
+    SELECT c.conrelid::regclass::text AS tbl, a.attname AS col, a.attnotnull AS not_null
+    FROM pg_constraint c
+    JOIN unnest(c.conkey) k(attnum) ON true
+    JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+    JOIN pg_class cl ON cl.oid = c.conrelid
+    WHERE c.contype = 'f'
+      AND c.confdeltype = 'a'          -- NO ACTION: the ones that block
+      AND c.confrelid IN ('auth.users'::regclass, 'public.profiles'::regclass)
+      AND cl.relnamespace = 'public'::regnamespace
+  LOOP
+    IF r.not_null THEN
+      -- Cannot null it; report it by name instead of failing generically.
+      EXECUTE format('SELECT count(*) FROM %s WHERE %I = $1', r.tbl, r.col)
+        USING p_user_id INTO v_count;
+      IF v_count > 0 THEN
+        v_blockers := v_blockers || format('%s.%s (%s rows) ', r.tbl, r.col, v_count);
+      END IF;
+      CONTINUE;
+    END IF;
+
+    EXECUTE format('UPDATE %s SET %I = NULL WHERE %I = $1', r.tbl, r.col, r.col)
+      USING p_user_id;
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    IF v_count > 0 THEN
+      v_out := v_out || jsonb_build_object(r.tbl || '.' || r.col, v_count);
+    END IF;
+  END LOOP;
+
+  IF v_blockers <> '' THEN
+    RAISE EXCEPTION 'User has NOT NULL references that cannot be detached: %. These columns need a schema decision (nullable, or reassignment) before this user can be deleted.', v_blockers;
+  END IF;
+
+  RETURN v_out;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.detach_user_references(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.detach_user_references(uuid) TO authenticated, service_role;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260808280000",
-      "migrations_count": 322,
+      "migration_head": "20260808290000",
+      "migrations_count": 323,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1293,6 +1293,10 @@
         {
           "version": "20260808280000",
           "name": "approver-legacy-to-staff"
+        },
+        {
+          "version": "20260808290000",
+          "name": "detach-user-references"
         }
       ]
     },
@@ -1327,7 +1331,7 @@
         "create-invoice-payment": "sha256:917c78b89d0131f426ed5c6109eea67d8020604def81f1179eba2e5bb0c8bea6",
         "create-user": "sha256:bed454b8a235c1a99baead4133a74618ac2761b221592c346f4fb8f1c6bffc34",
         "customer-signup": "sha256:8f29b9defed8bb8227767e2c0a748739d80d1e182f87e6b19f4b46e485be52d6",
-        "delete-user": "sha256:942a1d859452c372fac7d27d89e2f312524fb01139a90a6bf1c31326e46647d3",
+        "delete-user": "sha256:30ab94347450ac8d1664234057b39861e825e27af98f1688b21dbcb1262d8edb",
         "demo-cycle": "sha256:ae99ce60cbb68aec05a9dfbb9b4bde332ff41cd9d85b6b8f6fcb803cfb8dfaf0",
         "docs-chat": "sha256:8a78fddb7cba24df21044920daaea0ad9798ec970ecdb334d4845124ed7550eb",
         "document-share": "sha256:16c5281eb83fc8409d0b8c2906bb05ee74a7956786497e3eeaa7f2883067dd67",


### PR DESCRIPTION
Started as the FK-map handoff (#163's original content, which a force-push removed from main) — and became the fix, because reviewing local Claude's `delete-user` against the map found a real gap, live.

## One family detached, the other not

`delete-user` (defdbe167) detaches exactly the 3 NO ACTION columns that reference **`profiles`** — a complete list *for that family*. But there are two families:

| references | NO ACTION columns | handled |
|---|---|---|
| `profiles` | 3 | **3** ✅ |
| `auth.users` | **27** | **0** |

Not theoretical. On optic's admin, right now: `contract_versions.created_by = 2`, `projects.created_by = 1`. **Deleting any colleague who has actually worked fails on an FK error** — and deleting a user who never created anything succeeds, which is exactly how the gap survives testing.

## The fix is a catalog walk, not a longer list

A hardcoded list was right on the day it was written and wrong by review time. `detach_user_references()` walks `pg_constraint` at execution time:

- every NO ACTION FK to `auth.users` **or** `profiles` — one mechanism for both families
- nulled when nullable (all 30 are, today)
- **reported by name** when NOT NULL — an honest error instead of a generic FK failure; that error is the prompt for a schema decision, not a bug
- authorship is nulled, never reassigned: history keeps the row and loses the name
- guarded `service_role OR admin`, **no postgres escape hatch** — verified live: sales-role claims are rejected

`delete-user` now calls it instead of the three hardcoded detaches. **Deployed to optic as v2.**

## The cascade is defused

From the wiped FK map, the one CASCADE that was business data:

```
auth.users DELETE → flowtable_bases.owner_id CASCADE → tables → fields + records
```

Deleting optic's admin would have silently destroyed the **Produkter** base (3 tables, 24 rows) the entire sales conversation reads from. Now: `owner_id` nullable + `ON DELETE SET NULL`, and the owner-only UPDATE/DELETE policies gain the admin path — an ownerless base was previously unmanageable by anyone, since the old policies had no admin clause at all.

## Proven end-to-end, in a rolled-back transaction on optic

```
detach → {"projects.created_by":1, "project_tasks.created_by":1, "contract_versions.created_by":2}
DELETE FROM auth.users (the real admin row)
→ both bases survive, ownerless · 25 flowtable rows intact · 3 contracts intact
ROLLBACK → everything restored, verified
```

## Also in here

- **Restores the FK-map handoff** that the force-push removed, updated to post-fix state — including the correction that local's 0/7-leads finding was right and this session's retraction of it was wrong (the `approver` legacy-role root cause).
- **Ownership note deduplicated**: local measured the same columns independently the same evening and converged on the same plan — the handoff now points at their write-up instead of duplicating it.

14 guardrails, negative-tested: removing the RPC call, re-adding the postgres escape, or restoring CASCADE each fails one. Full suite **1680 passed**, `tsc` clean, forward-dating guard passes (`> 20260808280000`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5