### PR TITLE
fix(ci): typkontrollen blir en grind i stället för en dekoration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,17 @@ jobs:
         run: npm run lint
         continue-on-error: true
 
-      - name: Run TypeScript type check
-        run: npx tsc --noEmit
-        continue-on-error: true
+      # BLOCKING, and against the app's own config.
+      #
+      # This step was decorative in two ways at once. `continue-on-error: true`
+      # meant it could never fail a build, and the root config skips the app
+      # sources — so `tsc --noEmit` completed in under a second while
+      # `tsc -p tsconfig.app.json` reported real errors in useAccounting.ts and
+      # NewJournalEntryDialog.tsx. A green tick that checks nothing is worse
+      # than no tick: it is a claim the repo makes about itself and does not
+      # keep. Verified zero errors on main before removing the escape hatch.
+      - name: Run TypeScript type check (BLOCKING)
+        run: npx tsc -p tsconfig.app.json --noEmit
 
       - name: Run tests
         run: npx vitest run

--- a/src/lib/__tests__/ci-typecheck-gate.guardrails.test.ts
+++ b/src/lib/__tests__/ci-typecheck-gate.guardrails.test.ts
@@ -1,0 +1,54 @@
+/**
+ * A gate that cannot fail is a claim the repo does not keep.
+ *
+ * CI's type check was decorative in two ways at once: `continue-on-error: true`
+ * meant it could never fail a build, and it ran against the ROOT tsconfig,
+ * which skips the app sources. The step completed in under a second and stayed
+ * green while `tsc -p tsconfig.app.json` reported real errors in
+ * useAccounting.ts and NewJournalEntryDialog.tsx.
+ *
+ * That is the same failure shape as the lockfile and the stale manifest: a
+ * signal that looks like coverage and is not. This guardrail keeps the escape
+ * hatch from coming back quietly.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ci = readFileSync(join(process.cwd(), '.github/workflows/ci.yml'), 'utf-8');
+
+/** The lines of one YAML step, from its `- name:` to the next one. */
+function step(nameFragment: string): string {
+  const lines = ci.split('\n');
+  const start = lines.findIndex((l) => /^\s*- name:/.test(l) && l.includes(nameFragment));
+  expect(start, `no CI step matching "${nameFragment}"`).toBeGreaterThan(-1);
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => /^\s*- name:/.test(l));
+  return [lines[start], ...(end === -1 ? rest : rest.slice(0, end))].join('\n');
+}
+
+describe('the type check is a gate, not a decoration', () => {
+  const typecheck = step('TypeScript type check');
+
+  it('cannot be waved through', () => {
+    expect(typecheck).not.toMatch(/continue-on-error:\s*true/);
+  });
+
+  it('checks the app sources, not just whatever the root config includes', () => {
+    // `tsc --noEmit` against the root config returned in under a second and
+    // missed every error the app config found.
+    expect(typecheck).toMatch(/tsc -p tsconfig\.app\.json --noEmit/);
+  });
+});
+
+describe('the steps that were already blocking stay blocking', () => {
+  for (const name of [
+    'Skill linter',
+    'Parity matrix freshness',
+    'Migration forward-dating guard',
+  ]) {
+    it(`${name} has no escape hatch`, () => {
+      expect(step(name)).not.toMatch(/continue-on-error:\s*true/);
+    });
+  }
+});


### PR DESCRIPTION
Steget var prydnad på **två sätt samtidigt**:

```yaml
- name: Run TypeScript type check
  run: npx tsc --noEmit          # ← rotkonfigurationen, hoppar över app-källorna
  continue-on-error: true        # ← kunde aldrig fälla ett bygge
```

I den senaste körningen på main tog steget **noll sekunder** — 16:48:48 → 16:48:48. Det är inte en snabb typkontroll, det är en som inte gör något mätbart. Samtidigt rapporterade `tsc -p tsconfig.app.json` riktiga fel i `useAccounting.ts` och `NewJournalEntryDialog.tsx`.

Det är samma felform som den osynkade låsfilen och det inaktuella manifestet den här veckan: **en signal som ser ut som täckning och inte är det.** En grön bock som inte kontrollerar något är sämre än ingen bock alls — den är ett påstående repot gör om sig självt och inte håller.

## Båda villkoren för att skärpa den är uppfyllda

Felen är borta från main — verifierat **noll fel under båda konfigurationerna** på `ecef196`. Att ta bort nödutgången gör alltså inte main röd i samma sekund.

```yaml
- name: Run TypeScript type check (BLOCKING)
  run: npx tsc -p tsconfig.app.json --noEmit
```

## Verifierat

**5 guardrails, var och en negativtestad:**

| sabotage | utfall |
|---|---|
| `continue-on-error: true` tillbaka | röd |
| tillbaka till rotkonfigurationen | röd |
| nödutgång på migrationsvakten | röd |

De redan blockerande stegen — skill-lintern, paritetsmatrisen och framdateringsvakten — täcks också, så ingen av dem kan tyst få en nödutgång heller.

Full svit **2218 passed / 4 skipped**.

## En not om CI-triggern

`pull_request`-eventet schemalade ingen körning för #188 trots fyra försök (öppna, stäng/öppna, force-push, ready-for-review), medan `push` till main körde samma commit direkt. Om den här PR:en också står utan checkar är det den kända formen — **frånvarande, inte röd** — och inte något med innehållet.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_