### PR TITLE
Inbjudan landar på lösenordssteget — och spärren får ett ansikte

### DIFF
--- a/src/components/admin/EmailRouterSettings.tsx
+++ b/src/components/admin/EmailRouterSettings.tsx
@@ -13,6 +13,7 @@ import { useIntegrations, useUpdateIntegrations, useIsIntegrationActive } from "
 import { Mail, Inbox, CheckCircle2, XCircle } from "lucide-react";
 import { Link } from "react-router-dom";
 import { InboundMailboxesSection } from "@/components/admin/email/InboundMailboxesSection";
+import { OutboundGuardPanel } from "@/components/admin/email/OutboundGuardPanel";
 
 /**
  * Email Router control plane. Owns provider selection, default From identity,
@@ -70,6 +71,11 @@ export function EmailRouterSettings() {
 
   return (
     <div className="space-y-6">
+      {/* The guard goes FIRST: an instance that is holding mail should say so
+          before it explains how mail flows, because everything below is about
+          sends that may not be leaving. */}
+      <OutboundGuardPanel />
+
       {/* Flow map — how transport, router and use cases connect */}
       <Card>
         <CardHeader>

--- a/src/components/admin/email/OutboundGuardPanel.tsx
+++ b/src/components/admin/email/OutboundGuardPanel.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { ShieldCheck, ShieldOff, Ban } from 'lucide-react';
+import {
+  useEmailAllowlist, useUpdateEmailAllowlist, useWithheldEmails, type EmailAllowlist,
+} from '@/hooks/useEmailAllowlist';
+
+/**
+ * "Not live yet" — the outbound guard, shown as a state the instance is in
+ * rather than as a settings checkbox.
+ *
+ * The panel deliberately leads with CONSEQUENCE, not configuration: how many
+ * sends were held and which ones. The anxiety this answers is not "is it on?"
+ * but "what did it stop, and am I still hiding?". And the dangerous mistake is
+ * the opposite of the one the guard prevents — going live with it still on, so
+ * invoices quietly never arrive — which is why the count is the loudest thing
+ * here and "Go live" is a single obvious action.
+ */
+const EMPTY: EmailAllowlist = { enabled: false, domains: [], addresses: [], scope: 'customer_facing' };
+
+export function OutboundGuardPanel() {
+  const { data, isLoading } = useEmailAllowlist();
+  const { data: withheld } = useWithheldEmails();
+  const save = useUpdateEmailAllowlist();
+
+  const [draft, setDraft] = useState<EmailAllowlist>(EMPTY);
+  const [dirty, setDirty] = useState(false);
+  useEffect(() => { if (data) { setDraft(data); setDirty(false); } }, [data]);
+
+  if (isLoading) return null;
+
+  const on = draft.enabled;
+  const list = [...draft.domains.map((d) => `*@${d}`), ...draft.addresses];
+  const edit = (patch: Partial<EmailAllowlist>) => { setDraft({ ...draft, ...patch }); setDirty(true); };
+
+  return (
+    <Card className={on ? 'border-warning/40' : undefined}>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          {on ? <ShieldCheck className="h-4 w-4 text-warning" /> : <ShieldOff className="h-4 w-4 text-muted-foreground" />}
+          {on ? 'This instance is not live yet' : 'Outbound guard'}
+          {on && <Badge variant="outline" className="text-warning border-warning/40">holding mail</Badge>}
+        </CardTitle>
+        <CardDescription>
+          {on
+            ? 'Mail to anyone outside the list below is withheld, so you can rehearse a real process on real data without reaching a customer. Turn this off when you go live.'
+            : 'Off. Every outbound mail leaves this instance normally. Turn it on while rehearsing on real data so a test cannot reach a customer.'}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-5">
+        {/* Consequence first: what the guard actually stopped. */}
+        {(withheld?.total ?? 0) > 0 && (
+          <div className="rounded-md border bg-muted/40 p-3">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <Ban className="h-4 w-4 text-muted-foreground" />
+              {withheld!.total} {withheld!.total === 1 ? 'send was' : 'sends were'} held back
+            </div>
+            <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
+              {withheld!.rows.map((r) => (
+                <li key={r.id} className="flex gap-2">
+                  <span className="font-mono shrink-0">{new Date(r.created_at).toISOString().slice(0, 10)}</span>
+                  <span className="truncate">{r.recipient}</span>
+                  <span className="ml-auto shrink-0 opacity-70">{r.source ?? '—'}</span>
+                </li>
+              ))}
+            </ul>
+            <p className="mt-2 text-xs text-muted-foreground">
+              These were never sent. Nothing is queued — they are not delivered when the guard is turned off.
+            </p>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between rounded-md border px-3 py-2.5">
+          <div>
+            <Label className="text-sm">Hold outbound mail</Label>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {on ? 'On — only the recipients below receive mail.' : 'Off — this instance mails anyone.'}
+            </p>
+          </div>
+          <Switch checked={on} onCheckedChange={(v) => edit({ enabled: v })} />
+        </div>
+
+        {on && (
+          <>
+            <div className="space-y-1.5">
+              <Label className="text-sm">What it covers</Label>
+              <Select value={draft.scope ?? 'all'} onValueChange={(v) => edit({ scope: v as EmailAllowlist['scope'] })}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="customer_facing">Customer mail only</SelectItem>
+                  <SelectItem value="all">Everything</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {(draft.scope ?? 'all') === 'customer_facing'
+                  ? 'Invoices, quotes, reminders and anything else aimed at a customer. Colleague invitations still go out — the risk this guard exists for is mailing a customer, and blocking your own team trains people to switch it off.'
+                  : 'Every send, including invitations to your own colleagues.'}
+              </p>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label className="text-sm">Who may receive</Label>
+              <Input
+                value={draft.domains.join(', ')}
+                placeholder="yourcompany.com, yourcompany.eu"
+                onChange={(e) => edit({
+                  domains: e.target.value.split(',').map((d) => d.trim().replace(/^@/, '')).filter(Boolean),
+                })}
+              />
+              <Input
+                value={draft.addresses.join(', ')}
+                placeholder="one.person@example.com (optional)"
+                onChange={(e) => edit({
+                  addresses: e.target.value.split(',').map((a) => a.trim()).filter(Boolean),
+                })}
+              />
+              <p className="text-xs text-muted-foreground">
+                A domain you own with catch-all is the best target: address a test customer at
+                anything@yourdomain and the mail lands in your own inbox. A subdomain is not the
+                domain — mail.example.com and example.com are different mailboxes.
+              </p>
+              {list.length === 0 && (
+                <p className="text-xs text-destructive">
+                  Nobody is listed, so every send is withheld. That is a valid setting — and rarely what anyone means.
+                </p>
+              )}
+            </div>
+          </>
+        )}
+
+        <div className="flex items-center gap-2">
+          <Button size="sm" disabled={!dirty || save.isPending} onClick={() => save.mutate(draft)}>
+            {save.isPending ? 'Saving…' : 'Save'}
+          </Button>
+          {on && (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={save.isPending}
+              onClick={() => save.mutate({ ...draft, enabled: false })}
+            >
+              Go live — stop holding mail
+            </Button>
+          )}
+          {dirty && <span className="text-xs text-muted-foreground">Unsaved changes</span>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/admin/email/__tests__/outbound-guard-panel.test.tsx
+++ b/src/components/admin/email/__tests__/outbound-guard-panel.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { OutboundGuardPanel } from '../OutboundGuardPanel';
+
+/**
+ * The panel exists because the guard was invisible: a rule only the database
+ * knew about, which blocked a colleague invitation this morning and told the
+ * admin nothing but an HTTP status.
+ *
+ * Its most important job is NOT the on/off switch. The dangerous mistake is the
+ * opposite of the one the guard prevents — going live with it still on, so
+ * invoices quietly never arrive. So the count of held sends has to be loud, and
+ * "go live" has to be one obvious action.
+ */
+
+const save = vi.fn();
+let allowlist: unknown = null;
+let withheld = { rows: [] as Array<Record<string, unknown>>, total: 0 };
+
+vi.mock('@/hooks/useEmailAllowlist', () => ({
+  useEmailAllowlist: () => ({ data: allowlist, isLoading: false }),
+  useWithheldEmails: () => ({ data: withheld }),
+  useUpdateEmailAllowlist: () => ({ mutate: save, isPending: false }),
+}));
+
+function show() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <OutboundGuardPanel />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  save.mockReset();
+  withheld = { rows: [], total: 0 };
+  allowlist = { enabled: true, domains: ['optictunnels.eu'], addresses: [], scope: 'customer_facing' };
+});
+
+describe('an instance that is holding mail says so', () => {
+  it('leads with the state, not with settings', () => {
+    show();
+    expect(screen.getByText(/This instance is not live yet/i)).toBeInTheDocument();
+    // The badge sits inside the title, so both the badge and its parent match.
+    expect(screen.getAllByText(/holding mail/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows what was actually held — consequence before configuration', () => {
+    withheld = {
+      total: 4,
+      rows: [{
+        id: '1', recipient: 'peter@optictunnels.com', subject: 'Invitation',
+        source: 'invite-colleague', created_at: '2026-08-10T10:22:00Z',
+      }],
+    };
+    show();
+    expect(screen.getByText(/4 sends were held back/i)).toBeInTheDocument();
+    expect(screen.getByText('peter@optictunnels.com')).toBeInTheDocument();
+    // Nobody should think turning the guard off releases a backlog.
+    expect(screen.getByText(/they are not delivered when the guard is turned off/i)).toBeInTheDocument();
+  });
+
+  it('offers going live as ONE action, and that action turns it off', () => {
+    show();
+    fireEvent.click(screen.getByRole('button', { name: /Go live/i }));
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it('warns when the list is empty, because that withholds everything', () => {
+    allowlist = { enabled: true, domains: [], addresses: [], scope: 'customer_facing' };
+    show();
+    expect(screen.getByText(/every send is withheld/i)).toBeInTheDocument();
+  });
+
+  it('explains why colleagues still get mail under customer_facing', () => {
+    // The false positive that started this: blocking your own team trains
+    // people to switch the guard off.
+    show();
+    expect(screen.getByText(/blocking your own team trains people to switch it off/i)).toBeInTheDocument();
+  });
+});
+
+describe('an instance that is live says that too', () => {
+  beforeEach(() => {
+    allowlist = { enabled: false, domains: [], addresses: [], scope: 'customer_facing' };
+  });
+
+  it('does not pretend to be guarding', () => {
+    show();
+    expect(screen.getByText(/^Outbound guard$/)).toBeInTheDocument();
+    expect(screen.getByText(/this instance mails anyone/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Go live/i })).not.toBeInTheDocument();
+  });
+
+  it('still shows what was held earlier, so history does not vanish on going live', () => {
+    withheld = {
+      total: 2,
+      rows: [{
+        id: '1', recipient: 'kund@example.com', subject: 'Invoice',
+        source: 'send_invoice', created_at: '2026-08-09T09:00:00Z',
+      }],
+    };
+    show();
+    expect(screen.getByText(/2 sends were held back/i)).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useEmailAllowlist.ts
+++ b/src/hooks/useEmailAllowlist.ts
@@ -1,0 +1,79 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+
+/**
+ * The outbound allowlist — an instance that is installed but not live yet.
+ *
+ * Every FlowWink instance passes through a period where someone rehearses
+ * order-to-cash on real data. The guard holds customer mail during that period
+ * so the rehearsal cannot reach a customer, and it is the only shape that works:
+ * "remember to use a test address" is a convention, and conventions fail the
+ * first time somebody — or an agent being realistic with a real CRM record —
+ * forgets.
+ *
+ * The riskier failure is the OTHER direction: going live and forgetting to turn
+ * it off, so invoices quietly never arrive. That is why this hook also reads the
+ * held-back count. A guard nobody can see is a guard nobody switches off.
+ */
+export interface EmailAllowlist {
+  enabled: boolean;
+  domains: string[];
+  addresses: string[];
+  reason?: string;
+  scope?: 'all' | 'customer_facing';
+}
+
+const SETTING_KEY = 'email_allowlist';
+
+export function useEmailAllowlist() {
+  return useQuery({
+    queryKey: ['email-allowlist'],
+    queryFn: async (): Promise<EmailAllowlist | null> => {
+      const { data, error } = await supabase
+        .from('site_settings')
+        .select('value')
+        .eq('key', SETTING_KEY)
+        .maybeSingle();
+      if (error) throw error;
+      return (data?.value ?? null) as EmailAllowlist | null;
+    },
+  });
+}
+
+/** What the guard actually held back, so the panel shows consequence, not config. */
+export function useWithheldEmails(limit = 10) {
+  return useQuery({
+    queryKey: ['email-allowlist-withheld', limit],
+    queryFn: async () => {
+      const { data, error, count } = await supabase
+        .from('outbound_communications')
+        .select('id, recipient, subject, source, created_at', { count: 'exact' })
+        .eq('status', 'blocked')
+        .order('created_at', { ascending: false })
+        .limit(limit);
+      if (error) throw error;
+      return { rows: data ?? [], total: count ?? 0 };
+    },
+  });
+}
+
+export function useUpdateEmailAllowlist() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (next: EmailAllowlist) => {
+      const { error } = await supabase
+        .from('site_settings')
+        .upsert({ key: SETTING_KEY, value: next as never }, { onConflict: 'key' });
+      if (error) throw error;
+      return next;
+    },
+    onSuccess: (next) => {
+      qc.invalidateQueries({ queryKey: ['email-allowlist'] });
+      toast.success(next.enabled
+        ? 'Outbound guard updated'
+        : 'This instance is live — outbound mail is no longer held back');
+    },
+    onError: (e: Error) => toast.error(`Could not save: ${e.message}`),
+  });
+}

--- a/src/lib/__tests__/invite-colleague.guardrails.test.ts
+++ b/src/lib/__tests__/invite-colleague.guardrails.test.ts
@@ -82,7 +82,10 @@ describe('the backend gates and reconciles correctly', () => {
     // an early return in the mail branch.
     const code = fn.split('\n').filter((l) => !l.trim().startsWith('//')).join('\n');
     const upsertAt = code.indexOf('user_roles").upsert');
-    const mailAt = code.indexOf('invoke("email-send"');
+    // Anchor inside the INVITE branch: the reset branch also sends mail, and
+    // it returns early by design (it grants no role and has none to reconcile).
+    const inviteAt = code.indexOf('type: "invite"');
+    const mailAt = code.indexOf('invoke("email-send"', inviteAt);
     expect(upsertAt).toBeGreaterThan(mailAt); // reconciliation comes after, unconditionally
     const mailBranch = code.slice(mailAt, upsertAt);
     expect(mailBranch).not.toMatch(/return json/);
@@ -103,5 +106,51 @@ describe('the backend gates and reconciles correctly', () => {
     expect(cleanupAt).toBeGreaterThan(-1);
     const guard = code.slice(code.lastIndexOf('if (', cleanupAt), cleanupAt);
     expect(guard).toMatch(/status !== "granted_existing"|status === "invited"/);
+  });
+});
+
+describe('an invitation lands on the password step, not past it', () => {
+  /**
+   * Two colleagues were invited and walked straight into the dashboard with a
+   * live session and no password ever set. The verify-link pointed at /admin,
+   * so the activation screen — which exists, and is the only place that calls
+   * updateUser({password}) on an invited account — was simply never reached.
+   *
+   * The consequences are both ways round: they could not sign in a second time,
+   * and anyone holding a forwarded copy of that link was equally admitted.
+   */
+  it('sends the invite to the activation screen, carrying where to go after', () => {
+    expect(fn).toMatch(/\/account\/activate\?next=\/admin/);
+    expect(fn).not.toMatch(/const redirectTo = `\$\{siteUrl\}\/admin`/);
+  });
+
+  it('resolves the site URL ONE way for every link it makes', () => {
+    // The reset branch arrived with its own resolver reading a different
+    // source. Two ways to answer the same question in one file is how the
+    // answers drift.
+    expect((fn.match(/async function resolveSiteUrl/g) ?? []).length).toBe(1);
+    expect((fn.match(/await resolveSiteUrl\(admin, req\)/g) ?? []).length).toBe(2);
+  });
+});
+
+describe('an admin can hand a colleague a way back in', () => {
+  it('offers a password reset, because re-inviting an existing user mails nothing', () => {
+    expect(fn).toMatch(/action === "reset_password"/);
+    expect(fn).toMatch(/type: "recovery"/);
+    expect(fn).toMatch(/No account for \$\{cleanEmail\}\. Invite them first\./);
+  });
+
+  it('sends it through the operator’s own rail, like the invitation', () => {
+    expect(fn).toMatch(/source: "colleague-password-reset"/);
+    const allowlist = readFileSync(
+      resolve(__dirname, '../../../supabase/functions/_shared/email-allowlist.ts'), 'utf-8');
+    // A reset for a colleague is internal — holding it would be the same false
+    // positive that blocked the invitation.
+    expect(allowlist).toMatch(/'colleague-password-reset',/);
+  });
+
+  it('never claims a send that did not happen', () => {
+    expect(fn).toMatch(/status: "reset_no_mail"/);
+    expect(fn).toMatch(/blocked_by_allowlist/);
   });
 });

--- a/src/pages/account/ActivateAccountPage.tsx
+++ b/src/pages/account/ActivateAccountPage.tsx
@@ -13,7 +13,7 @@
  * No valid invite session → an honest dead-end, not a signup form.
  */
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -24,6 +24,7 @@ import { toast } from 'sonner';
 
 export default function ActivateAccountPage() {
   const navigate = useNavigate();
+  const [params] = useSearchParams();
   const [status, setStatus] = useState<'checking' | 'ready' | 'invalid'>('checking');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -68,7 +69,13 @@ export default function ActivateAccountPage() {
       const { error } = await supabase.auth.updateUser({ password });
       if (error) throw error;
       toast.success('Welcome — your account is ready.');
-      navigate('/account');
+      // Where the invitation was headed. A colleague invited to the admin should
+      // land in the admin, a portal customer in the portal — one activation
+      // screen, two destinations, rather than a second copy of a password form.
+      // Relative paths only: an open redirect on a page that hands out a session
+      // is how an invitation link becomes somebody else's.
+      const next = params.get('next');
+      navigate(next && next.startsWith('/') && !next.startsWith('//') ? next : '/account');
     } catch (e) {
       toast.error((e as Error).message);
     } finally {

--- a/src/pages/admin/UsersPage.tsx
+++ b/src/pages/admin/UsersPage.tsx
@@ -25,7 +25,7 @@ import {
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Shield, User, Settings2, Trash2 } from 'lucide-react';
+import { Shield, User, Settings2, Trash2, KeyRound } from 'lucide-react';
 import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader,
@@ -114,6 +114,39 @@ export default function UsersPage() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin-users'] });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  /**
+   * The way back in for a colleague who has an account but cannot sign into it:
+   * invited before the activation screen existed, or simply forgot. Re-inviting
+   * does nothing — an existing user is granted the role and mailed nothing —
+   * so without this an admin had no move at all.
+   */
+  const resetPassword = useMutation({
+    mutationFn: async (email: string) => {
+      const { data, error } = await supabase.functions.invoke('invite-colleague', {
+        body: { action: 'reset_password', email },
+      });
+      if (error) throw new Error(error.message);
+      const res = data as { status?: string; action_link?: string; mail_problem?: string; error?: string };
+      if (res?.error) throw new Error(res.error);
+      return res;
+    },
+    onSuccess: (res) => {
+      if (res.status === 'reset_sent') {
+        toast({ title: 'Password link sent', description: 'They can set a new password from the email.' });
+      } else {
+        // Honest: the link exists, the mail did not go. Hand it over rather
+        // than claim a send that never happened.
+        toast({
+          title: 'Email not sent — pass the link on yourself',
+          description: `${res.mail_problem ?? ''} ${res.action_link ?? ''}`.trim(),
+        });
+      }
     },
     onError: (error: Error) => {
       toast({ title: 'Error', description: error.message, variant: 'destructive' });
@@ -303,6 +336,15 @@ export default function UsersPage() {
                           {new Date(user.created_at).toLocaleDateString('en-US')}
                         </TableCell>
                         <TableCell className="text-right">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            disabled={resetPassword.isPending}
+                            title="Send a link to set a new password"
+                            onClick={() => resetPassword.mutate(user.email)}
+                          >
+                            <KeyRound className="h-4 w-4 text-muted-foreground" />
+                          </Button>
                           <AlertDialog>
                             <AlertDialogTrigger asChild>
                               <Button

--- a/supabase/functions/_shared/email-allowlist.ts
+++ b/supabase/functions/_shared/email-allowlist.ts
@@ -49,6 +49,7 @@ export interface EmailAllowlist {
 export const INTERNAL_SOURCES = new Set([
   'invite-colleague',
   'invite-employee',
+  'colleague-password-reset',
   'platform-test',
   'run-platform-tests',
 ]);

--- a/supabase/functions/invite-colleague/index.ts
+++ b/supabase/functions/invite-colleague/index.ts
@@ -36,6 +36,22 @@ const INVITABLE_ROLES = [
   "warehouse", "marketing", "purchasing", "projects",
 ];
 
+/**
+ * Where the invitation link should point. The instance's configured site URL
+ * first — the origin header is whatever browser the admin happened to use, and
+ * an early invitation once shipped a link aimed at the sender's own laptop.
+ * The header stays as the local-dev fallback.
+ *
+ * One resolver, because the invite branch and the reset branch had two and that
+ * is how the two drift.
+ */
+async function resolveSiteUrl(admin: ReturnType<typeof getServiceClient>, req: Request): Promise<string> {
+  const { data: general } = await admin
+    .from("site_settings").select("value").eq("key", "general").maybeSingle();
+  return ((general?.value as { siteUrl?: string } | null)?.siteUrl ?? "").replace(/\/+$/, "")
+    || (req.headers.get("origin") ?? "").replace(/\/+$/, "");
+}
+
 serve(async (req: Request) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
   if (req.method !== "POST") return json({ error: "Method not allowed" }, 405);
@@ -55,14 +71,80 @@ serve(async (req: Request) => {
     });
     if (!isAdmin) return json({ error: "Admin role required" }, 403);
 
-    const { email, role, full_name } = (await req.json()) as {
-      email?: string; role?: string; full_name?: string;
+    const { email, role, full_name, action } = (await req.json()) as {
+      email?: string; role?: string; full_name?: string; action?: string;
     };
 
     const cleanEmail = (email ?? "").trim().toLowerCase();
     if (!cleanEmail || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(cleanEmail)) {
       return json({ error: "A valid email is required." }, 400);
     }
+    // ── Password reset ──────────────────────────────────────────────────
+    // The recovery path for a colleague who has an account but cannot sign in:
+    // invited before the activation screen existed, forgot their password, or
+    // was created with one they never received. Re-inviting does not help —
+    // an existing user is granted the role and mailed nothing.
+    //
+    // generateLink again, not resetPasswordForEmail: the mail must go through
+    // the operator's own rail (verified domain, branded shell, allowlist, no
+    // shared-sender cap) exactly like the invitation does.
+    if (action === "reset_password") {
+      const { data: users } = await admin.auth.admin.listUsers({ page: 1, perPage: 200 });
+      const target = users?.users?.find((u) => u.email?.toLowerCase() === cleanEmail);
+      if (!target) {
+        return json({ error: `No account for ${cleanEmail}. Invite them first.` }, 404);
+      }
+
+      const siteUrl = await resolveSiteUrl(admin, req);
+      const { data: linkData, error: linkErr } = await admin.auth.admin.generateLink({
+        type: "recovery",
+        email: cleanEmail,
+        options: { redirectTo: `${siteUrl}/account/activate?next=/admin` },
+      });
+      if (linkErr || !linkData?.properties?.action_link) {
+        return json({ error: linkErr?.message ?? "Could not create reset link" }, 500);
+      }
+      const link = linkData.properties.action_link;
+
+      const { data: sendData, error: sendErr } = await admin.functions.invoke("email-send", {
+        body: {
+          to: cleanEmail,
+          subject: "Set a new password",
+          html: `<h2 style="margin:0 0 12px">Set a new password</h2>
+            <p>An administrator asked us to send you a link to set a new password.</p>
+            <p><a href="${link}" style="display:inline-block;background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none">Set my password</a></p>
+            <p style="color:#666;font-size:13px">If you did not expect this, you can ignore it — the link expires and nothing changes until you use it.</p>`,
+          source: "colleague-password-reset",
+          tags: { source: "colleague-password-reset" },
+        },
+      });
+
+      const simulated = Boolean((sendData as { simulated?: boolean } | null)?.simulated);
+      const mailed = !sendErr && Boolean((sendData as { success?: boolean } | null)?.success) && !simulated;
+      if (mailed) return json({ status: "reset_sent", email: cleanEmail });
+
+      // Same honesty as the invitation: the admin gets the link to pass on
+      // rather than a false "sent", and the reason rather than an HTTP status.
+      let reason = sendErr?.message ?? "unknown error";
+      const ctx = (sendErr as { context?: Response } | null)?.context;
+      if (ctx && typeof ctx.json === "function") {
+        try {
+          const body = await ctx.json() as { blocked_by_allowlist?: boolean; error?: string; how_to_change?: string };
+          if (body?.blocked_by_allowlist) {
+            reason = `${body.error ?? "Recipient is outside this instance's email allowlist."} ${body.how_to_change ?? ""}`.trim();
+          } else if (body?.error) reason = body.error;
+        } catch { /* not JSON */ }
+      }
+      return json({
+        status: "reset_no_mail",
+        email: cleanEmail,
+        action_link: link,
+        mail_problem: simulated
+          ? "No email provider is configured — send this link yourself."
+          : reason,
+      });
+    }
+
     if (!role || !INVITABLE_ROLES.includes(role)) {
       return json({ error: `role must be one of: ${INVITABLE_ROLES.join(", ")}` }, 400);
     }
@@ -102,11 +184,15 @@ serve(async (req: Request) => {
       // from install, so the first real invitation shipped a link pointing at
       // the recipient's own machine. Falling back to the header keeps local
       // dev working.
-      const { data: general } = await admin
-        .from("site_settings").select("value").eq("key", "general").maybeSingle();
-      const siteUrl = ((general?.value as { siteUrl?: string } | null)?.siteUrl ?? "").replace(/\/+$/, "")
-        || (req.headers.get("origin") ?? "");
-      const redirectTo = `${siteUrl}/admin`;
+      const siteUrl = await resolveSiteUrl(admin, req);
+      // Land on the activation screen, NOT straight in the admin. Pointing an
+      // invite verify-link at /admin gave the colleague a live session and no
+      // password: they were in, and could never sign in again without another
+      // link. Anyone holding a forwarded copy of that link was equally in.
+      // /account/activate is the one place that sets a password on an invited
+      // account; `next` sends a colleague to the admin afterwards and a portal
+      // customer to the portal, so there is one screen and not two copies.
+      const redirectTo = `${siteUrl}/account/activate?next=/admin`;
       const { data: linkData, error: linkErr } = await admin.auth.admin.generateLink({
         type: "invite",
         email: cleanEmail,

--- a/supabase/functions/invite-employee/index.ts
+++ b/supabase/functions/invite-employee/index.ts
@@ -84,7 +84,10 @@ Deno.serve(async (req) => {
       userId = found.id;
     } else {
       // Send invite
-      const redirectTo = `${req.headers.get("origin") ?? ""}/account`;
+      // The activation screen, not the portal itself — same reason as
+      // invite-colleague: an invite link that lands past the password step
+      // leaves an account nobody can sign into twice.
+      const redirectTo = `${req.headers.get("origin") ?? ""}/account/activate`;
       const { data: invited, error: inviteErr } = await admin.auth.admin.inviteUserByEmail(emp.email, {
         data: { full_name: emp.name, signup_type: "employee" },
         redirectTo,

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1519,7 +1519,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:17b7d2e5641573ef27ea2ec0aa5eedb608a4671df4a6367fcac4e051beec34eb",
+      "shared_hash": "sha256:cd3db4af484e41852fb5fc70d45fa9691259541b5fb0860fcdf5e71060d80397",
       "functions": {
         "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
@@ -1563,8 +1563,8 @@
         "gmail-oauth-callback": "sha256:b851b5a37da669b8dc506d399417619361317d008a2ac17a3b3cfda4dfff0dea",
         "instance-health": "sha256:19ed2278f4b6656d7923caf70627fe107e529a53ac7f3c5327117bccc55cbf1a",
         "integrations-account": "sha256:97349b1f66e6a4e628de49bd36473af4f5c19726174c30e3b47ff4c594d68e29",
-        "invite-colleague": "sha256:9080c0ce1d633eda3da606fd9bc03c304e7051d75fb7d201a07602bbb94da932",
-        "invite-employee": "sha256:87bf2502e9d9e67f6d659342ef5abaca3009eb46e0fa9937c833b465f3c4efcd",
+        "invite-colleague": "sha256:cad6246a2988ca3c780cb3497707a4d818e311f3b1bf704957b3754b9d86b5b3",
+        "invite-employee": "sha256:354d9ecbcc20ff402597a0e4c10875807c1a140ace0c5c06505ff8fc9fe13eb5",
         "knowledge-indexer": "sha256:c6f628a21822a011e37b3719ef639f93b0dedab23c5becc0255e0c16e9c31289",
         "llms-txt": "sha256:0a8a132d383590b810617ff9cdcd4893980208233d0c26b65d6c17a80af4f452",
         "mcp-server": "sha256:3cb3f630ad868ee15eb2c559e50af08449af876d3856ba0557f9c2ab9300d2b4",


### PR DESCRIPTION
## Två kollegor kom in utan att sätta lösenord

Verify-länken pekade på `/admin`. `/account/activate` — som finns, och är det
enda stället som anropar `updateUser({password})` på ett inbjudet konto — nåddes
aldrig.

Det skär åt två håll: de kan inte logga in en andra gång, för det finns inget
lösenord att logga in med, och **vem som helst med en vidarebefordrad kopia av
länken kommer in lika lätt**. `invite-employee` pekade en dörr bort, på
`/account`, med samma resultat.

Båda landar nu på aktiveringssidan, som lärt sig en `next`-parameter: en kollega
fortsätter in i admin, en portalkund in i portalen. En lösenordssida med två
destinationer i stället för två kopior av formuläret. Bara relativa sökvägar —
en öppen omdirigering på sidan som delar ut en session är hur en inbjudan blir
någon annans.

## Och en väg tillbaka

Admin kan skicka lösenordsåterställning. Det är återvägen för precis de konton
buggen skapade: att bjuda in en befintlig användare igen ger rollen och skickar
ingenting, så innan detta fanns inget drag alls.

Samma räls som inbjudan (`generateLink`, inte `resetPasswordForEmail` — egen
verifierad domän, brandat skal, tillåtlistan, inget delat avsändartak) och samma
ärlighet: ett blockerat eller okonfigurerat utskick ger admin länken i stället
för att påstå en leverans.

Reset-grenen kom med en egen uppslagning av site-URL som läste en annan källa än
inbjudan. En resolver nu — två svar på samma fråga i samma fil är precis hur de
glider isär.

## Spärren får ett ansikte

Med i samma tråd: tillåtlistan var en regel bara databasen kände till, vilket är
varför den kunde blockera en kollegainbjudan utan att kunna säga något om det.

Panelen leder med konsekvens i stället för konfiguration — hur många utskick som
hållits tillbaka och vilka — för det farliga misstaget är motsatsen till det
spärren förhindrar: att gå skarpt med den kvar på, så att fakturor tyst aldrig
kommer fram. "Go live" är en enda tydlig handling.

2 203 tester gröna. Optic redan deployat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)