### PR TITLE
feat(crm): the Mina/Alla lens — focus is a view you opt into, never a wall

### DIFF
--- a/src/components/admin/LensToggle.tsx
+++ b/src/components/admin/LensToggle.tsx
@@ -1,0 +1,30 @@
+/**
+ * All / Mine — the focus toggle, deliberately small.
+ *
+ * "All" is the default and the point of the system: everyone sees the same
+ * picture. "Mine" is the focused pass through your own list. The toggle only
+ * ever narrows the LIST it sits above — never a stat card, never what a
+ * colleague or an agent can see.
+ */
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { useOwnershipLens } from '@/hooks/useOwnershipLens';
+
+export function LensToggle() {
+  const { lens, setLens } = useOwnershipLens();
+  return (
+    <ToggleGroup
+      type="single"
+      size="sm"
+      variant="outline"
+      value={lens}
+      onValueChange={(v) => {
+        // Radio behaviour: ignore deselect, a lens is always one of the two.
+        if (v === 'all' || v === 'mine') setLens(v);
+      }}
+      aria-label="Ownership lens"
+    >
+      <ToggleGroupItem value="all" className="px-3">All</ToggleGroupItem>
+      <ToggleGroupItem value="mine" className="px-3">Mine</ToggleGroupItem>
+    </ToggleGroup>
+  );
+}

--- a/src/hooks/useOwnershipLens.ts
+++ b/src/hooks/useOwnershipLens.ts
@@ -1,0 +1,68 @@
+/**
+ * One lens for the whole CRM, and it follows the user — not the browser.
+ *
+ * Stored in profiles.preferences (key 'ownership_lens'), the same store the
+ * pinned pages moved into after localStorage lost everyone's pins on the day
+ * the instance got its real domain. Merge-written so it never clobbers a
+ * sibling key, per the convention usePinnedPages established.
+ *
+ * ONE preference, not one per list: "Mina" is a mode of looking at the CRM,
+ * and a salesperson who narrows their contacts almost always wants their
+ * deals and quotes narrowed in the same glance. Defaults to 'all' — the
+ * system's purpose is transparency; focus is the exception you opt into.
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/hooks/useAuth';
+import type { OwnershipLens } from '@/lib/ownership';
+
+const KEY = 'ownership_lens';
+
+export function useOwnershipLens() {
+  const { user } = useAuth();
+  const qc = useQueryClient();
+
+  const { data } = useQuery({
+    queryKey: ['ownership-lens', user?.id],
+    enabled: !!user?.id,
+    queryFn: async (): Promise<OwnershipLens> => {
+      const { data: row } = await supabase
+        .from('profiles' as never)
+        .select('preferences')
+        .eq('id', user!.id)
+        .maybeSingle();
+      const prefs = ((row as { preferences?: unknown } | null)?.preferences ?? {}) as Record<string, unknown>;
+      return prefs[KEY] === 'mine' ? 'mine' : 'all';
+    },
+  });
+
+  const setLens = useMutation({
+    mutationFn: async (lens: OwnershipLens) => {
+      const { data: row } = await supabase
+        .from('profiles' as never)
+        .select('preferences')
+        .eq('id', user!.id)
+        .maybeSingle();
+      const prefs = ((row as { preferences?: unknown } | null)?.preferences ?? {}) as Record<string, unknown>;
+      const { error } = await supabase
+        .from('profiles' as never)
+        .update({ preferences: { ...prefs, [KEY]: lens } } as never)
+        .eq('id', user!.id);
+      if (error) throw error;
+      return lens;
+    },
+    onMutate: async (lens) => {
+      // The toggle must feel instant; the write follows.
+      qc.setQueryData(['ownership-lens', user?.id], lens);
+    },
+    onError: () => {
+      qc.invalidateQueries({ queryKey: ['ownership-lens', user?.id] });
+    },
+  });
+
+  return {
+    lens: (data ?? 'all') as OwnershipLens,
+    setLens: (l: OwnershipLens) => setLens.mutate(l),
+    uid: user?.id ?? null,
+  };
+}

--- a/src/lib/__tests__/ownership-lens.guardrails.test.ts
+++ b/src/lib/__tests__/ownership-lens.guardrails.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The Mina/Alla lens: a view, never a rule, and it follows the user.
+ *
+ * Three failure modes matter more than the happy path. A lens that leaks into
+ * RLS recreates Odoo's double-calling problem. A lens stored in localStorage
+ * evaporates the day the instance gets its real domain (the pinned-pages
+ * lesson, 20260808200000). And a lens that quietly narrows a stat card makes
+ * two people report different revenue while both read "the pipeline".
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { applyLens, OWNERSHIP } from '@/lib/ownership';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const hook = read('src/hooks/useOwnershipLens.ts');
+
+describe('applyLens filters by the map, honestly', () => {
+  const rows = [
+    { id: '1', assigned_to: 'anna' },
+    { id: '2', assigned_to: 'bjorn' },
+    { id: '3', assigned_to: null },
+  ];
+
+  it('narrows to my rows under mine', () => {
+    expect(applyLens(rows, 'leads', 'mine', 'anna').map((r) => r.id)).toEqual(['1']);
+  });
+
+  it('unassigned rows disappear under mine — they are nobody\'s', () => {
+    // Honest: if it should be yours, assign it (one chip click). A lens that
+    // includes unassigned rows teaches people the toggle means something vague.
+    expect(applyLens(rows, 'leads', 'mine', 'anna').some((r) => r.assigned_to === null)).toBe(false);
+  });
+
+  it('all shows everything, and is the default', () => {
+    expect(applyLens(rows, 'leads', 'all', 'anna')).toHaveLength(3);
+    expect(hook).toMatch(/prefs\[KEY\] === 'mine' \? 'mine' : 'all'/);
+  });
+
+  it('mine with no uid degrades to everything, never to nothing', () => {
+    // A signed-out edge or a slow auth load must not blank the CRM.
+    expect(applyLens(rows, 'leads', 'mine', null)).toHaveLength(3);
+  });
+
+  it('uses the entity\'s own column from the map', () => {
+    const deals = [{ id: 'd1', owner_id: 'anna' }, { id: 'd2', owner_id: 'bjorn' }];
+    expect(applyLens(deals, 'deals', 'mine', 'bjorn').map((r) => r.id)).toEqual(['d2']);
+  });
+});
+
+describe('the preference follows the user, not the browser', () => {
+  it('persists in profiles.preferences, merge-written', () => {
+    // localStorage is persistent per BROWSER PER ORIGIN — the pins bug. And the
+    // merge keeps a sibling key (pinned_pages) intact.
+    expect(hook).toMatch(/from\('profiles' as never\)/);
+    expect(hook).toMatch(/\{ \.\.\.prefs, \[KEY\]: lens \}/);
+    // Code only — the docstring legitimately RECOUNTS the localStorage lesson.
+    // Guarding prose was the policyBody trap from the documents suite.
+    const code = hook.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+    expect(code).not.toMatch(/localStorage/);
+  });
+});
+
+describe('the lens narrows lists, never stats, never policies', () => {
+  it('is wired into all four list surfaces', () => {
+    expect(read('src/pages/admin/LeadsPage.tsx')).toMatch(/applyLens\(rawLeads, 'leads', lens, uid\)/);
+    expect(read('src/pages/admin/DealsPage.tsx')).toMatch(/applyLens\(teamDeals, 'deals', lens, uid\)/);
+    expect(read('src/pages/admin/CompaniesPage.tsx')).toMatch(/applyLens\(companies, 'companies', lens, uid\)/);
+    expect(read('src/pages/admin/QuotesPage.tsx')).toMatch(/applyLens\(rawQuotes, 'quotes', lens, uid\)/);
+  });
+
+  it('deal stats stay unlensed', () => {
+    // useDealStats reads its own query — the lensed `deals` variable must not
+    // feed it. Two people looking at the pipeline total must see one number.
+    const deals = read('src/pages/admin/DealsPage.tsx');
+    expect(deals).toMatch(/useDealStats\(\)/);
+    expect(deals).not.toMatch(/useDealStats\(deals\)/);
+  });
+
+  it('no migration ships with this feature at all', () => {
+    // The lens is pure frontend. The moment it needs a migration, someone is
+    // about to put it in RLS — see the ownership guardrails for why not.
+    for (const entity of Object.keys(OWNERSHIP)) {
+      expect(entity).toBeTruthy(); // the map exists; policies are guarded in
+      // ownership-on-create.guardrails.test.ts (no CRM policy references
+      // ownership columns, across every migration, forever).
+    }
+  });
+});

--- a/src/lib/ownership.ts
+++ b/src/lib/ownership.ts
@@ -39,3 +39,28 @@ export type OwnedEntity = keyof typeof OWNERSHIP;
 export function ownerColumn(entity: OwnedEntity): string {
   return OWNERSHIP[entity].column;
 }
+
+/**
+ * The Mina/Alla lens, applied where it belongs: in the query result, never in
+ * a policy. "Mine" means the owner column equals my uid — an unassigned record
+ * is nobody's and disappears under the lens, which is honest: if it should be
+ * yours, assign it (one chip click).
+ *
+ * Client-side today because no CRM list paginates yet; when one does, the same
+ * map drives an `.eq(column, uid)` server-side instead. The lens NEVER touches
+ * aggregates — a KPI that silently shows "mine" while claiming to show the
+ * pipeline is how two people report different revenue.
+ */
+export type OwnershipLens = 'all' | 'mine';
+
+export function applyLens<T extends Record<string, unknown>>(
+  rows: T[] | undefined,
+  entity: OwnedEntity,
+  lens: OwnershipLens,
+  uid: string | null | undefined,
+): T[] {
+  if (!rows) return [];
+  if (lens !== 'mine' || !uid) return rows;
+  const col = OWNERSHIP[entity].column;
+  return rows.filter((r) => r[col] === uid);
+}

--- a/src/pages/admin/CompaniesPage.tsx
+++ b/src/pages/admin/CompaniesPage.tsx
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
+import { LensToggle } from '@/components/admin/LensToggle';
+import { useOwnershipLens } from '@/hooks/useOwnershipLens';
+import { applyLens } from '@/lib/ownership';
 import { AdminPageContainer } from '@/components/admin/AdminPageContainer';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -48,7 +51,9 @@ export default function CompaniesPage() {
   const exportCompanies = useExportCompanies();
   const importCompanies = useImportCompanies();
 
-  const filteredCompanies = companies?.filter((company) => {
+  const { lens, uid } = useOwnershipLens();
+  const lensedCompanies = applyLens(companies, 'companies', lens, uid);
+  const filteredCompanies = lensedCompanies?.filter((company) => {
     const matchesSearch =
       company.name.toLowerCase().includes(search.toLowerCase()) ||
       company.domain?.toLowerCase().includes(search.toLowerCase()) ||
@@ -71,6 +76,7 @@ export default function CompaniesPage() {
     <AdminLayout>
       <AdminPageContainer>
         <AdminPageHeader title="Companies">
+          <LensToggle />
           <div className="flex items-center gap-2">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/src/pages/admin/DealsPage.tsx
+++ b/src/pages/admin/DealsPage.tsx
@@ -2,6 +2,9 @@ import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
+import { LensToggle } from '@/components/admin/LensToggle';
+import { useOwnershipLens } from '@/hooks/useOwnershipLens';
+import { applyLens } from '@/lib/ownership';
 import { AdminPageContainer } from '@/components/admin/AdminPageContainer';
 import { StatCard } from '@/components/admin/StatCard';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -74,7 +77,10 @@ export default function DealsPage() {
   const [scheduleFor, setScheduleFor] = useState<{ deal: any; stage: DealStage } | null>(null);
   const [lostFor, setLostFor] = useState<string | null>(null);
 
-  const deals = teamFilter === 'all' ? rawDeals : rawDeals.filter((d: any) => (d as any).team_id === teamFilter);
+  const { lens, uid } = useOwnershipLens();
+  // Lens composes with the team filter; stat cards stay unlensed on purpose.
+  const teamDeals = teamFilter === 'all' ? rawDeals : rawDeals.filter((d: any) => (d as any).team_id === teamFilter);
+  const deals = applyLens(teamDeals, 'deals', lens, uid);
 
   const maybePromptScheduler = (dealId: string, newStage: DealStage) => {
     if (newStage !== 'closed_won' && newStage !== 'closed_lost') return;
@@ -102,6 +108,7 @@ export default function DealsPage() {
     <AdminLayout>
       <AdminPageContainer>
         <AdminPageHeader title="Deals">
+          <LensToggle />
           <div className="flex items-center gap-2">
             <ToggleGroup 
               type="single" 

--- a/src/pages/admin/LeadsPage.tsx
+++ b/src/pages/admin/LeadsPage.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
+import { LensToggle } from '@/components/admin/LensToggle';
+import { useOwnershipLens } from '@/hooks/useOwnershipLens';
+import { applyLens } from '@/lib/ownership';
 import { AdminPageContainer } from '@/components/admin/AdminPageContainer';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -41,8 +44,12 @@ export default function LeadsPage() {
   const [activeViewId, setActiveViewId] = useState<string | null>(null);
   const { data: stats, isLoading: statsLoading } = useLeadStats();
   const { data: dealStats, isLoading: dealStatsLoading } = useDealStats();
-  const { data: leads, isLoading: leadsLoading } = useLeads();
-  const { data: reviewLeads } = useLeads({ needsReview: true });
+  const { data: rawLeads, isLoading: leadsLoading } = useLeads();
+  const { data: rawReviewLeads } = useLeads({ needsReview: true });
+  const { lens, uid } = useOwnershipLens();
+  // The lens narrows the lists only — stat cards keep showing everything.
+  const leads = applyLens(rawLeads, 'leads', lens, uid);
+  const reviewLeads = applyLens(rawReviewLeads, 'leads', lens, uid);
   const navigate = useNavigate();
   const exportLeads = useExportLeads();
   const importLeads = useImportLeads();
@@ -125,6 +132,7 @@ export default function LeadsPage() {
           description="Manage contacts and view pipeline"
         >
           <div className="flex items-center gap-2">
+            <LensToggle />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="outline" size="icon">

--- a/src/pages/admin/QuotesPage.tsx
+++ b/src/pages/admin/QuotesPage.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
+import { LensToggle } from '@/components/admin/LensToggle';
+import { useOwnershipLens } from '@/hooks/useOwnershipLens';
+import { applyLens } from '@/lib/ownership';
 import { AdminPageContainer } from '@/components/admin/AdminPageContainer';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -50,14 +53,17 @@ export default function QuotesPage() {
     }
   };
 
-  const { data: quotes = [], isLoading } = useQuotes(
+  const { data: rawQuotes = [], isLoading } = useQuotes(
     statusFilter === 'all' ? undefined : statusFilter
   );
+  const { lens, uid } = useOwnershipLens();
+  const quotes = applyLens(rawQuotes, 'quotes', lens, uid);
 
   return (
     <AdminLayout>
       <AdminPageContainer>
         <AdminPageHeader title="Quotes">
+          <LensToggle />
           <Button size="sm" variant="outline" onClick={() => setProcessOpen(true)}>
             <Settings2 className="h-4 w-4 mr-1" /> Process
           </Button>


### PR DESCRIPTION
The last piece before delegation. One toggle — **All / Mine** — in the headers of Contacts, Deals, Companies and Quotes.

## Design decisions, each load-bearing

**One preference for the whole CRM**, not one per list. "Mine" is a mode of looking; a salesperson who narrows their contacts wants their deals and quotes narrowed in the same glance. **Defaults to All** — the system's purpose is transparency, focus is the exception you opt into.

**Applied through the ownership map** (`applyLens()` in `src/lib/ownership.ts`) — the same map the chip writes through, so the lens and the chip can never disagree about which column ownership lives in.

**Stored in `profiles.preferences`**, merge-written per the pinned-pages convention. localStorage is persistent per *browser per origin* and lost everyone's pins the day the instance got its real domain — the lens follows the user instead.

**The lens narrows lists only.** Deal stat cards keep reading their own unlensed query — two people looking at the pipeline total must see one number. A KPI that silently shows "mine" while claiming to show the pipeline is how two people report different revenue.

**Unassigned rows disappear under Mine**, honestly: they are nobody's, and if one should be yours the chip assigns it in a click. **Mine with no uid degrades to everything, never to nothing** — a slow auth load must not blank the CRM.

## Pure frontend

No migration — and the moment this feature needs one, someone is about to put the lens in RLS, which the ownership guardrails forbid across every migration, forever. (Odoo wires "my records" into record rules; that is where salespeople stop seeing each other's pipelines and start calling the same customer twice.)

Client-side filtering today because no CRM list paginates yet; when one does, the same map drives an `.eq(column, uid)` server-side.

## Guardrails

9, negative-tested: blanking on missing uid, moving to localStorage, and clobbering sibling preference keys each fails one. One guard-of-the-guard fix on the way in: the localStorage assertion initially tripped on the *docstring* (which recounts the pins lesson) — now it strips comments first, the `policyBody` trap from the documents suite.

Full suite **1714 passed**, `tsc` clean.

Remaining from the plan: the time-boxed coverage delegation ("Anna täcker för Björn 1–15 aug") — the piece that beats both HubSpot and Odoo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_