### PR TITLE
Resten av hinkarna som fanns på vissa instanser och i noll migrationer

### DIFF
--- a/supabase/migrations/20260810140000_river-and-cowork-buckets-in-repo.sql
+++ b/supabase/migrations/20260810140000_river-and-cowork-buckets-in-repo.sql
@@ -1,0 +1,75 @@
+-- The rest of the buckets that existed on some instances and in zero migrations.
+--
+-- Two days ago the `documents` bucket turned out to live only on the instances
+-- that happened to get it by hand, so uploads failed with bucket-not-found on
+-- optic and demo. That migration fixed `documents` and its header named the
+-- class — infrastructure that exists only where someone once created it — and
+-- then stopped at the one bucket in front of us.
+--
+-- `river-media` and `cowork-uploads` were the remaining instances of it, and
+-- river's image attach failed on optic today for exactly the same reason. When
+-- a class is named, the sweep belongs in the same breath as the fix.
+--
+-- Config and policies below are read from www, where both features work: the
+-- running fleet is the spec, not a guess. Same method as the documents
+-- migration, and the same reason — a bucket recreated from memory gets its
+-- public flag or its owner check subtly wrong, and a storage policy that is
+-- subtly wrong is either a leak or a support ticket.
+
+-- ── river-media: public read, because river renders images on public pages ──
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('river-media', 'river-media', true)
+ON CONFLICT (id) DO UPDATE SET public = EXCLUDED.public;
+
+DROP POLICY IF EXISTS "river-media public read" ON storage.objects;
+CREATE POLICY "river-media public read" ON storage.objects
+  FOR SELECT TO public
+  USING (bucket_id = 'river-media');
+
+DROP POLICY IF EXISTS "river-media authed upload" ON storage.objects;
+CREATE POLICY "river-media authed upload" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'river-media');
+
+-- Only what you put there. Deleting someone else's attachment out of a shared
+-- feed is not a thing any river user should be able to do by accident.
+DROP POLICY IF EXISTS "river-media owner delete" ON storage.objects;
+CREATE POLICY "river-media owner delete" ON storage.objects
+  FOR DELETE TO authenticated
+  USING (bucket_id = 'river-media' AND owner = auth.uid());
+
+-- ── cowork-uploads: private, and scoped to the uploader's own folder ────────
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('cowork-uploads', 'cowork-uploads', false)
+ON CONFLICT (id) DO UPDATE SET public = EXCLUDED.public;
+
+DROP POLICY IF EXISTS "cowork own upload" ON storage.objects;
+CREATE POLICY "cowork own upload" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'cowork-uploads'
+              AND (storage.foldername(name))[1] = (auth.uid())::text);
+
+DROP POLICY IF EXISTS "cowork own read" ON storage.objects;
+CREATE POLICY "cowork own read" ON storage.objects
+  FOR SELECT TO authenticated
+  USING (bucket_id = 'cowork-uploads'
+         AND (storage.foldername(name))[1] = (auth.uid())::text);
+
+DROP POLICY IF EXISTS "cowork own delete" ON storage.objects;
+CREATE POLICY "cowork own delete" ON storage.objects
+  FOR DELETE TO authenticated
+  USING (bucket_id = 'cowork-uploads'
+         AND (storage.foldername(name))[1] = (auth.uid())::text);
+
+DO $$
+DECLARE v_missing text;
+BEGIN
+  SELECT string_agg(b, ', ') INTO v_missing
+    FROM unnest(ARRAY['cms-images', 'documents', 'form-uploads', 'river-media', 'cowork-uploads']) b
+   WHERE NOT EXISTS (SELECT 1 FROM storage.buckets WHERE id = b);
+  IF v_missing IS NULL THEN
+    RAISE NOTICE 'Storage: every bucket the code writes to exists on this instance.';
+  ELSE
+    RAISE WARNING 'Storage: still missing %. Every one of these is an upload that fails with bucket-not-found.', v_missing;
+  END IF;
+END $$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260810130000",
-      "migrations_count": 376,
+      "migration_head": "20260810140000",
+      "migrations_count": 377,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1509,6 +1509,10 @@
         {
           "version": "20260810130000",
           "name": "expense-receipts-follow-the-money"
+        },
+        {
+          "version": "20260810140000",
+          "name": "river-and-cowork-buckets-in-repo"
         }
       ]
     },


### PR DESCRIPTION
Att bifoga en bild i river föll på optic med *bucket not found*. `river-media`
fanns på liteit, www och autoversio — för att någon en gång skapade den där — och
ingen annanstans.

För två dagar sedan visade sig `documents` ha exakt samma form. Den migrationens
rubrik namngav klassen — **infrastruktur som bara finns där någon råkade skapa
den** — och stannade sedan vid den ena hinken vi hade framför oss. `river-media`
och `cowork-uploads` var resten av den, och låg och väntade på att någon skulle
försöka ladda upp något.

När en klass är namngiven hör svepet hemma i samma andetag som fixen.

Konfiguration och policyer är **lästa ur www**, där båda funktionerna fungerar:
den körande flottan är specen, inte en gissning. En hink återskapad ur minnet får
sin publika flagga eller sin ägarkontroll subtilt fel, och en lagringspolicy som
är subtilt fel är antingen en läcka eller ett supportärende.

Migrationen kontrollerar dessutom varje hink koden skriver till och varnar med
namn för den som saknas — så nästa gör sig påmind i stället för att vänta på att
en uppladdning ska misslyckas.

Utrullad på alla fem: alla svarar nu att varje hink finns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)