### PR TITLE
En sond måste testa det plattformen faktiskt gör

### DIFF
--- a/src/lib/__tests__/integration-health.guardrails.test.ts
+++ b/src/lib/__tests__/integration-health.guardrails.test.ts
@@ -54,3 +54,40 @@ describe('integration health', () => {
     expect(h, 'a probe issues a POST — probes must be reads').not.toMatch(/method:\s*'POST'/);
   });
 });
+
+describe('a probe must test what the platform actually does', () => {
+  /**
+   * optic's FlowChat reported "resend: key rejected (HTTP 401) — rotate or
+   * re-enter the API key" about a key that had sent a colleague invitation
+   * fourteen minutes earlier and a password reset four minutes earlier.
+   *
+   * The probe hit GET /domains. The platform sends with POST /emails. A Resend
+   * key scoped to "Sending access" — least privilege, the right choice — is
+   * refused by /domains. So the health check failed a working integration, and
+   * the remedy it suggested (rotate the key) would have broken a working one.
+   *
+   * A warning that fires on a healthy system teaches people to ignore warnings.
+   */
+  const src = read('supabase/functions/_shared/handlers/check-integrations.ts');
+
+  it('asks the outbound log before it asks the vendor', () => {
+    const resendBlock = src.slice(src.indexOf('resend: async'), src.indexOf('openai:'));
+    expect(resendBlock).toMatch(/from\('outbound_communications'\)/);
+    expect(resendBlock).toMatch(/\.eq\('provider', 'resend'\)/);
+    expect(resendBlock).toMatch(/\.eq\('status', 'sent'\)/);
+    // A delivered mail is proof on the real path — stronger than any probe.
+    expect(resendBlock).toMatch(/sending works — last delivered/);
+  });
+
+  it('does not tell you to rotate a key it cannot actually judge', () => {
+    const resendBlock = src.slice(src.indexOf('resend: async'), src.indexOf('openai:'));
+    expect(resendBlock).not.toMatch(/rotate or re-enter/);
+    expect(resendBlock).toMatch(/cannot verify from here/);
+    expect(resendBlock).toMatch(/a sending-only key is refused by \/domains/);
+  });
+
+  it('the probe signature carries the client, so evidence stays available', () => {
+    expect(src).toMatch(/supabase: SupabaseClient,\n\) => Promise<\{ ok: boolean; detail: string \}>;/);
+    expect(src).toMatch(/await probe\(entry\.config \?\? \{\}, supabase\)/);
+  });
+});

--- a/supabase/functions/_shared/handlers/check-integrations.ts
+++ b/supabase/functions/_shared/handlers/check-integrations.ts
@@ -36,7 +36,10 @@ async function timedFetch(url: string, init?: RequestInit): Promise<Response> {
   }
 }
 
-type Probe = (config: Record<string, unknown>) => Promise<{ ok: boolean; detail: string }>;
+type Probe = (
+  config: Record<string, unknown>,
+  supabase: SupabaseClient,
+) => Promise<{ ok: boolean; detail: string }>;
 
 function keyProbe(envKey: string, url: string, init: (key: string) => RequestInit): Probe {
   return async () => {
@@ -89,9 +92,48 @@ const PROBES: Record<string, Probe> = {
     headers: { Authorization: `Bearer ${k}` },
   })),
 
-  resend: keyProbe('RESEND_API_KEY', 'https://api.resend.com/domains', (k) => ({
-    headers: { Authorization: `Bearer ${k}` },
-  })),
+  // Evidence before probe. A Resend key scoped to "Sending access" — the
+  // correct, least-privilege choice, and what optic uses — can POST /emails but
+  // gets 401 on GET /domains. The old probe hit /domains and reported "key
+  // rejected — rotate the key" about a key that had sent an invitation
+  // fourteen minutes earlier. A warning that fires on a working system teaches
+  // people to ignore warnings.
+  //
+  // So: ask the platform's own outbound log first. A recent successful send IS
+  // the health check, performed on the real path, in production, for free.
+  // Only with no such evidence does it fall back to the management endpoint —
+  // and a 401 there says what it can honestly say, which is that this endpoint
+  // cannot tell.
+  resend: async (_config, supabase) => {
+    const key = Deno.env.get('RESEND_API_KEY');
+    if (!key) return { ok: false, detail: 'RESEND_API_KEY is not set in edge function secrets' };
+
+    const since = new Date(Date.now() - 7 * 24 * 3600_000).toISOString();
+    const { data: recent } = await supabase
+      .from('outbound_communications')
+      .select('created_at')
+      .eq('provider', 'resend')
+      .eq('status', 'sent')
+      .gte('created_at', since)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (recent?.length) {
+      const when = String(recent[0].created_at).slice(0, 16).replace('T', ' ');
+      return { ok: true, detail: `sending works — last delivered ${when} UTC` };
+    }
+
+    const res = await timedFetch('https://api.resend.com/domains', {
+      headers: { Authorization: `Bearer ${key}` },
+    });
+    if (res.ok) return { ok: true, detail: `auth ok (HTTP ${res.status})` };
+    if (res.status === 401 || res.status === 403) {
+      return {
+        ok: false,
+        detail: `cannot verify from here (HTTP ${res.status}): a sending-only key is refused by /domains, and nothing has been sent in 7 days to prove otherwise. Send one mail, or check the key.`,
+      };
+    }
+    return { ok: false, detail: `unexpected HTTP ${res.status}` };
+  },
 
   openai: keyProbe('OPENAI_API_KEY', 'https://api.openai.com/v1/models', (k) => ({
     headers: { Authorization: `Bearer ${k}` },
@@ -231,7 +273,7 @@ export async function executeCheckIntegrations(
       }
       const started = Date.now();
       try {
-        const r = await probe(entry.config ?? {});
+        const r = await probe(entry.config ?? {}, supabase);
         results.push({
           name,
           status: r.ok ? 'ok' : 'fail',

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1519,7 +1519,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:cd3db4af484e41852fb5fc70d45fa9691259541b5fb0860fcdf5e71060d80397",
+      "shared_hash": "sha256:d433f1f397c7ba310d13635f33a7c26ee75df547e17e497400aee4498755f174",
       "functions": {
         "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",


### PR DESCRIPTION
Optics FlowChat rapporterade *"resend: key rejected (HTTP 401) — rotate or
re-enter the API key"* om en nyckel som hade skickat en kollegainbjudan fjorton
minuter tidigare och en lösenordsåterställning fyra minuter tidigare.

Sonden slog mot `GET /domains`. Plattformen skickar med `POST /emails`. En
Resend-nyckel med enbart *Sending access* — minsta möjliga behörighet, alltså
rätt val — nekas av `/domains`. Hälsokontrollen underkände en fungerande
integration, och åtgärden den föreslog hade slagit sönder en som fungerade.

**Bevis före sond.** Fråga plattformens egen utgående logg först: ett levererat
mejl de senaste sju dagarna *är* hälsokontrollen, utförd på den riktiga vägen, i
produktion, gratis. Bara utan sådant bevis faller den tillbaka på
administrations-endpointen — och ett 401 där säger nu vad den ärligt kan säga,
att den inte kan avgöra saken, i stället för att peka ut en skyldig.

Sondsignaturen bär nu klienten, så samma bevis-först-form är tillgänglig för
varje sond som har spår av sina egna lyckade anrop.

Tredje varianten idag av samma tema, värd att namnge: **en varning som utlöses
på ett friskt system lär folk att sluta läsa varningar.** Momsrapportens
3001-flagga, tillåtlistan som stoppade Peter, och nu den här.

2 206 tester gröna. Optic redan deployat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)