### PR TITLE
feat(crm): ownership flows down the chain — lead to deal to quote, decided once

### DIFF
--- a/src/hooks/useQuotes.ts
+++ b/src/hooks/useQuotes.ts
@@ -30,6 +30,7 @@ export interface Quote {
   accepted_at: string | null;
   rejected_at: string | null;
   created_by: string | null;
+  owner_id?: string | null;
   created_at: string;
   updated_at: string;
   leads: InvoiceLead | null;

--- a/src/lib/__tests__/ownership-inheritance.guardrails.test.ts
+++ b/src/lib/__tests__/ownership-inheritance.guardrails.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Ownership flows down the chain, so nobody sets it twice.
+ *
+ * Step 1 on top of 20260808300000: a salesperson owns the lead, the deal on
+ * that lead is theirs, the quote on that deal is theirs. One decision, at the
+ * top. Two rules carry the design:
+ *
+ *   - Inheritance OUTRANKS the creator. An admin creating a deal on Anna's
+ *     lead hands it to Anna, not to themselves.
+ *   - Inheritance applies on the agent path. "Never guess" (step 0) means the
+ *     creator-fallback stays off under the service role — but the lead's owner
+ *     is a human decision already made, and inheriting it is not guessing.
+ *
+ * Proven live on optic, six directions in a rolled-back transaction: agent
+ * deal on an owned lead inherits; admin deal on Anna's lead goes to Anna;
+ * agent deal on an unowned lead stays NULL; quote inherits via deal, via
+ * lead, and stays NULL with neither.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { OWNERSHIP } from '@/lib/ownership';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const sql = read('supabase/migrations/20260808310000_ownership-inheritance.sql');
+
+describe('the priority order is explicit > inherited > creator > null', () => {
+  it('deals inherit from their lead before falling back to the creator', () => {
+    const deals = sql.slice(sql.indexOf("TG_TABLE_NAME = 'deals'"), sql.indexOf("TG_TABLE_NAME = 'quotes'"));
+    const inherit = deals.indexOf('SELECT assigned_to INTO NEW.owner_id');
+    const creator = deals.indexOf('NEW.owner_id := v_uid');
+    expect(inherit).toBeGreaterThan(-1);
+    expect(creator).toBeGreaterThan(inherit);
+  });
+
+  it('quotes try the deal first, then the lead, then the creator', () => {
+    const quotes = sql.slice(sql.indexOf("TG_TABLE_NAME = 'quotes'"));
+    const viaDeal = quotes.indexOf('SELECT owner_id INTO NEW.owner_id FROM public.deals');
+    const viaLead = quotes.indexOf('SELECT assigned_to INTO NEW.owner_id FROM public.leads');
+    const creator = quotes.indexOf('NEW.owner_id := v_uid');
+    expect(viaDeal).toBeGreaterThan(-1);
+    expect(viaLead).toBeGreaterThan(viaDeal);
+    expect(creator).toBeGreaterThan(viaLead);
+  });
+
+  it('inheritance runs unconditionally; only the creator-fallback checks v_uid', () => {
+    // The step-0 shape was an early `IF v_uid IS NULL THEN RETURN NEW` — under
+    // that, an agent-created deal on Anna's lead would stay unowned. Inheriting
+    // a human decision is not guessing.
+    expect(sql).not.toMatch(/IF v_uid IS NULL THEN\s*\n\s*RETURN NEW/);
+    expect(sql).toMatch(/IF NEW\.owner_id IS NULL AND v_uid IS NOT NULL THEN/);
+  });
+});
+
+describe('quotes joins the ownership family properly', () => {
+  it('gets a real column with SET NULL, not a join-time derivation', () => {
+    // SET NULL puts it in the family delete-user handles automatically —
+    // the NO ACTION families are the ones that block (see 20260808290000).
+    expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS owner_id uuid REFERENCES auth\.users\(id\) ON DELETE SET NULL/);
+  });
+
+  it('gets its trigger', () => {
+    expect(sql).toMatch(/CREATE TRIGGER quotes_assign_owner\s+BEFORE INSERT ON public\.quotes/);
+  });
+
+  it('is in the ownership map, so the chip cannot spell the wrong column', () => {
+    expect(OWNERSHIP.quotes.column).toBe('owner_id');
+  });
+
+  it('shows the owner in the quotes list', () => {
+    expect(read('src/pages/admin/QuotesPage.tsx')).toMatch(
+      /<OwnerChip entity="quotes" recordId=\{q\.id\} ownerId=\{q\.owner_id\}/,
+    );
+  });
+
+  it('declares the field on the Quote type', () => {
+    expect(read('src/hooks/useQuotes.ts')).toMatch(/owner_id\?: string \| null;/);
+  });
+});
+
+describe('the backfill flows downhill and never overwrites', () => {
+  it('fills deals from leads before quotes from deals', () => {
+    const dealsAt = sql.indexOf('UPDATE public.deals d SET owner_id = l.assigned_to');
+    const quotesAt = sql.indexOf('UPDATE public.quotes q SET owner_id = d.owner_id');
+    expect(dealsAt).toBeGreaterThan(-1);
+    expect(quotesAt).toBeGreaterThan(dealsAt);
+  });
+
+  it('every backfill is guarded on the owner being NULL', () => {
+    for (const m of sql.matchAll(/UPDATE public\.(deals|quotes)[\s\S]{0,200}?;/g)) {
+      expect(m[0]).toMatch(/owner_id IS NULL/);
+    }
+  });
+});
+
+describe('still a lens, still not a rule', () => {
+  it('creates no RLS policy', () => {
+    expect(sql).not.toMatch(/CREATE POLICY/i);
+  });
+});

--- a/src/lib/ownership.ts
+++ b/src/lib/ownership.ts
@@ -28,6 +28,10 @@ export const OWNERSHIP = {
     column: 'account_owner',
     invalidate: ['companies', 'company'],
   },
+  quotes: {
+    column: 'owner_id',
+    invalidate: ['quotes', 'quote'],
+  },
 } as const;
 
 export type OwnedEntity = keyof typeof OWNERSHIP;

--- a/src/pages/admin/QuotesPage.tsx
+++ b/src/pages/admin/QuotesPage.tsx
@@ -10,6 +10,7 @@ import { QuoteProcessSettingsDialog } from '@/components/admin/quotes/QuoteProce
 import { useQuotes, getQuoteCustomerName, getQuoteCustomerEmail, getQuoteCompanyName, type QuoteStatus } from '@/hooks/useQuotes';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { OwnerChip } from '@/components/admin/OwnerChip';
 import { QuoteDetailSheet } from '@/components/admin/quotes/QuoteDetailSheet';
 import { CreateQuoteDialog } from '@/components/admin/quotes/CreateQuoteDialog';
 import { RecurringQuotesTab } from '@/components/admin/quotes/RecurringQuotesTab';
@@ -95,6 +96,7 @@ export default function QuotesPage() {
                 <TableHead>Number</TableHead>
                 <TableHead>Customer</TableHead>
                 <TableHead>Status</TableHead>
+                <TableHead>Owner</TableHead>
                 <TableHead className="text-right">Total</TableHead>
                 <TableHead>Valid Until</TableHead>
                 <TableHead>Created</TableHead>
@@ -103,13 +105,13 @@ export default function QuotesPage() {
             <TableBody>
               {isLoading ? (
                 <TableRow>
-                  <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                  <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
                     Loading…
                   </TableCell>
                 </TableRow>
               ) : quotes.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                  <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
                     No quotes yet
                   </TableCell>
                 </TableRow>
@@ -134,6 +136,9 @@ export default function QuotesPage() {
                         <Badge variant="secondary" className={STATUS_COLORS[q.status]}>
                           {q.status}
                         </Badge>
+                      </TableCell>
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <OwnerChip entity="quotes" recordId={q.id} ownerId={q.owner_id} />
                       </TableCell>
                       <TableCell className="text-right font-mono">
                         {formatCurrency(q.total_cents, q.currency)}

--- a/supabase/migrations/20260808310000_ownership-inheritance.sql
+++ b/supabase/migrations/20260808310000_ownership-inheritance.sql
@@ -1,0 +1,98 @@
+-- Ownership flows down the chain, so nobody sets it twice.
+--
+-- Step 1 of the Mina/Alla plan (step 0: 20260808300000). The chain
+-- lead→deal→quote is real now — deals carry lead_id, quotes carry deal_id and
+-- lead_id, contracts carry quote_id — so the owner can be DERIVED instead of
+-- asked for. A salesperson owns the lead; the deal on that lead is theirs; the
+-- quote on that deal is theirs. One decision, made once, at the top.
+--
+-- THE INHERITANCE RULE OUTRANKS THE CREATOR RULE, deliberately. When an admin
+-- (or FlowPilot) creates a deal on Anna's lead, the deal is Anna's — the
+-- relationship owner's, not the typist's. HubSpot defaults to the typist and
+-- hides inheritance behind a setting; Odoo carries the salesperson from lead
+-- to opportunity but not beyond. We carry it the whole way.
+--
+-- AND INHERITANCE APPLIES ON THE AGENT PATH TOO. Step 0's rule was "the agent
+-- never GUESSES" — auth.uid() is NULL under the service role, so the
+-- creator-fallback stays off. But inheriting is not guessing: the lead's owner
+-- is a human decision already made. An agent creating a deal on Anna's lead
+-- now correctly hands it to Anna; an agent creating an orphan deal still
+-- leaves it unowned.
+--
+-- quotes gets an owner column of its own rather than a join-time derivation:
+-- a quote can outlive its deal link (ON DELETE SET NULL), the Mina lens needs
+-- one indexed column to filter on, and ownership must be REASSIGNABLE per
+-- quote without touching the deal. ON DELETE SET NULL puts it in the family
+-- delete-user already handles automatically.
+
+ALTER TABLE public.quotes
+  ADD COLUMN IF NOT EXISTS owner_id uuid REFERENCES auth.users(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.quotes.owner_id IS
+  'Owner (profiles/auth uid). Inherited on insert: explicit > deal owner > lead owner > creator; NULL on an agent-created quote with no owned origin. A lens and a label — never referenced by RLS.';
+
+-- One function, one priority order per table. CREATE OR REPLACE swaps the
+-- step-0 body in place; the triggers from 20260808300000 keep pointing here.
+CREATE OR REPLACE FUNCTION public.assign_owner_on_insert()
+RETURNS trigger
+LANGUAGE plpgsql SET search_path TO 'public'
+AS $$
+DECLARE v_uid uuid := auth.uid();
+BEGIN
+  IF TG_TABLE_NAME = 'leads' THEN
+    IF NEW.assigned_to IS NULL AND v_uid IS NOT NULL THEN
+      NEW.assigned_to := v_uid;
+    END IF;
+
+  ELSIF TG_TABLE_NAME = 'companies' THEN
+    IF NEW.account_owner IS NULL AND v_uid IS NOT NULL THEN
+      NEW.account_owner := v_uid;
+    END IF;
+
+  ELSIF TG_TABLE_NAME = 'deals' THEN
+    -- explicit > lead's owner > creator > NULL
+    IF NEW.owner_id IS NULL AND NEW.lead_id IS NOT NULL THEN
+      SELECT assigned_to INTO NEW.owner_id FROM public.leads WHERE id = NEW.lead_id;
+    END IF;
+    IF NEW.owner_id IS NULL AND v_uid IS NOT NULL THEN
+      NEW.owner_id := v_uid;
+    END IF;
+
+  ELSIF TG_TABLE_NAME = 'quotes' THEN
+    -- explicit > deal's owner > lead's owner > creator > NULL
+    IF NEW.owner_id IS NULL AND NEW.deal_id IS NOT NULL THEN
+      SELECT owner_id INTO NEW.owner_id FROM public.deals WHERE id = NEW.deal_id;
+    END IF;
+    IF NEW.owner_id IS NULL AND NEW.lead_id IS NOT NULL THEN
+      SELECT assigned_to INTO NEW.owner_id FROM public.leads WHERE id = NEW.lead_id;
+    END IF;
+    IF NEW.owner_id IS NULL AND v_uid IS NOT NULL THEN
+      NEW.owner_id := v_uid;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS quotes_assign_owner ON public.quotes;
+CREATE TRIGGER quotes_assign_owner
+  BEFORE INSERT ON public.quotes
+  FOR EACH ROW EXECUTE FUNCTION public.assign_owner_on_insert();
+
+-- Backfill down the chain, never over an existing owner. Order matters: deals
+-- first (from their leads), then quotes (from the freshly-filled deals).
+UPDATE public.deals d SET owner_id = l.assigned_to
+  FROM public.leads l
+  WHERE d.owner_id IS NULL AND d.lead_id = l.id AND l.assigned_to IS NOT NULL;
+
+UPDATE public.quotes q SET owner_id = d.owner_id
+  FROM public.deals d
+  WHERE q.owner_id IS NULL AND q.deal_id = d.id AND d.owner_id IS NOT NULL;
+
+UPDATE public.quotes q SET owner_id = l.assigned_to
+  FROM public.leads l
+  WHERE q.owner_id IS NULL AND q.lead_id = l.id AND l.assigned_to IS NOT NULL;
+
+UPDATE public.quotes SET owner_id = created_by
+  WHERE owner_id IS NULL AND created_by IS NOT NULL;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260808300000",
-      "migrations_count": 324,
+      "migration_head": "20260808310000",
+      "migrations_count": 325,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1301,6 +1301,10 @@
         {
           "version": "20260808300000",
           "name": "ownership-on-create"
+        },
+        {
+          "version": "20260808310000",
+          "name": "ownership-inheritance"
         }
       ]
     },


### PR DESCRIPTION
Step 1 on top of #166. The chain lead→deal→quote is real now — deals carry `lead_id`, quotes carry `deal_id` and `lead_id` — so the owner is **derived instead of asked for**. A salesperson owns the lead; the deal on that lead is theirs; the quote on that deal is theirs. One decision, made once, at the top. No double administration, because there is no second entry.

## Two rules carry the design

**Inheritance outranks the creator.** An admin — or FlowPilot — creating a deal on Anna's lead hands it to *Anna*, the relationship owner, not the typist. HubSpot defaults to the typist and hides inheritance behind a setting; Odoo carries the salesperson from lead to opportunity but not beyond. We carry it the whole way.

**Inheritance applies on the agent path.** Step 0's rule was "the agent never *guesses*" — the creator-fallback stays off under the service role. But the lead's owner is a human decision already made, and inheriting it is not guessing. An agent creating a deal on Anna's lead now correctly hands it to Anna; an agent creating an orphan deal still leaves it unowned.

Priority per table:

| table | order |
|---|---|
| deals | explicit → lead's owner → creator → NULL |
| quotes | explicit → deal's owner → lead's owner → creator → NULL |

## quotes joins the family properly

A real `owner_id` column (`ON DELETE SET NULL` — the family `delete-user` already handles automatically), not a join-time derivation: a quote can outlive its deal link, the Mina lens needs one indexed column, and ownership must be reassignable per quote without touching the deal. The quotes list gets the chip; `src/lib/ownership.ts` gains its fourth entry.

## Backfill flows downhill

Deals from leads first, then quotes from the freshly-filled deals, then from leads, then `created_by` — every step guarded on the owner being NULL, so nothing is ever overwritten.

## Proven live on optic, rolled back

| direction | result |
|---|---|
| agent deal on Anna's lead | **Anna owns it** (inheritance ≠ guessing) |
| admin deal on Anna's lead | **Anna**, not the admin |
| agent deal on an unowned lead | NULL |
| quote on that deal | Anna, via the deal |
| quote with only `lead_id` | Anna, via the lead |
| agent quote with no links | NULL |

Migration applied **and ledger-recorded** on optic.

11 guardrails, negative-tested: swapping creator ahead of inheritance, restoring step 0's early return, or dropping a backfill NULL-guard each fails one. Full suite **1705 passed**, `tsc` clean, forward-dating guard passes.

Remaining from the plan: the Mina/Alla toggle (`profiles.preferences`) and the time-boxed coverage delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_