### PR TITLE
main är röd: testet påstod en egenskap hos maskinen, inte om avkodningen

### DIFF
--- a/src/lib/__tests__/sie-reader.test.ts
+++ b/src/lib/__tests__/sie-reader.test.ts
@@ -34,21 +34,31 @@ describe('CP437 is not Latin-1, and guessing loses data', () => {
     expect(decodeCp437(new Uint8Array([0x86, 0x84, 0x94, 0x8f, 0x8e, 0x99]))).toBe('åäöÅÄÖ');
   });
 
-  it('the same byte gives three different wrong answers, and none of them throws', () => {
+  it('the same byte gives different wrong answers, and none of them throws', () => {
     // "för" as a CP437 writer emits it: 66 94 72.
     const bytes = new Uint8Array([0x66, 0x94, 0x72]);
     expect(decodeCp437(bytes)).toBe('för');
-    // "Latin-1" is not even one thing: every WHATWG runtime maps that label to
-    // windows-1252, where 0x94 is a curly quote. So the ö becomes ”.
-    expect(new TextDecoder('latin1').decode(bytes)).toBe('f”r');
-    expect(new TextDecoder('iso-8859-1').decode(bytes)).toBe('f”r');
-    // UTF-8 at least leaves a visible scar.
+
+    // "Latin-1" is not even one thing, and this test learned that the hard way.
+    // WHATWG maps the label to windows-1252 (0x94 = ”) and a full-ICU Node does
+    // exactly that — but CI runs a build where it decodes as true ISO-8859-1
+    // (0x94 = the U+0094 control character). Asserting either as universal is
+    // asserting a property of the machine. What is invariant is the part that
+    // matters: the ö is gone, silently, and the runtime is happy about it.
+    for (const label of ['latin1', 'iso-8859-1']) {
+      const out = new TextDecoder(label).decode(bytes);
+      expect(out).toHaveLength(3);
+      expect(out).not.toBe('för');
+      expect(out).not.toContain('\uFFFD'); // no replacement char = no visible damage
+    }
+
+    // UTF-8 at least leaves a scar you can see.
     expect(new TextDecoder('utf-8').decode(bytes)).toBe('f\uFFFDr');
 
-    // The dangerous one is Latin-1: f”r looks like a stray quote, a typo, a
-    // formatting glitch — anything but an encoding failure. Which is why the
-    // adapter comment calling CP437 "Latin-1" pointed at the failure mode
-    // nobody would have investigated.
+    // Which is why Latin-1 is the dangerous guess: whatever the runtime turns
+    // 0x94 into, the result reads as a typo or a formatting glitch — anything
+    // but an encoding failure. The adapter comment that called CP437 "Latin-1"
+    // pointed straight at the failure mode nobody would investigate.
   });
 });
 


### PR DESCRIPTION
`main` gick röd på `sie-reader.test.ts` direkt efter #176.

CI avkodar etiketten `latin1` som äkta ISO-8859-1 (0x94 → U+0094, en styrtecken).
En Node med full ICU följer WHATWG och mappar samma etikett till windows-1252
(0x94 → ”). Testet påstod det andra som universellt, så det passerade lokalt och
föll i CI — och sa ingenting sant om någondera maskinen.

Det som faktiskt spelar roll är identiskt på båda: ö:et är borta, strängen är
fortfarande tre tecken, det finns inget ersättningstecken att se, och ingenting
kastar. Det ÄR hela argumentet för att läsa SIE som bytes.

Testet påstår nu det, och kommentaren berättar varför den tidigare varianten var
fel — så nästa person inte skriver tillbaka den.

🤖 Generated with [Claude Code](https://claude.com/claude-code)