### PR TITLE
feat(crm): ownership exists — creator owns, the chip shows it, nothing hides

### DIFF
--- a/src/components/admin/DealKanbanCard.tsx
+++ b/src/components/admin/DealKanbanCard.tsx
@@ -8,6 +8,7 @@ import type { Deal } from '@/hooks/useDeals';
 import { cn } from '@/lib/utils';
 import { NextStepChip } from './crm/NextStepChip';
 import { useOverdueActivityIndex } from '@/hooks/useOverdueActivityIndex';
+import { OwnerChip } from './OwnerChip';
 
 interface DealKanbanCardProps {
   deal: Deal;
@@ -63,14 +64,17 @@ export function DealKanbanCard({ deal }: DealKanbanCardProps) {
               {formatCurrency(deal.value_cents, deal.currency, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
             </p>
           </div>
-          <button
-            type="button"
-            className="cursor-grab active:cursor-grabbing touch-none p-1 -m-1 text-muted-foreground hover:text-foreground shrink-0"
-            aria-label="Drag deal"
-            {...listeners}
-          >
-            <GripVertical className="h-4 w-4" />
-          </button>
+          <div className="flex flex-col items-end gap-1 shrink-0">
+            <button
+              type="button"
+              className="cursor-grab active:cursor-grabbing touch-none p-1 -m-1 text-muted-foreground hover:text-foreground"
+              aria-label="Drag deal"
+              {...listeners}
+            >
+              <GripVertical className="h-4 w-4" />
+            </button>
+            <OwnerChip entity="deals" recordId={deal.id} ownerId={deal.owner_id} compact />
+          </div>
         </div>
 
         {productName && (

--- a/src/components/admin/OwnerChip.tsx
+++ b/src/components/admin/OwnerChip.tsx
@@ -1,0 +1,140 @@
+/**
+ * The owner chip IS the transparency mechanism.
+ *
+ * "Vänstra handen skall kunna se vad den högra gör" — the left hand sees the
+ * right one because every list row SHOWS who owns the record, not because
+ * anything is hidden. A filter conceals; this column informs. It also carries
+ * the whole permanent handover: click the chip, pick a colleague, done — one
+ * write, no admin screen, because salespeople do not do admin.
+ *
+ * Self-contained on purpose: the chip owns its mutation and goes through the
+ * ownership map (src/lib/ownership.ts), so a call site cannot write the wrong
+ * column and the three entities cannot drift apart.
+ */
+import { useState } from 'react';
+import { UserCircle2 } from 'lucide-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { supabase } from '@/integrations/supabase/client';
+import { useTeamProfiles, type TeamProfile } from '@/hooks/useFlowtable';
+import { OWNERSHIP, type OwnedEntity } from '@/lib/ownership';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface OwnerChipProps {
+  entity: OwnedEntity;
+  recordId: string;
+  ownerId: string | null | undefined;
+  /** Compact = initials only (kanban cards); default shows the name. */
+  compact?: boolean;
+  className?: string;
+}
+
+const initials = (p: TeamProfile) =>
+  (p.full_name || p.email)
+    .split(/[\s@.]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((s) => s[0]?.toUpperCase())
+    .join('');
+
+export function OwnerChip({ entity, recordId, ownerId, compact, className }: OwnerChipProps) {
+  const [open, setOpen] = useState(false);
+  const { data: team } = useTeamProfiles();
+  const qc = useQueryClient();
+
+  const owner = team?.find((p) => p.id === ownerId) ?? null;
+
+  const reassign = useMutation({
+    mutationFn: async (newOwner: string | null) => {
+      const { column } = OWNERSHIP[entity];
+      const { error } = await supabase
+        .from(entity as never)
+        .update({ [column]: newOwner } as never)
+        .eq('id', recordId);
+      if (error) throw error;
+    },
+    onSuccess: (_d, newOwner) => {
+      for (const key of OWNERSHIP[entity].invalidate) {
+        qc.invalidateQueries({ queryKey: [key] });
+      }
+      const name = team?.find((p) => p.id === newOwner);
+      toast.success(newOwner ? `Owner: ${name?.full_name || name?.email || 'colleague'}` : 'Owner cleared');
+    },
+    onError: (e: Error) => toast.error(`Could not reassign: ${e.message}`),
+  });
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          // Rows and kanban cards are clickable/draggable — the chip must not
+          // open the record it sits on.
+          onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          title={owner ? `Owner: ${owner.full_name || owner.email}` : 'Unassigned — click to assign'}
+          className={cn(
+            'inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs transition-colors',
+            owner
+              ? 'bg-primary/10 border-primary/30 text-primary hover:bg-primary/20'
+              : 'border-dashed text-muted-foreground hover:bg-muted',
+            className,
+          )}
+        >
+          {owner ? (
+            <>
+              <span className="flex h-4 w-4 items-center justify-center rounded-full bg-primary/20 text-[9px] font-semibold">
+                {initials(owner)}
+              </span>
+              {!compact && <span className="max-w-[110px] truncate">{owner.full_name || owner.email}</span>}
+            </>
+          ) : (
+            <>
+              <UserCircle2 className="h-3.5 w-3.5" />
+              {!compact && <span>Unassigned</span>}
+            </>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56 p-1" align="end" onClick={(e) => e.stopPropagation()}>
+        <div className="max-h-64 overflow-y-auto">
+          {(team ?? []).map((p) => (
+            <Button
+              key={p.id}
+              variant="ghost"
+              size="sm"
+              className={cn('w-full justify-start gap-2 font-normal', p.id === ownerId && 'bg-muted')}
+              disabled={reassign.isPending}
+              onClick={() => {
+                setOpen(false);
+                if (p.id !== ownerId) reassign.mutate(p.id);
+              }}
+            >
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-primary/15 text-[10px] font-semibold">
+                {initials(p)}
+              </span>
+              <span className="truncate">{p.full_name || p.email}</span>
+            </Button>
+          ))}
+          {ownerId && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start gap-2 font-normal text-muted-foreground"
+              disabled={reassign.isPending}
+              onClick={() => {
+                setOpen(false);
+                reassign.mutate(null);
+              }}
+            >
+              <UserCircle2 className="h-4 w-4" />
+              Clear owner
+            </Button>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/lib/__tests__/ownership-on-create.guardrails.test.ts
+++ b/src/lib/__tests__/ownership-on-create.guardrails.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Ownership must exist before any "mine" filter may — and must never become one.
+ *
+ * Measured before building: leads.assigned_to 0/7, deals.owner_id 0/5,
+ * companies.account_owner 0/2. A "my deals" lens on that shows every
+ * salesperson an empty list — a filter that reads as a security feature
+ * working correctly. Step 0 makes ownership exist: creator owns on insert,
+ * backfill from created_by, and an owner chip in every list so the left hand
+ * SEES what the right hand does.
+ *
+ * Proven live on optic in a rolled-back transaction, four directions: a
+ * logged-in salesperson's insert gets their uid; an explicit other owner is
+ * respected; a service-role insert stays NULL (an agent must not guess); and
+ * companies behaves like leads.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { OWNERSHIP } from '@/lib/ownership';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const sql = read('supabase/migrations/20260808300000_ownership-on-create.sql');
+const chip = read('src/components/admin/OwnerChip.tsx');
+
+describe('the trigger assigns, and only when nothing was said', () => {
+  it('fills the owner from auth.uid() per table', () => {
+    expect(sql).toMatch(/IF NEW\.assigned_to IS NULL THEN NEW\.assigned_to := v_uid/);
+    expect(sql).toMatch(/IF NEW\.owner_id IS NULL THEN NEW\.owner_id := v_uid/);
+    expect(sql).toMatch(/IF NEW\.account_owner IS NULL THEN NEW\.account_owner := v_uid/);
+  });
+
+  it('never guesses for the agent path', () => {
+    // Under the service role auth.uid() is NULL. An unowned record is visible
+    // truth; a wrongly-owned one is a lie with an audit trail. Verified live:
+    // a service-role deal insert came back owner_id NULL.
+    expect(sql).toMatch(/IF v_uid IS NULL THEN\s*\n\s*RETURN NEW;/);
+  });
+
+  it('covers all three tables with BEFORE INSERT triggers', () => {
+    for (const t of ['leads_assign_owner', 'deals_assign_owner', 'companies_assign_owner']) {
+      expect(sql).toMatch(new RegExp(`CREATE TRIGGER ${t}\\s+BEFORE INSERT`));
+    }
+  });
+});
+
+describe('the backfill derives, never overwrites', () => {
+  it('only fills NULL owners, from created_by only', () => {
+    expect(sql).toMatch(/SET assigned_to\s*= created_by WHERE assigned_to\s*IS NULL AND created_by IS NOT NULL/);
+    expect(sql).toMatch(/SET owner_id\s*= created_by WHERE owner_id\s*IS NULL AND created_by IS NOT NULL/);
+    expect(sql).toMatch(/SET account_owner = created_by WHERE account_owner IS NULL AND created_by IS NOT NULL/);
+  });
+});
+
+describe('ownership is a lens, never a rule', () => {
+  it('this migration creates no RLS policy', () => {
+    // Odoo wires "my records" into record rules — that is where salespeople
+    // stop seeing each other's pipelines and start calling the same customer
+    // twice. The whole design rests on this line staying out.
+    expect(sql).not.toMatch(/CREATE POLICY/i);
+  });
+
+  it('no migration gates RLS on the CRM ownership columns', () => {
+    // Scoped to policies ON leads/deals/companies. Other tables legitimately
+    // use assignment in WRITE rules (picking_orders: only the assigned picker
+    // updates the order — found by this guard's first, too-broad version). The
+    // CRM lens columns are different: if this test ever fails, the failure IS
+    // the design discussion.
+    const dir = join(process.cwd(), 'supabase/migrations');
+    const onCrm = /ON\s+(?:"?public"?\.)?"?(leads|deals|companies)"?\b/i;
+    for (const f of readdirSync(dir)) {
+      const body = readFileSync(join(dir, f), 'utf-8');
+      for (const m of body.matchAll(/CREATE POLICY[\s\S]{0,600}?;/g)) {
+        if (!onCrm.test(m[0])) continue;
+        expect(m[0], `${f}: CRM policy references an ownership column`).not.toMatch(
+          /\b(assigned_to|owner_id|account_owner)\b/,
+        );
+      }
+    }
+  });
+});
+
+describe('one map, three spellings', () => {
+  it('names the wire columns without renaming them', () => {
+    expect(OWNERSHIP.leads.column).toBe('assigned_to');
+    expect(OWNERSHIP.deals.column).toBe('owner_id');
+    expect(OWNERSHIP.companies.column).toBe('account_owner');
+  });
+
+  it('the chip writes through the map, not a literal column', () => {
+    // A call site that spells its own column is how three entities drift.
+    expect(chip).toMatch(/const \{ column \} = OWNERSHIP\[entity\]/);
+    expect(chip).toMatch(/\.update\(\{ \[column\]: newOwner \}/);
+  });
+});
+
+describe('the chip reaches the database and not the row underneath', () => {
+  it('is wired into all three surfaces', () => {
+    expect(read('src/pages/admin/LeadsPage.tsx')).toMatch(/<OwnerChip entity="leads" recordId=\{lead\.id\} ownerId=\{lead\.assigned_to\}/);
+    expect(read('src/components/admin/DealKanbanCard.tsx')).toMatch(/<OwnerChip entity="deals" recordId=\{deal\.id\} ownerId=\{deal\.owner_id\}/);
+    expect(read('src/pages/admin/CompaniesPage.tsx')).toMatch(/<OwnerChip entity="companies" recordId=\{company\.id\} ownerId=\{company\.account_owner\}/);
+  });
+
+  it('stops propagation, since rows and cards are clickable', () => {
+    // Without this, assigning an owner also opens the record — or starts a
+    // kanban drag.
+    expect(chip).toMatch(/onClick=\{\(e\) => e\.stopPropagation\(\)\}/);
+    expect(chip).toMatch(/onPointerDown=\{\(e\) => e\.stopPropagation\(\)\}/);
+  });
+
+  it('invalidates the entity queries after reassigning', () => {
+    expect(chip).toMatch(/for \(const key of OWNERSHIP\[entity\]\.invalidate\)/);
+  });
+});

--- a/src/lib/ownership.ts
+++ b/src/lib/ownership.ts
@@ -1,0 +1,37 @@
+/**
+ * Ownership lives in ONE map, because it already lives under three names.
+ *
+ * `leads.assigned_to`, `deals.owner_id`, `companies.account_owner` — same idea,
+ * three spellings, all wire identifiers that stay as they are (naming policy:
+ * fix the story, not the wire). Every surface that reads or writes ownership
+ * goes through this map; the alternative is five hooks that each know one
+ * column name and drift apart — the one-of-N-places bug shape this codebase
+ * keeps finding.
+ *
+ * Ownership is a lens and a label, NEVER a security boundary. The "Mina/Alla"
+ * filter applies these columns in queries; RLS must never reference them.
+ * (Odoo wires "my records" into record rules — that is where salespeople stop
+ * seeing each other's pipelines and start calling the same customer twice.)
+ */
+
+export const OWNERSHIP = {
+  leads: {
+    column: 'assigned_to',
+    /** Query keys to invalidate after a reassignment. */
+    invalidate: ['leads', 'lead'],
+  },
+  deals: {
+    column: 'owner_id',
+    invalidate: ['deals', 'deal'],
+  },
+  companies: {
+    column: 'account_owner',
+    invalidate: ['companies', 'company'],
+  },
+} as const;
+
+export type OwnedEntity = keyof typeof OWNERSHIP;
+
+export function ownerColumn(entity: OwnedEntity): string {
+  return OWNERSHIP[entity].column;
+}

--- a/src/pages/admin/CompaniesPage.tsx
+++ b/src/pages/admin/CompaniesPage.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { OwnerChip } from '@/components/admin/OwnerChip';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
@@ -184,6 +185,7 @@ export default function CompaniesPage() {
                   <TableHead>Industry</TableHead>
                   <TableHead>Size</TableHead>
                   <TableHead>Contact</TableHead>
+                  <TableHead>Owner</TableHead>
                   <TableHead>Customer Since</TableHead>
                   <TableHead className="w-[100px]"></TableHead>
                 </TableRow>
@@ -264,6 +266,9 @@ export default function CompaniesPage() {
                           </a>
                         )}
                       </div>
+                    </TableCell>
+                    <TableCell>
+                      <OwnerChip entity="companies" recordId={company.id} ownerId={company.account_owner} />
                     </TableCell>
                     <TableCell className="text-muted-foreground">
                       {company.customer_since

--- a/src/pages/admin/LeadsPage.tsx
+++ b/src/pages/admin/LeadsPage.tsx
@@ -24,6 +24,7 @@ import { LeadKanban } from '@/components/admin/leads/LeadKanban';
 import { BulkLeadEmailDialog } from '@/components/admin/crm/BulkLeadEmailDialog';
 import { SavedViewsMenu } from '@/components/admin/SavedViewsMenu';
 import { useOverdueActivityIndex } from '@/hooks/useOverdueActivityIndex';
+import { OwnerChip } from '@/components/admin/OwnerChip';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
@@ -428,6 +429,7 @@ interface LeadCardProps {
     ai_summary: string | null;
     needs_review: boolean;
     created_at: string;
+    assigned_to?: string | null;
   };
   showStatus?: boolean;
   onClick?: () => void;
@@ -485,6 +487,7 @@ function LeadCard({ lead, showStatus, onClick, selected, onToggleSelect }: LeadC
             )}
           </div>
           <div className="flex flex-col items-end gap-1">
+            <OwnerChip entity="leads" recordId={lead.id} ownerId={lead.assigned_to} compact />
             <Badge variant="outline" className="font-mono">
               {lead.score}p
             </Badge>

--- a/supabase/migrations/20260808300000_ownership-on-create.sql
+++ b/supabase/migrations/20260808300000_ownership-on-create.sql
@@ -1,0 +1,82 @@
+-- An owner nobody set is a lens nobody can use.
+--
+-- The "Mina/Alla" plan (see the ownership-scoping section in
+-- docs/operators/session-memory.md — both sessions measured and converged
+-- independently) starts from a hard fact: the ownership columns exist and are
+-- EMPTY. leads.assigned_to 0/7, deals.owner_id 0/5, companies.account_owner
+-- 0/2 at measurement. A "my deals" filter built on that shows every
+-- salesperson an empty list — a filter that reads as a security feature
+-- working correctly, which is the worst failure shape this codebase knows.
+--
+-- Step 0, deliberately WITHOUT any filter: make ownership exist.
+--
+--   1. Whoever creates a record owns it, unless they said otherwise. A BEFORE
+--      INSERT trigger fills the owner column from auth.uid() ONLY when the
+--      caller left it NULL — an explicit owner is never overwritten (the
+--      trigger-fills-only-NULL precedent from contracts_assign_number).
+--   2. The agent path stays honest: under the service role auth.uid() is
+--      NULL, and the trigger then leaves the owner NULL rather than guessing.
+--      An unowned record is visible truth; a wrongly-owned one is a lie with
+--      an audit trail.
+--   3. Backfill from created_by where an owner is missing — the best guess
+--      that exists, and a traceable one. Never over an existing owner. (On the
+--      instance this was written against, created_by is itself NULL
+--      everywhere — the delete-user detach tests nulled it — so the backfill
+--      is a no-op there and meaningful on the rest of the fleet.)
+--
+-- WHAT THIS MIGRATION MUST NEVER GROW: an RLS policy. Ownership here is a
+-- lens and a label — Odoo's mistake is wiring "my records" into record rules,
+-- which is where salespeople stop seeing each other's pipelines and start
+-- calling the same customer twice. Visibility stays a security decision;
+-- "mine" stays a query filter. The guardrail suite enforces this.
+
+CREATE OR REPLACE FUNCTION public.assign_owner_on_insert()
+RETURNS trigger
+LANGUAGE plpgsql SET search_path TO 'public'
+AS $$
+DECLARE v_uid uuid := auth.uid();
+BEGIN
+  -- Service role / direct DB: no user, no guess.
+  IF v_uid IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_TABLE_NAME = 'leads' THEN
+    IF NEW.assigned_to IS NULL THEN NEW.assigned_to := v_uid; END IF;
+  ELSIF TG_TABLE_NAME = 'deals' THEN
+    IF NEW.owner_id IS NULL THEN NEW.owner_id := v_uid; END IF;
+  ELSIF TG_TABLE_NAME = 'companies' THEN
+    IF NEW.account_owner IS NULL THEN NEW.account_owner := v_uid; END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS leads_assign_owner ON public.leads;
+CREATE TRIGGER leads_assign_owner
+  BEFORE INSERT ON public.leads
+  FOR EACH ROW EXECUTE FUNCTION public.assign_owner_on_insert();
+
+DROP TRIGGER IF EXISTS deals_assign_owner ON public.deals;
+CREATE TRIGGER deals_assign_owner
+  BEFORE INSERT ON public.deals
+  FOR EACH ROW EXECUTE FUNCTION public.assign_owner_on_insert();
+
+DROP TRIGGER IF EXISTS companies_assign_owner ON public.companies;
+CREATE TRIGGER companies_assign_owner
+  BEFORE INSERT ON public.companies
+  FOR EACH ROW EXECUTE FUNCTION public.assign_owner_on_insert();
+
+-- Backfill: creator as owner, only where no owner exists. Idempotent — a
+-- second run finds nothing to do.
+UPDATE public.leads     SET assigned_to  = created_by WHERE assigned_to  IS NULL AND created_by IS NOT NULL;
+UPDATE public.deals     SET owner_id     = created_by WHERE owner_id     IS NULL AND created_by IS NOT NULL;
+UPDATE public.companies SET account_owner = created_by WHERE account_owner IS NULL AND created_by IS NOT NULL;
+
+COMMENT ON COLUMN public.leads.assigned_to IS
+  'Owner (profiles/auth uid). Auto-set to the creator on insert when not supplied; NULL when created by an agent/service path. A lens and a label — never referenced by RLS.';
+COMMENT ON COLUMN public.deals.owner_id IS
+  'Owner (profiles/auth uid). Auto-set to the creator on insert when not supplied; NULL when created by an agent/service path. A lens and a label — never referenced by RLS.';
+COMMENT ON COLUMN public.companies.account_owner IS
+  'Account owner (profiles/auth uid). Auto-set to the creator on insert when not supplied; NULL when created by an agent/service path. A lens and a label — never referenced by RLS.';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260808290000",
-      "migrations_count": 323,
+      "migration_head": "20260808300000",
+      "migrations_count": 324,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1297,6 +1297,10 @@
         {
           "version": "20260808290000",
           "name": "detach-user-references"
+        },
+        {
+          "version": "20260808300000",
+          "name": "ownership-on-create"
         }
       ]
     },


### PR DESCRIPTION
Step 0 of the Mina/Alla plan — the one both sessions measured and converged on independently. Built now that the role sweep is done.

## The problem it solves

`leads.assigned_to` **0/7**, `deals.owner_id` **0/5**, `companies.account_owner` **0/2**. The columns existed; nothing filled them. A "my deals" filter on that shows every salesperson an empty list — a filter that reads as a security feature working correctly, the worst failure shape this codebase knows. So step 0 makes ownership *exist*, deliberately **without building any filter**.

## What ships

**Creator owns, unless they said otherwise.** A BEFORE INSERT trigger on leads/deals/companies fills the owner from `auth.uid()` only when NULL — an explicit owner is never overwritten (the `contracts_assign_number` precedent).

**The agent path never guesses.** Under the service role `auth.uid()` is NULL, and the owner stays NULL. An unowned record is visible truth; a wrongly-owned one is a lie with an audit trail.

**Backfill from `created_by`**, only where no owner exists. A no-op on optic — the delete-user detach tests nulled `created_by` — and meaningful on the rest of the fleet.

**One map, three spellings.** `assigned_to` / `owner_id` / `account_owner` are wire identifiers that stay (naming policy). `src/lib/ownership.ts` is the single place that knows which column belongs to which entity, and `OwnerChip` writes through it — a call site cannot spell the wrong column.

**The chip is the transparency mechanism.** Lead cards, deal kanban cards, the companies table — every row shows who owns it. *Vänstra handen ser den högra* because the column is visible, not because anything is hidden. Reassignment — the whole permanent handover — is click-chip-pick-colleague. No admin screen, because salespeople do not do admin.

## Never in RLS

Odoo wires "my records" into record rules; that is where salespeople stop seeing each other's pipelines and start calling the same customer twice. A guardrail walks **every migration** and fails if a policy on leads/deals/companies ever references an ownership column. (Its first version was too broad and tripped on `picking_orders`, where only-the-assigned-picker-updates is a legitimate *write* rule on a different table — now scoped, and the false positive is documented in the test.)

## Proven live on optic, rolled back

| direction | result |
|---|---|
| logged-in salesperson inserts, no owner given | owns it |
| explicit other owner supplied | respected, not overwritten |
| service-role (agent) insert | owner stays NULL |
| companies | same as leads |

Migration applied to optic **and ledger-recorded** (the Management-API lesson from the fleet handoff).

11 guardrails, negative-tested — removing the agent guard, letting the backfill overwrite, putting the lens in RLS, or writing a literal column each fails one. Full suite **1694 passed**, `tsc` clean, forward-dating guard passes.

Next steps (not in this PR): inheritance lead→deal→quote, the Mina/Alla toggle in `profiles.preferences`, and the time-boxed coverage delegation that beats both HubSpot and Odoo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_