### PR TITLE
fix(app): två bootstrap-defaults som är osynliga tills de är fel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,7 +191,30 @@ const UnitsOfMeasurePage = lazy(() => import("./pages/admin/UnitsOfMeasurePage")
 
 const TemplateGalleryPage = lazy(() => import("./pages/admin/TemplateGalleryPage"));
 
-const queryClient = new QueryClient();
+/**
+ * TanStack Query's own defaults are tuned for a page that mounts a handful of
+ * queries. FlowWink has 151 query hooks, and with `staleTime: 0` every one of
+ * them is stale the moment it resolves — so returning to the tab refetches the
+ * whole admin surface. 30 seconds is short enough that FlowPilot's autonomous
+ * writes still surface on the next focus, and long enough that switching
+ * between two admin pages does not re-run their queries.
+ *
+ * This is a floor, not a ceiling: the 54 hooks that already declare their own
+ * staleTime keep it. Mutations invalidate explicitly (`qc.invalidateQueries`)
+ * throughout, so freshness after a write never depended on staleTime anyway.
+ *
+ * `retry: 1` because three retries with exponential backoff hides a genuine
+ * failure for ~7 seconds behind a spinner — in an operator console, being told
+ * quickly beats being told completely.
+ */
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: 1,
+    },
+  },
+});
 
 const withPageFallback = (element: JSX.Element) => (
   <Suspense

--- a/src/lib/__tests__/app-bootstrap.guardrails.test.ts
+++ b/src/lib/__tests__/app-bootstrap.guardrails.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Two defaults that are invisible until they are wrong.
+ *
+ * `new QueryClient()` with no options gives every one of the 151 query hooks
+ * `staleTime: 0` — stale the instant it resolves — so returning to the tab
+ * refetches the whole admin surface. And a root rendered without StrictMode
+ * never gets the development double-mount that exposes an effect which is not
+ * safe to run twice.
+ *
+ * Neither shows up in a test or a type error; both are one line. These
+ * guardrails keep them from quietly disappearing in a later refactor.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const strip = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+
+const app = strip(read('src/App.tsx'));
+const main = strip(read('src/main.tsx'));
+
+describe('the query client carries deliberate defaults', () => {
+  it('is not constructed bare', () => {
+    expect(app).not.toMatch(/new QueryClient\(\s*\)/);
+    expect(app).toMatch(/new QueryClient\(\s*\{/);
+  });
+
+  it('sets a staleTime floor', () => {
+    expect(app).toMatch(/defaultOptions:\s*\{[\s\S]*queries:\s*\{[\s\S]*staleTime:/);
+  });
+
+  it('does not retry a failing query three times', () => {
+    // The default is 3 with exponential backoff — ~7s of spinner before an
+    // operator learns anything went wrong.
+    const m = app.match(/retry:\s*(\d+)/);
+    expect(m, 'retry should be set explicitly').not.toBeNull();
+    expect(Number(m![1])).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('the root mounts under StrictMode', () => {
+  it('imports and wraps with it', () => {
+    expect(main).toMatch(/import \{ StrictMode \} from "react"/);
+    expect(main).toMatch(/<StrictMode>[\s\S]*<App \/>[\s\S]*<\/StrictMode>/);
+  });
+
+  it('still guards the root element rather than asserting it away', () => {
+    // The `!` non-null assertion turns a missing #root into a stack trace
+    // pointing at React instead of at the HTML.
+    expect(main).not.toMatch(/getElementById\("root"\)!/);
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
@@ -13,4 +14,15 @@ if (!root) {
   throw new Error("FlowWink root element was not found");
 }
 
-createRoot(root).render(<App />);
+// StrictMode is a development-only mirror: it mounts, unmounts and remounts
+// every component once, so an effect that is not safe to run twice fails here
+// instead of in front of a customer. Production renders exactly once.
+//
+// Checked before enabling it: usePageViewTracker sets its `tracked` ref
+// synchronously before the first await, so the second mount bails and no page
+// view is counted twice.
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);


### PR DESCRIPTION
Två enradsluckor som en React/Vite-genomgång hittade. Ingen av dem syns i ett test eller ett typfel.

## `new QueryClient()` utan defaults

TanStack Querys egna standardvärden är avvägda för en sida med en handfull queries. FlowWink har **151 query-hooks**, och `staleTime: 0` gör var och en inaktuell i samma ögonblick den löser sig — så att gå tillbaka till fliken hämtar om hela adminytan.

`staleTime` blir nu ett **golv på 30 s**: kort nog att FlowPilots autonoma skrivningar syns vid nästa fokus, långt nog att pendla mellan två adminsidor inte kör om deras queries. Ett golv, inte ett tak — de **54 hooks som redan deklarerar sitt eget** behåller det, och mutationer invaliderar explicit (`qc.invalidateQueries`) genomgående, så färskhet efter en skrivning har aldrig hängt på `staleTime`.

`retry` går från 3 till **1**. Tre försök med exponentiell backoff döljer ett verkligt fel bakom ~7 sekunders spinner; i en operatörskonsol slår *snabbt besked* *fullständigt besked*.

## Roten renderades utan `StrictMode`

Utan den sker aldrig utvecklingslägets dubbelmontering — den som avslöjar en effekt som inte tål att köras två gånger.

Kontrollerat innan den slogs på: `usePageViewTracker` sätter sin `tracked`-ref **synkront före första `await`**, så den andra monteringen bailar och ingen sidvisning dubbelräknas.

## Verifierat

- 5 guardrails, **var och en negativtestad** — bar `QueryClient`, `retry: 3` och borttagen `StrictMode`-wrapper ger var för sig en röd.
- Full svit: **2020 passed / 4 skipped**. Build ren.

## Not — en sak jag hittade på vägen

`npx tsc -p tsconfig.app.json --noEmit` är **röd på main sedan tidigare** (13 fel i `src/lib/__tests__/site-identity.test.ts`, `Property … does not exist on type 'never'`), verifierat med mina ändringar undanstashade. CI ser det inte, av två skäl: steget kör `npx tsc --noEmit` mot rotkonfigurationen, och det har `continue-on-error: true`. Typkontrollsteget kan alltså aldrig fälla ett bygge. Rapporterat, inte åtgärdat här — filen är locals.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_