### PR TITLE
feat(flowtable): delat är default, privat är beslutet

### DIFF
--- a/src/lib/__tests__/flowtable-default-shared.guardrails.test.ts
+++ b/src/lib/__tests__/flowtable-default-shared.guardrails.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Sharing is the default; private is the decision.
+ *
+ * Documents already worked this way (`visibility` defaults to 'shared').
+ * Flowtable did not: `workspace_shared` defaulted to FALSE, so a base was born
+ * invisible to everyone but its author — staying private took no decision while
+ * sharing took one per base. That inverts what a shared operating platform is
+ * for: the transparency, and the context an agent needs to act on the
+ * business's behalf. A base nobody can see is one FlowPilot cannot reason about.
+ *
+ * The whole tree hangs off one helper — can_access_flowtable_base() resolves
+ * "owner OR shared" and the tables/fields/records policies all defer to it — so
+ * the default is the only thing that moves.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const strip = (s: string) => s.replace(/--[^\n]*/g, '');
+
+const sql = strip(read('supabase/migrations/20260810110000_flowtable-default-shared.sql'));
+// Comments are stripped before any assertion about the code: a negative
+// assertion trips on the very comment that explains what was removed. That
+// exact trap has fired twice in this repo — once on a policy body, once on a
+// docstring mentioning localStorage.
+const page = read('src/pages/admin/FlowtablePage.tsx')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/[^\n]*$/gm, '');
+
+describe('a new base is shared unless someone decides otherwise', () => {
+  it('flips the column default to true', () => {
+    expect(sql).toMatch(/ALTER TABLE public\.flowtable_bases\s+ALTER COLUMN workspace_shared SET DEFAULT true/);
+  });
+
+  it('matches how documents already behave', () => {
+    // documents.visibility defaults to 'shared'. One platform, one rule.
+    expect(sql).not.toMatch(/SET DEFAULT false/i);
+  });
+});
+
+describe('history is not republished', () => {
+  it('does not backfill existing private bases', () => {
+    // A base sitting at FALSE may be private by choice or by the old default,
+    // and nothing records which. Publishing a sheet someone meant to keep
+    // private cannot be undone; leaving one private for another day is a
+    // switch. The asymmetry decides it — same as the allowlist's fail-closed.
+    expect(sql).not.toMatch(/UPDATE\s+public\.flowtable_bases/i);
+    expect(sql).not.toMatch(/SET workspace_shared\s*=\s*true/i);
+  });
+
+  it('changes no policy — the access helper already said "owner or shared"', () => {
+    expect(sql).not.toMatch(/CREATE POLICY|DROP POLICY|can_access_flowtable_base/);
+  });
+});
+
+describe('the UI marks the exception, not the rule', () => {
+  it('badges a private base with a lock instead of badging every shared one', () => {
+    expect(page).toMatch(/!b\.workspace_shared && \(/);
+    expect(page).toMatch(/<Lock className="h-3 w-3/);
+  });
+
+  it('labels the switch by its actual state, in both directions', () => {
+    // "Share with workspace" read as an invitation to opt in — backwards once
+    // the switch is how you opt OUT.
+    expect(page).toMatch(/Shared with colleagues/);
+    expect(page).toMatch(/Private to you/);
+    expect(page).not.toMatch(/Share with workspace/);
+  });
+
+  it('says what private costs — the agent loses sight of it too', () => {
+    expect(page).toMatch(/neither can FlowPilot/);
+  });
+});

--- a/src/pages/admin/FlowtablePage.tsx
+++ b/src/pages/admin/FlowtablePage.tsx
@@ -34,7 +34,7 @@ import { useToast } from '@/hooks/use-toast';
 import {
   Table2, Plus, Download, Upload, MoreHorizontal, Trash2, ChevronDown, LayoutGrid, List as ListIcon, Rows3,
   Send, Users, X, Database, PanelLeft, PanelRight, Filter, ArrowUpDown, Columns3, GripVertical,
-  Maximize2, ChevronLeft, ChevronRight, WrapText,
+  Maximize2, ChevronLeft, ChevronRight, WrapText, Lock,
 } from 'lucide-react';
 import {
   useFlowtableBases, useCreateBase, useUpdateBase, useDeleteBase,
@@ -605,7 +605,12 @@ export default function FlowtablePage() {
                   {!basesMinimized && (
                     <>
                       <span className="flex-1 truncate">{b.name}</span>
-                      {b.workspace_shared && <Users className="h-3 w-3 text-muted-foreground" />}
+                      {/* Mark the exception, not the rule. Shared is the default
+                          now, so a group icon on almost every row says nothing —
+                          a lock on the few private ones says everything. */}
+                      {!b.workspace_shared && (
+                        <Lock className="h-3 w-3 text-muted-foreground" aria-label="Private — only you can see this base" />
+                      )}
                     </>
                   )}
                 </button>
@@ -644,14 +649,26 @@ export default function FlowtablePage() {
                   }
                   className="bg-transparent border-0 outline-none text-base font-semibold flex-1 min-w-0"
                 />
+                {/* The label follows the state instead of naming one direction.
+                    "Share with workspace" read as an invitation to opt in, which
+                    is backwards now that shared is the default — the switch is
+                    how you opt OUT. */}
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <Label htmlFor="ws-share" className="cursor-pointer flex items-center gap-1.5">
-                    <Users className="h-3.5 w-3.5" />
-                    Share with workspace
+                    {activeBase.workspace_shared ? (
+                      <><Users className="h-3.5 w-3.5" /> Shared with colleagues</>
+                    ) : (
+                      <><Lock className="h-3.5 w-3.5" /> Private to you</>
+                    )}
                   </Label>
                   <Switch
                     id="ws-share"
                     checked={activeBase.workspace_shared}
+                    title={
+                      activeBase.workspace_shared
+                        ? 'Everyone can see this base. Switch off to make it private.'
+                        : 'Only you can see this base — and neither can FlowPilot. Switch on to share it.'
+                    }
                     onCheckedChange={(v) =>
                       updateBase.mutate({ id: activeBase.id, patch: { workspace_shared: v } })
                     }

--- a/supabase/migrations/20260810110000_flowtable-default-shared.sql
+++ b/supabase/migrations/20260810110000_flowtable-default-shared.sql
@@ -1,0 +1,37 @@
+-- Flowtable follows the platform's rule: shared is the default, private is the choice.
+--
+-- Documents already work this way — `documents.visibility` defaults to 'shared'
+-- and a colleague marks the exception. Flowtable was the odd one out:
+-- `workspace_shared` defaulted to FALSE, so every base was born invisible to
+-- everyone but its author, and staying private required no decision at all
+-- while sharing required one per base.
+--
+-- That inverts the point of the workspace. Someone who needs a private sheet
+-- already has one somewhere else; what a shared operating platform is FOR is
+-- the transparency and the context — including the context an agent needs to
+-- act on the business's behalf. A base nobody can see is a base FlowPilot
+-- cannot reason about either.
+--
+-- The whole tree already hangs off one helper: can_access_flowtable_base()
+-- resolves "owner OR shared", and flowtable_tables / _fields / _records all
+-- defer to it. So the default is the only thing that has to move; no policy
+-- changes, no new column.
+--
+-- EXISTING PRIVATE BASES ARE LEFT ALONE — deliberately, and this is the part
+-- worth arguing about. A base sitting at FALSE today might be private by
+-- deliberate choice or merely by inheriting the old default, and nothing in the
+-- schema records which. The failure modes are asymmetric: publishing a sheet
+-- someone meant to keep private cannot be taken back, while a base that stays
+-- private one day longer is one switch away from shared. So the default moves
+-- forward and history stays untouched — the same reasoning as the email
+-- allowlist's fail-closed and the resumption guard's idempotent-only list.
+--
+-- The UI carries the other half: with shared as the norm, the informative badge
+-- is a LOCK on the exception, not a group icon on the rule.
+--
+-- Idempotent.
+ALTER TABLE public.flowtable_bases
+  ALTER COLUMN workspace_shared SET DEFAULT true;
+
+COMMENT ON COLUMN public.flowtable_bases.workspace_shared IS
+  'Visible to every colleague. Defaults to true — sharing is the norm on this platform, as with documents.visibility. Set false to make a base private; existing private bases were not converted when this default flipped.';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -4,7 +4,7 @@
   "layers": {
     "schema": {
       "migration_head": "20260810140000",
-      "migrations_count": 377,
+      "migrations_count": 378,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1501,6 +1501,10 @@
         {
           "version": "20260810095345",
           "name": "c45da418-825b-41cc-8444-6c09ccede03f"
+        },
+        {
+          "version": "20260810110000",
+          "name": "flowtable-default-shared"
         },
         {
           "version": "20260810120000",


### PR DESCRIPTION
Dokumenten fungerade redan så här — `documents.visibility` har default `'shared'` och en kollega markerar undantaget. **Flowtable var den udda:** `workspace_shared` hade default `FALSE`, så en bas föddes osynlig för alla utom sin författare.

Att förbli privat krävde alltså **inget beslut alls**, medan delning krävde ett per bas. Det inverterar poängen med en gemensam plattform: den som behöver ett privat kalkylblad har redan ett någon annanstans, medan det den här ytan erbjuder är transparensen och kontexten — inklusive den kontext en agent behöver för att kunna hjälpa verksamheten framåt. **En bas ingen ser är en bas FlowPilot inte heller kan resonera om**, och det står nu vid reglaget.

## Hela trädet hängde redan på en hjälpfunktion

```sql
can_access_flowtable_base(_base_id)
  → b.owner_id = auth.uid() OR b.workspace_shared = true
```

`flowtable_tables`, `_fields` och `_records` refererar alla till den. Så **defaulten är det enda som flyttar** — inga policyändringar, ingen ny kolumn.

```sql
ALTER TABLE public.flowtable_bases
  ALTER COLUMN workspace_shared SET DEFAULT true;
```

## Befintliga privata baser lämnas ifred — medvetet

Det här är den del som är värd att argumentera om. En bas som står på `FALSE` i dag kan vara privat **av val** eller bara ha ärvt den gamla defaulten, och ingenting i schemat säger vilket.

Felmoderna är asymmetriska: att publicera ett blad någon menade att hålla privat går inte att ta tillbaka, medan en bas som förblir privat en dag till är ett reglage bort. Så defaulten flyttar framåt och historiken står still — samma resonemang som tillåtlistans fail-closed.

## UI:t bär andra halvan

- **Listan**: gruppikonen på varje delad bas ersätts av ett **lås på de få privata**. Markera undantaget, inte regeln — en ikon som sitter på nästan varje rad säger ingenting.
- **Reglaget**: etiketten följer sitt faktiska tillstånd — *"Shared with colleagues"* / *"Private to you"* — i stället för *"Share with workspace"*, som lästes som en inbjudan att slå på något. Nu är reglaget hur man slår **av**.
- **Titeln på det privata läget** säger vad privat kostar: *"Only you can see this base — and neither can FlowPilot."*

## Verifierat

Applicerad och liggarförd på optic. I en rullad-tillbaka transaktion: en ny bas föds med `workspace_shared = true`, och de tre befintliga är oförändrade.

**7 guardrails, var och en negativtestad** — `SET DEFAULT false`, en tillagd backfill-`UPDATE`, och badge på delade i stället för privata ger var för sig en röd. Full svit **2157 passed / 4 skipped**.

En not om testet: kommentarer strippas innan varje negativt påstående om koden. Utan det tripper `not.toMatch(/Share with workspace/)` på den kommentar som förklarar att strängen togs bort — exakt den fälla som slagit till två gånger tidigare i repot.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_