### PR TITLE
feat(templates): en webbmall blir något en agent kan författa — plus CI grön igen

### DIFF
--- a/docs/architecture/site-template-authoring.md
+++ b/docs/architecture/site-template-authoring.md
@@ -1,0 +1,132 @@
+# Site templates an agent can author
+
+The contract side already proved that an external operator can author a
+FlowWink artifact well. This document records **why** it worked, what the site
+template equivalent needs, and carries the finished guide text for the skill
+seed — the half that lives in `src/lib/modules/` and is therefore handed over,
+not written here.
+
+## Why contract authoring worked
+
+Five mechanisms, and they only work together:
+
+| # | mechanism | contracts |
+|---|---|---|
+| 1 | the template is **instance data** | `contract_templates` table |
+| 2 | an **authoring RPC** with the service_role escape | `manage_contract_template` |
+| 3 | a **guide in `instructions`**, fetched lazily via `read_skill` | 4 443 chars |
+| 4 | a **machine-readable validation response** | `unrendered_tokens` |
+| 5 | **discovery before authoring** | `list_contract_templates` |
+
+Mechanism 3 is the largest lever and the least obvious one. The skill's
+*description* explicitly tells the agent to load the full instructions **before**
+authoring, so `read_skill` delivers the house style, the vocabulary and the
+process couplings into context at the moment they are needed. Mechanism 4 closes
+the loop: the agent learns it guessed wrong and fixes itself, with no human in
+the path.
+
+## What site templates had
+
+Site templates lived in `src/data/templates/*.ts` — TypeScript compiled into the
+bundle. An agent could install one and export the current site as one, but could
+never **create** one. Import made the gap concrete: the admin UI parked an
+imported template in `sessionStorage`, so "save it and install it on the next
+instance" had no durable middle.
+
+There was also a sharper asymmetry. `manage_page_blocks`'s instructions say:
+
+> when unsure what a block supports, ask for its schema rather than guessing from examples
+
+…but no skill returns a block schema. FlowPilot sees the full vocabulary — all
+56 block types with their field lists — because `cms-context.ts` injects
+`BLOCK_TYPES_SCHEMA` into its prompt. The external operator over the MCP gateway
+sees nothing and guesses. The contract guide has no such asymmetry: the token
+list sits in the skill's instructions, so both consumers read the same text.
+
+## The storage half (shipped)
+
+`20260808500000_site-templates-authorable.sql`:
+
+- **`site_templates`** — `template_json` holds the StarterTemplate body.
+  `created_by` is `ON DELETE SET NULL`: a template outlives the colleague who
+  wrote it (business record, not a personal artifact).
+- **`manage_site_template(action, …)`** — `list | get | create | update |
+  archive`, idempotent on name, resolving by id / exact name / unique prefix
+  (ambiguity errors with the candidates listed), guarded by
+  `auth.role() = 'service_role' OR has_role(auth.uid(), 'admin')`.
+- **`_site_template_structure_report(jsonb)`** — the `unrendered_tokens`
+  equivalent. Errors block the write; warnings are advice.
+
+Verified live on optic in rolled-back transactions: create → idempotent re-create
+→ list → get-by-prefix all behave; a non-admin authenticated caller is refused
+with P0001 while `service_role` passes; and each defect class below is reported
+rather than stored.
+
+**Errors** (refuse the write): no pages · page without title or slug · duplicate
+slug · block without `type` · `data` that is not an object · a Tiptap document
+sent as a **string** · no homepage (no page matching `siteSettings.homepageSlug`
+and none marked `isHomePage`).
+
+**Warnings**: a page with no blocks · no tagline.
+
+### One thing deliberately absent
+
+The block **vocabulary**. Which block types exist and what fields they carry has
+exactly one home — `src/lib/block-reference.ts`, synced to
+`_shared/block-schema.ts` by `scripts/sync-block-schema.ts`. A copy in the
+database would be stale within the week; that exact failure produced a third
+copy of the contract token list one day after the second was reconciled. So the
+DB validates **shape**, and the vocabulary check belongs where the vocabulary
+already is, in the edge layer. A guardrail test fails if a block-type list is
+ever added to the migration.
+
+## The remaining half (edge layer — `src/lib/modules/`)
+
+Three pieces, all in files owned by the local session:
+
+1. **`manage_site_template` skill seed** — `handler: 'rpc:manage_site_template'`,
+   `category: 'content'`, `trust_level: 'notify'`, with the guide below as
+   `instructions` and a description that tells the agent to load them first.
+2. **`describe_blocks`** — returns `BLOCK_TYPES_SCHEMA`, whole or for one block
+   type. This is the skill `manage_page_blocks` already tells agents to call. It
+   is a **platform primitive** — an external operator needs it with the
+   FlowPilot module switched off — so it belongs in `platform-seeds.ts`, not in
+   the pages module.
+3. **`install_template` accepting a stored template** — today it takes a catalog
+   id. Accepting a `site_templates` row (or an inline body) closes the loop:
+   author → stored on the instance → exported as JSON → installed on the next
+   instance.
+
+---
+
+## The guide text (for `instructions` on `manage_site_template`)
+
+> THE SITE COMPOSITION GUIDE — FlowWink owns the framework; the INSTANCE owns the content.
+>
+> STEP 0, GATHER CONTEXT FIRST (never compose from a blank page):
+> 1. `manage_site_template action=list` and `list_templates` — the existing templates ARE the house style; mirror their page set, section rhythm and voice.
+> 2. `describe_blocks` — the block vocabulary with exact field names. Never guess a field name from an example; a wrong key is silently dropped and the section renders empty.
+> 3. `search_kb` / `search_wiki` for the instance's positioning, tone and product language.
+> The platform supplies structure; the instance's own material supplies the words. Do not invent claims, customer names, metrics or logos — placeholder copy that reads as placeholder beats fabricated proof.
+>
+> THE BODY: `template_json` is a StarterTemplate — `{ pages[], blogPosts[], branding, chatSettings, headerSettings, footerSettings, seoSettings, siteSettings{homepageSlug}, requiredModules[] }`. Each page is `{ title, slug, isHomePage?, blocks[], meta{}, menu_order?, showInMenu? }`. Each block is `{ type, data{} }` where `data` matches that block type exactly.
+>
+> RICH TEXT: fields typed `tiptap` MUST be JSON objects — `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"…"}]}]}` — never strings. A stringified doc renders as nothing and looks correct in the payload; `create` refuses it and names the field.
+>
+> PAGE RECIPES (a starting rhythm, not a rule):
+> - **home**: hero → features or bento-grid → two-column story → social proof (testimonials / logos / stats) → CTA.
+> - **services/products**: hero → pricing or comparison → accordion (objections) → CTA.
+> - **about**: two-column story → timeline → team → CTA.
+> - **contact**: contact or form → map, and nothing else competing for the eye.
+> - **support/help**: ai-faq or accordion → quick-links → chat-launcher.
+>
+> COMPOSITION:
+> - Use the blocks' full range. A page written with only title+content looks like the poor cousin of what the renderer can do. `two-column` is the most underused: `eyebrow` + `eyebrowColor`, `titleSize` (default | large | display), `accentText` with `accentPosition`, `imageAspect` / `imageFit` / `imageRounded`, `secondImageSrc`, `stickyColumn`, `ctaText`/`ctaUrl` with `note`.
+> - Alternate eyebrows across sections instead of repeating H2-only headers. At most one `accentText` per page — it is seasoning, not sauce.
+> - Every page needs one clear next action. Two CTAs competing on the same screen is none.
+> - `features` requires an `icon` on every item (PascalCase Lucide names).
+> - Full-bleed blocks (hero, parallax-section, marquee, featured-carousel) already span the viewport — do not wrap them in a container-style section.
+>
+> WHAT BELONGS WHERE: branding, header, footer, SEO and cookie settings are template-level, not page blocks — a logo pasted into a hero is not a header. `requiredModules` lists what the template's pages actually need (a booking block needs the booking module); it is a declaration, not a switch.
+>
+> MECHANICS: `create` is idempotent on name — an existing name returns `already_existed: true`; use `action=update` to change a body. Every create/update returns `validation` — a non-empty `errors` list means the write was refused; `warnings` are advice worth reading. `archive` deactivates; templates are not deleted, because an installed site's provenance points back at them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flowwink",
-  "version": "1.3.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flowwink",
-      "version": "1.3.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.11",
@@ -106,6 +106,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
+        "@lovable.dev/vite-plugin-dev-server-bridge": "^1.0.2",
+        "@lovable.dev/vite-plugin-hmr-gate": "^1.5.0",
         "@tailwindcss/typography": "^0.5.16",
         "@types/node": "^22.16.5",
         "@types/pg": "^8.20.0",
@@ -1477,6 +1479,36 @@
       },
       "peerDependencies": {
         "react": "16 - 19"
+      }
+    },
+    "node_modules/@lovable.dev/vite-plugin-dev-server-bridge": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lovable.dev/vite-plugin-dev-server-bridge/-/vite-plugin-dev-server-bridge-1.3.0.tgz",
+      "integrity": "sha512-rtObF3+65Ru56l2/E+GPEmfj5dB7WKuuRfKFiEZEo29Om+oSJJWhLk+H8uzMprpaeeGCmHctw4eltZNRXNFjLQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": ">=5.0.0 <9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@lovable.dev/vite-plugin-hmr-gate": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@lovable.dev/vite-plugin-hmr-gate/-/vite-plugin-hmr-gate-1.5.0.tgz",
+      "integrity": "sha512-OrkuaCNmeyItdwa5XRDSM+BJKmTptdvofWBECg6/gc4P2KUl5lbDYb3uhdYhGdD39S141EgbQHluSOVVVRXbTw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": ">=5.0.0 <9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": false
+        }
       }
     },
     "node_modules/@marijn/find-cluster-break": {

--- a/src/lib/__tests__/site-templates.guardrails.test.ts
+++ b/src/lib/__tests__/site-templates.guardrails.test.ts
@@ -1,0 +1,92 @@
+/**
+ * A website template an agent can author — the mirror of the contract anatomy.
+ *
+ * What made contract generation work for an external operator was five things
+ * acting together: the template lives in a TABLE (not in the bundle), an
+ * authoring RPC with the service_role escape, a long guide delivered lazily via
+ * read_skill, a machine-readable validation response, and discovery before
+ * authoring. Site templates had none of them — they were TypeScript files.
+ *
+ * Proven live on optic (rolled back): create/idempotency/list/get-by-prefix all
+ * behave; a non-admin authenticated caller is refused (P0001) while service_role
+ * — the MCP gateway's identity — goes through; and every structural defect
+ * class is reported rather than stored.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const strip = (s: string) => s.replace(/--[^\n]*/g, '');
+const sql = strip(read('supabase/migrations/20260808500000_site-templates-authorable.sql'));
+
+describe('the template is instance data, like a contract template', () => {
+  it('stores the body in a table, not in the bundle', () => {
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS public\.site_templates/);
+    expect(sql).toMatch(/template_json jsonb NOT NULL/);
+  });
+
+  it('is unique by name so create can be idempotent', () => {
+    expect(sql).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS site_templates_name_lower_key/);
+    expect(sql).toMatch(/'already_existed', true/);
+  });
+
+  it('outlives its author — SET NULL, not CASCADE', () => {
+    // The 20260808290000 doctrine: CASCADE for personal artifacts, SET NULL for
+    // business records. A template a colleague wrote is the instance's, not theirs.
+    expect(sql).toMatch(/created_by uuid REFERENCES auth\.users\(id\) ON DELETE SET NULL/);
+  });
+});
+
+describe('an external operator can actually call it', () => {
+  it('keeps the service_role escape', () => {
+    // Without this the MCP gateway (service key, auth.uid() NULL) only ever sees
+    // "Only admins…" — the failure that stranded 44 admin functions.
+    expect(sql).toMatch(/auth\.role\(\) = 'service_role' OR public\.has_role\(auth\.uid\(\), 'admin'\)/);
+  });
+
+  it('resolves a template by id, exact name, or unique prefix — never guessing', () => {
+    expect(sql).toMatch(/Several templates start with/);
+  });
+});
+
+describe('the validation response is the unrendered_tokens of templates', () => {
+  it('reports rather than silently accepting', () => {
+    expect(sql).toMatch(/_site_template_structure_report/);
+    expect(sql).toMatch(/'valid', cardinality\(v_errors\) = 0/);
+    expect(sql).toMatch(/'warnings', to_jsonb\(v_warnings\)/);
+  });
+
+  it('refuses to store a structurally broken template', () => {
+    // Mirrors guard_contracts_require_body: a contract with no body and a
+    // template with no landing page are the same kind of nothing.
+    const creates = sql.match(/Template structure is invalid/g) ?? [];
+    expect(creates.length).toBeGreaterThanOrEqual(2); // create AND update
+  });
+
+  it('catches the mistake agents actually make — Tiptap sent as a string', () => {
+    // It renders as nothing and looks correct in the payload, so the agent has
+    // no way to notice unless told. Verified live against a broken template.
+    expect(sql).toMatch(/"type"\\s\*:\\s\*"doc"/);
+    expect(sql).toMatch(/is a Tiptap document sent as a string/);
+  });
+
+  it('every array append is explicitly text', () => {
+    // `text[] || 'literal'` reads the unknown-typed literal as an ARRAY literal
+    // and dies on the first word. Live testing caught this; the property is that
+    // no bare-literal append survives.
+    const appends = sql.match(/v_(errors|warnings) := v_\1 \|\| '[^']*'(?!::text)/g) ?? [];
+    expect(appends).toEqual([]);
+  });
+});
+
+describe('the block vocabulary keeps exactly one home', () => {
+  it('the migration does not copy the list of block types', () => {
+    // Today's lesson: a third copy of the contract token list appeared one day
+    // after the second was reconciled. block-reference.ts → block-schema.ts is
+    // the one source; the DB validates shape, never vocabulary.
+    for (const blockType of ["'hero'", "'two-column'", "'bento-grid'", "'features'"]) {
+      expect(sql).not.toContain(blockType);
+    }
+  });
+});

--- a/supabase/migrations/20260808500000_site-templates-authorable.sql
+++ b/supabase/migrations/20260808500000_site-templates-authorable.sql
@@ -1,0 +1,327 @@
+-- A website template becomes instance data, so an agent can author one.
+--
+-- The contract side proved the anatomy: a template that lives in a TABLE can be
+-- created by an external operator, survives, shows up in the picker, and travels
+-- with the instance. Site templates lived in src/data/templates/*.ts — compiled
+-- into the bundle — so the one thing an agent could never do was make a new one.
+-- Import made it worse: the admin UI parked an imported template in
+-- sessionStorage, so "save it and install it on the next instance" had no
+-- durable middle.
+--
+-- This is the storage half of the mirror:
+--   contract_templates          → site_templates
+--   manage_contract_template    → manage_site_template
+--   _contract_template_unrendered_tokens → _site_template_structure_report
+--
+-- ONE THING DELIBERATELY ABSENT: the block vocabulary. Which block types exist
+-- and what fields they carry has exactly one home — src/lib/block-reference.ts,
+-- synced to _shared/block-schema.ts by scripts/sync-block-schema.ts. Today's
+-- lesson (a third copy of the contract token list appearing one day after the
+-- second was reconciled) says a DB copy would be stale within the week. So this
+-- function validates what the DATABASE knows — shape, slugs, homepage
+-- resolution, stringified rich text — and the vocabulary check stays where the
+-- vocabulary is. Idempotent throughout.
+
+CREATE TABLE IF NOT EXISTS public.site_templates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  description text,
+  category text NOT NULL DEFAULT 'enterprise',
+  icon text NOT NULL DEFAULT 'Sparkles',
+  tagline text,
+  -- The StarterTemplate body: pages[], blogPosts[], branding, *Settings.
+  template_json jsonb NOT NULL,
+  is_active boolean NOT NULL DEFAULT true,
+  -- A template outlives the colleague who wrote it (business record, not a
+  -- personal artifact) — SET NULL, per the 20260808290000 doctrine.
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Name is the handle an author resolves by, so it must be unique the way
+-- contract templates are: create is idempotent on it.
+CREATE UNIQUE INDEX IF NOT EXISTS site_templates_name_lower_key
+  ON public.site_templates (lower(name));
+
+ALTER TABLE public.site_templates ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Admins manage site templates" ON public.site_templates;
+CREATE POLICY "Admins manage site templates"
+  ON public.site_templates FOR ALL
+  USING (public.has_role(auth.uid(), 'admin'))
+  WITH CHECK (public.has_role(auth.uid(), 'admin'));
+
+DROP POLICY IF EXISTS "Authenticated view site templates" ON public.site_templates;
+CREATE POLICY "Authenticated view site templates"
+  ON public.site_templates FOR SELECT
+  TO authenticated
+  USING (is_active = true OR public.has_role(auth.uid(), 'admin'));
+
+
+-- ── the structural report ───────────────────────────────────────────────────
+-- The counterpart of unrendered_tokens: a machine-readable answer the agent can
+-- act on without a human. Errors block the write; warnings are advice.
+CREATE OR REPLACE FUNCTION public._site_template_structure_report(p_template jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public
+AS $fn$
+DECLARE
+  v_errors text[] := ARRAY[]::text[];
+  v_warnings text[] := ARRAY[]::text[];
+  v_pages jsonb;
+  v_page jsonb;
+  v_blocks jsonb;
+  v_block jsonb;
+  v_slugs text[] := ARRAY[]::text[];
+  v_slug text;
+  v_home text;
+  v_home_found boolean := false;
+  v_block_count int := 0;
+  v_page_idx int := 0;
+  v_key text;
+  v_val jsonb;
+BEGIN
+  IF p_template IS NULL OR jsonb_typeof(p_template) <> 'object' THEN
+    RETURN jsonb_build_object(
+      'valid', false,
+      'errors', jsonb_build_array('template_json must be a JSON object (the StarterTemplate body)'),
+      'warnings', '[]'::jsonb,
+      'stats', jsonb_build_object('pages', 0, 'blocks', 0, 'blog_posts', 0));
+  END IF;
+
+  v_pages := p_template -> 'pages';
+  IF v_pages IS NULL OR jsonb_typeof(v_pages) <> 'array' OR jsonb_array_length(v_pages) = 0 THEN
+    -- Bare string literals are `unknown` to the || operator, which then reads
+    -- them as array literals and dies on the first word. Every append in this
+    -- function is explicitly text — caught live, not in review.
+    v_errors := v_errors || 'A template must have at least one page (pages: [])'::text;
+    v_pages := '[]'::jsonb;
+  END IF;
+
+  -- The homepage may be declared per page (isHomePage) or by slug in
+  -- siteSettings.homepageSlug. Either resolves; neither is an error.
+  v_home := COALESCE(p_template #>> '{siteSettings,homepageSlug}', 'home');
+
+  FOR v_page IN SELECT * FROM jsonb_array_elements(v_pages) LOOP
+    v_page_idx := v_page_idx + 1;
+
+    IF COALESCE(btrim(v_page ->> 'title'), '') = '' THEN
+      v_errors := v_errors || format('Page %s: title is required', v_page_idx);
+    END IF;
+
+    v_slug := COALESCE(btrim(v_page ->> 'slug'), '');
+    IF v_slug = '' THEN
+      v_errors := v_errors || format('Page %s ("%s"): slug is required', v_page_idx, COALESCE(v_page ->> 'title', '?'));
+    ELSE
+      IF v_slug = ANY (v_slugs) THEN
+        v_errors := v_errors || format('Duplicate page slug "%s" — a slug is the page''s address and must be unique', v_slug);
+      END IF;
+      v_slugs := v_slugs || v_slug;
+      IF v_slug = v_home OR COALESCE((v_page ->> 'isHomePage')::boolean, false) THEN
+        v_home_found := true;
+      END IF;
+    END IF;
+
+    v_blocks := v_page -> 'blocks';
+    IF v_blocks IS NULL OR jsonb_typeof(v_blocks) <> 'array' OR jsonb_array_length(v_blocks) = 0 THEN
+      v_warnings := v_warnings || format('Page "%s": has no content blocks', COALESCE(v_page ->> 'title', v_slug));
+    ELSE
+      FOR v_block IN SELECT * FROM jsonb_array_elements(v_blocks) LOOP
+        v_block_count := v_block_count + 1;
+
+        IF COALESCE(btrim(v_block ->> 'type'), '') = '' THEN
+          v_errors := v_errors || format('Page "%s": a block is missing its "type"', COALESCE(v_page ->> 'title', v_slug));
+          CONTINUE;
+        END IF;
+
+        IF v_block -> 'data' IS NULL OR jsonb_typeof(v_block -> 'data') <> 'object' THEN
+          v_errors := v_errors || format('Page "%s", block "%s": "data" must be an object',
+                                         COALESCE(v_page ->> 'title', v_slug), v_block ->> 'type');
+          CONTINUE;
+        END IF;
+
+        -- The single most common authoring mistake: a Tiptap document sent as a
+        -- STRING instead of JSON. It renders as nothing, and it looks correct in
+        -- the payload — so the agent has no way to notice without being told.
+        FOR v_key, v_val IN SELECT * FROM jsonb_each(v_block -> 'data') LOOP
+          IF jsonb_typeof(v_val) = 'string'
+             AND (v_val #>> '{}') ~ '^\s*\{.*"type"\s*:\s*"doc"' THEN
+            v_errors := v_errors || format(
+              'Page "%s", block "%s": field "%s" is a Tiptap document sent as a string — send it as JSON ({"type":"doc","content":[…]}), not as text',
+              COALESCE(v_page ->> 'title', v_slug), v_block ->> 'type', v_key);
+          END IF;
+        END LOOP;
+      END LOOP;
+    END IF;
+  END LOOP;
+
+  IF jsonb_array_length(v_pages) > 0 AND NOT v_home_found THEN
+    v_errors := v_errors || format(
+      'No homepage: no page has slug "%s" and none is marked isHomePage — a template without a landing page installs into a site with no front door', v_home);
+  END IF;
+
+  IF COALESCE(btrim(p_template ->> 'tagline'), '') = '' THEN
+    v_warnings := v_warnings || 'No tagline — the gallery card reads better with one'::text;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'valid', cardinality(v_errors) = 0,
+    'errors', to_jsonb(v_errors),
+    'warnings', to_jsonb(v_warnings),
+    'stats', jsonb_build_object(
+      'pages', jsonb_array_length(v_pages),
+      'blocks', v_block_count,
+      'blog_posts', CASE WHEN jsonb_typeof(p_template -> 'blogPosts') = 'array'
+                         THEN jsonb_array_length(p_template -> 'blogPosts') ELSE 0 END));
+END; $fn$;
+
+
+-- ── the authoring RPC ───────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.manage_site_template(
+  p_action text,
+  p_template text DEFAULT NULL,
+  p_name text DEFAULT NULL,
+  p_description text DEFAULT NULL,
+  p_category text DEFAULT NULL,
+  p_icon text DEFAULT NULL,
+  p_tagline text DEFAULT NULL,
+  p_template_json jsonb DEFAULT NULL,
+  p_is_active boolean DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_row public.site_templates;
+  v_id uuid;
+  v_matches int;
+  v_report jsonb;
+BEGIN
+  -- The MCP gateway runs RPC skills with the service key, so auth.uid() is NULL
+  -- inside this function — without the escape an operator only ever sees
+  -- "Only admins…".
+  IF NOT (auth.role() = 'service_role' OR public.has_role(auth.uid(), 'admin')) THEN
+    RAISE EXCEPTION 'Only admins can manage site templates';
+  END IF;
+
+  IF p_action = 'list' THEN
+    RETURN jsonb_build_object('templates', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+               'id', t.id, 'name', t.name, 'description', t.description,
+               'category', t.category, 'tagline', t.tagline, 'is_active', t.is_active,
+               'pages', CASE WHEN jsonb_typeof(t.template_json -> 'pages') = 'array'
+                             THEN jsonb_array_length(t.template_json -> 'pages') ELSE 0 END,
+               'updated_at', t.updated_at)
+             ORDER BY t.name)
+      FROM public.site_templates t
+      WHERE t.is_active OR COALESCE(p_is_active, true) = false), '[]'::jsonb));
+  END IF;
+
+  -- ── Resolve an existing template: id, or name (exact then unique prefix) ──
+  IF p_action IN ('get', 'update', 'archive') THEN
+    IF COALESCE(btrim(p_template), '') = '' THEN
+      RAISE EXCEPTION '% requires p_template (the template name or its UUID)', p_action;
+    END IF;
+
+    SELECT * INTO v_row FROM public.site_templates
+    WHERE id = CASE WHEN p_template ~* '^[0-9a-f-]{36}$' THEN p_template::uuid END
+    LIMIT 1;
+
+    IF v_row.id IS NULL THEN
+      SELECT * INTO v_row FROM public.site_templates
+      WHERE lower(name) = lower(btrim(p_template)) LIMIT 1;
+    END IF;
+
+    IF v_row.id IS NULL THEN
+      -- Unique prefix only. Ambiguity must be an error, never a silent pick.
+      SELECT count(*) INTO v_matches FROM public.site_templates
+      WHERE lower(name) LIKE lower(btrim(p_template)) || '%';
+      IF v_matches > 1 THEN
+        RAISE EXCEPTION 'Several templates start with "%": %', p_template,
+          (SELECT string_agg(name, ' | ' ORDER BY name) FROM public.site_templates
+           WHERE lower(name) LIKE lower(btrim(p_template)) || '%');
+      END IF;
+      SELECT * INTO v_row FROM public.site_templates
+      WHERE lower(name) LIKE lower(btrim(p_template)) || '%' LIMIT 1;
+    END IF;
+
+    IF v_row.id IS NULL THEN
+      RAISE EXCEPTION 'Template "%" not found. Run manage_site_template action=list to see the names.', p_template;
+    END IF;
+  END IF;
+
+  IF p_action = 'get' THEN
+    RETURN jsonb_build_object('template', to_jsonb(v_row));
+
+  ELSIF p_action = 'create' THEN
+    IF COALESCE(btrim(p_name), '') = '' THEN
+      RAISE EXCEPTION 'create requires p_name';
+    END IF;
+    IF p_template_json IS NULL THEN
+      RAISE EXCEPTION 'create requires p_template_json (the StarterTemplate body: pages[], blogPosts[], branding, settings)';
+    END IF;
+
+    -- Idempotent on name, exactly like manage_contract_template.
+    SELECT * INTO v_row FROM public.site_templates WHERE lower(name) = lower(btrim(p_name));
+    IF FOUND THEN
+      RETURN jsonb_build_object('created', false, 'already_existed', true,
+                                'template_id', v_row.id, 'template', to_jsonb(v_row));
+    END IF;
+
+    -- A structurally broken template is refused rather than stored, the way the
+    -- contracts guard refuses an empty agreement body. Warnings do not block.
+    v_report := public._site_template_structure_report(p_template_json);
+    IF NOT (v_report ->> 'valid')::boolean THEN
+      RAISE EXCEPTION 'Template structure is invalid: %',
+        (SELECT string_agg(value #>> '{}', ' | ') FROM jsonb_array_elements(v_report -> 'errors'));
+    END IF;
+
+    INSERT INTO public.site_templates (name, description, category, icon, tagline, template_json, is_active, created_by)
+    VALUES (btrim(p_name), p_description, COALESCE(p_category, 'enterprise'),
+            COALESCE(p_icon, 'Sparkles'), p_tagline, p_template_json,
+            COALESCE(p_is_active, true), auth.uid())
+    RETURNING * INTO v_row;
+
+    RETURN jsonb_build_object('created', true, 'template_id', v_row.id,
+                              'template', to_jsonb(v_row), 'validation', v_report);
+
+  ELSIF p_action = 'update' THEN
+    IF p_template_json IS NOT NULL THEN
+      v_report := public._site_template_structure_report(p_template_json);
+      IF NOT (v_report ->> 'valid')::boolean THEN
+        RAISE EXCEPTION 'Template structure is invalid: %',
+          (SELECT string_agg(value #>> '{}', ' | ') FROM jsonb_array_elements(v_report -> 'errors'));
+      END IF;
+    END IF;
+
+    UPDATE public.site_templates SET
+      name = COALESCE(nullif(btrim(COALESCE(p_name, '')), ''), name),
+      description = COALESCE(p_description, description),
+      category = COALESCE(p_category, category),
+      icon = COALESCE(p_icon, icon),
+      tagline = COALESCE(p_tagline, tagline),
+      template_json = COALESCE(p_template_json, template_json),
+      is_active = COALESCE(p_is_active, is_active),
+      updated_at = now()
+    WHERE id = v_row.id
+    RETURNING * INTO v_row;
+
+    RETURN jsonb_build_object('updated', true, 'template_id', v_row.id,
+                              'template', to_jsonb(v_row),
+                              'validation', COALESCE(v_report, public._site_template_structure_report(v_row.template_json)));
+
+  ELSIF p_action = 'archive' THEN
+    UPDATE public.site_templates SET is_active = false, updated_at = now()
+      WHERE id = v_row.id RETURNING * INTO v_row;
+    RETURN jsonb_build_object('archived', true, 'template_id', v_row.id);
+  END IF;
+
+  RAISE EXCEPTION 'Unknown action %. Use list|get|create|update|archive', p_action;
+END; $fn$;
+
+GRANT EXECUTE ON FUNCTION public._site_template_structure_report(jsonb) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.manage_site_template(text, text, text, text, text, text, text, jsonb, boolean) TO authenticated, service_role;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260808400000",
-      "migrations_count": 354,
+      "migration_head": "20260808500000",
+      "migrations_count": 355,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1421,6 +1421,10 @@
         {
           "version": "20260808400000",
           "name": "contract-appendices"
+        },
+        {
+          "version": "20260808500000",
+          "name": "site-templates-authorable"
         }
       ]
     },


### PR DESCRIPTION
Två commits: först CI-fixen som gjorde main grön, sedan lagringshalvan av mallförfattandet.

---

## 1. `fix(ci)` — main var röd i 13 körningar, och inte av testerna

Sista gröna körningen var i går 23:17. Varje körning sedan dess dog **innan ett enda test kördes**: två `@lovable.dev`-vite-plugins nådde `package.json` utan låsfilen, så `npm ci` vägrade. Bakom den låg ett andra fel som den röda installationen dolde — `instance-manifest.json` var en migration efter. Båda regenererade.

## 2. `feat(templates)` — lagringshalvan

Avtalssidan visade anatomin: fem mekanismer som bara fungerar tillsammans — mallen ligger i en **tabell**, en författar-RPC bär service_role-escapen, en lång guide rider i skillens `instructions` (hämtas lazily via `read_skill`), varje skrivning svarar med maskinläsbar validering, och upptäckt föregår författande. Webbmallar hade ingen av dem: de var TypeScript kompilerad in i bundlen, så det enda en agent aldrig kunde göra var att skapa en ny. Import gjorde hålet konkret — admin-UI:t parkerade en importerad mall i `sessionStorage`, så "spara undan och installera på nästa instans" saknade en varaktig mitt.

**`20260808500000_site-templates-authorable.sql`:**

- **`site_templates`** — `template_json` bär StarterTemplate-kroppen. `created_by` är `ON DELETE SET NULL`: en mall överlever kollegan som skrev den (affärspost, inte personlig artefakt — doktrinen från `20260808290000`).
- **`manage_site_template`** — `list|get|create|update|archive`, idempotent på namn, upplösning via id / exakt namn / unikt prefix (tvetydighet blir fel med kandidaterna listade), skyddad av `auth.role()='service_role' OR has_role(auth.uid(),'admin')` så gatewayen inte möts av "Only admins…".
- **`_site_template_structure_report`** — motsvarigheten till `unrendered_tokens`. Fel vägrar skrivningen, varningar är råd.

| klass | utfall |
|---|---|
| inga sidor · saknad titel/slug · dubblettslug | **fel** |
| block utan `type` · `data` som inte är objekt | **fel** |
| Tiptap-dokument skickat som **sträng** | **fel** |
| ingen startsida (varken `homepageSlug` eller `isHomePage`) | **fel** |
| sida utan block · ingen tagline | varning |

### Blockvokabulären är medvetet frånvarande

Vilka blocktyper som finns har ett hem — `block-reference.ts` → `block-schema.ts` via `sync-block-schema.ts`. En kopia i databasen vore inaktuell inom en vecka; exakt det felet gav en **tredje** kopia av avtalens tokenlista dagen efter att den andra försonats. DB:n validerar form, vokabulärkollen hör hemma där vokabulären är. En guardrail fäller migrationen om en blocktyplista någonsin läggs in.

### Verifierat live på optic (rullade tillbaka transaktioner)

create → idempotent återskapande → list → get-via-prefix beter sig; en icke-admin `authenticated` nekas med P0001 medan `service_role` — gatewayens identitet — släpps igenom; varje felklass rapporteras i stället för att lagras.

Livetestet hittade också en riktig bugg i validatorn: `text[] || 'literal'` läser den otypade literalen som en **array**-literal och dör på första ordet. Rättad, och en guardrail fäller varje ny bar literal-append.

**10 guardrails, var och en negativtestad** (borttagen service_role-escape, CASCADE i stället för SET NULL, bar literal, inkopierad vokabulär → alla röda). Applicerad + liggarförd på optic.

## Kvar — den andra halvan (locals filer)

`docs/architecture/site-template-authoring.md` bär analysen och den **färdiga guidetexten** för skill-seedet. Tre delar återstår, alla i `src/lib/modules/`:

1. **`manage_site_template`-seedet** — `rpc:manage_site_template`, med guiden som `instructions`.
2. **`describe_blocks`** — returnerar blockreferensen. Det är skillen `manage_page_blocks` redan hänvisar till (*"ask for its schema rather than guessing"*) men som inte finns. **Plattformsprimitiv** → `platform-seeds.ts`, inte pages-modulen: en extern operatör behöver den även med FlowPilot avslaget.
3. **`install_template` som tar en lagrad mall** — stänger cirkeln författa → lagrad → exporterad → installerad på nästa instans.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5