### PR TITLE
UB blir IB — ingående balansen härleds i stället för att lagras två gånger

### DIFF
--- a/src/components/admin/accounting/OpeningBalancesTab.tsx
+++ b/src/components/admin/accounting/OpeningBalancesTab.tsx
@@ -16,8 +16,7 @@ import { AccountingTabHeader } from './AccountingTabHeader';
 
 export function OpeningBalancesTab() {
   const { locale } = useAccountingLocale();
-  const { year: fiscalYear, setYear: setFiscalYear } = useFiscalYear();
-  const currentYear = new Date().getFullYear();
+  const { year: fiscalYear } = useFiscalYear();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selectedAccount, setSelectedAccount] = useState('');
   const [amount, setAmount] = useState('');
@@ -79,20 +78,18 @@ export function OpeningBalancesTab() {
     <div className="space-y-4">
       <AccountingTabHeader
         title="Opening Balances"
-        description="Carry-forward balances at the start of the fiscal year — the foundation of every balance-sheet report."
+        description="The bridge into FlowWink — the position at the start of your FIRST year here, taken from wherever you kept the books before. Every later year carries forward from the ledger on its own; do not enter it twice."
       />
 
 
       <div className="rounded-lg border bg-card">
         <div className="flex flex-wrap items-center gap-4 px-6 py-4 border-b">
-          <Select value={String(fiscalYear)} onValueChange={v => setFiscalYear(Number(v))}>
-            <SelectTrigger className="w-28 h-9"><SelectValue /></SelectTrigger>
-            <SelectContent>
-              {[currentYear - 2, currentYear - 1, currentYear, currentYear + 1].map(y => (
-                <SelectItem key={y} value={String(y)}>{y}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          {/* No year picker here. The page header already has one, and this tab
+              used to carry a SECOND one whose options were hardcoded to the
+              current year ±2 — so selecting 2022 in the header left this control
+              blank and showing a year it could not represent. One piece of
+              state, one control. */}
+          <span className="text-sm font-medium tabular-nums">FY {fiscalYear}</span>
           <Badge variant={isBalanced ? 'secondary' : 'destructive'} className="font-normal">
             {isBalanced ? 'Balanced' : `Off by ${fmt(Math.abs(diff))}`}
           </Badge>

--- a/src/hooks/useAccounting.ts
+++ b/src/hooks/useAccounting.ts
@@ -571,7 +571,7 @@ export function useAccountLedger(accountCode: string | null, fiscalYear?: number
 
       return {
         account_code: accountCode,
-        account_name: chart?.account_name || (opening as any)?.account_name || accountCode,
+        account_name: chart?.account_name || lines[0]?.description || accountCode,
         normal_balance: normalBalance,
         opening_cents,
         lines,

--- a/src/hooks/useAccounting.ts
+++ b/src/hooks/useAccounting.ts
@@ -377,11 +377,26 @@ export function useAccountBalances(fiscalYear?: number) {
 
       if (error) throw error;
 
-      // Opening balances for the SELECTED fiscal year
-      const { data: openingData } = await supabase
-        .from('opening_balances')
-        .select('*')
-        .eq('fiscal_year', year);
+      // The opening balance is DERIVED — everything posted before this year —
+      // not read from a stored row for it. Storing it per year put the same
+      // number in two places (last year's closing, this year's opening) and
+      // they drifted: on liteit the two disagreed about whether a loan was
+      // long-term or short-term. See the migration for the full account.
+      const { data: openingRows } = await supabase.rpc(
+        'opening_balances_for_year' as never,
+        { p_year: year } as never,
+      );
+      const openingData = ((openingRows ?? []) as Array<{
+        account_code: string;
+        account_name: string;
+        net_cents: number;
+      }>).map((r) => ({
+        account_code: r.account_code,
+        account_name: r.account_name,
+        // net_cents is signed against the debit side.
+        amount_cents: Math.abs(Number(r.net_cents || 0)),
+        balance_type: Number(r.net_cents || 0) >= 0 ? 'debit' : 'credit',
+      }));
 
       // Aggregate by account
       const map = new Map<string, AccountBalance>();
@@ -505,19 +520,19 @@ export function useAccountLedger(accountCode: string | null, fiscalYear?: number
       const normalBalance: 'debit' | 'credit' =
         (chart?.normal_balance as 'debit' | 'credit') || 'debit';
 
-      const { data: opening } = await supabase
-        .from('opening_balances')
-        .select('amount_cents, balance_type, account_name')
-        .eq('fiscal_year', currentYear)
-        .eq('account_code', accountCode)
-        .maybeSingle();
-
-      let opening_cents = 0;
-      if (opening) {
-        const amt = Number((opening as any).amount_cents || 0);
-        const t = ((opening as any).balance_type || 'debit') as 'debit' | 'credit';
-        opening_cents = t === normalBalance ? amt : -amt;
-      }
+      // Derived, same rule as the balance sheet: everything posted before this
+      // year. An account ledger that opened at zero every January was the same
+      // defect seen from a different page.
+      const { data: openingRows } = await supabase.rpc(
+        'opening_balances_for_year' as never,
+        { p_year: currentYear } as never,
+      );
+      const net = Number(
+        ((openingRows ?? []) as Array<{ account_code: string; net_cents: number }>)
+          .find((r) => r.account_code === accountCode)?.net_cents ?? 0,
+      );
+      // net_cents is signed against the debit side.
+      const opening_cents = normalBalance === 'debit' ? net : -net;
 
       const { data: rows, error } = await supabase
         .from('journal_entry_lines')

--- a/src/lib/__tests__/opening-balance-carry-forward.guardrails.test.ts
+++ b/src/lib/__tests__/opening-balance-carry-forward.guardrails.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * UB blir IB — and the opening balance is never stored twice.
+ *
+ * The balance sheet used to read `opening_balances` for the SELECTED year, so
+ * any year without a stored row opened at zero. On liteit only 2026 had rows;
+ * 2023, 2024 and 2025 showed no opening balance at all despite four years of
+ * reconciled bookkeeping.
+ *
+ * The missing rows were the symptom. The defect was storing a carry-forward:
+ * the same number lived as 2025's closing balance AND 2026's opening balance,
+ * and the two had already drifted — one said the loan sat on 2393 (long-term),
+ * the other on 2893 (short-term). Same money, different balance sheet.
+ *
+ * These tests lock the RULE, not the SQL. If someone reintroduces a per-year
+ * lookup the drift comes back, and it comes back silently.
+ */
+
+const ROOT = join(__dirname, '../../..');
+const hook = readFileSync(join(ROOT, 'src/hooks/useAccounting.ts'), 'utf8');
+const migration = readFileSync(
+  join(ROOT, 'supabase/migrations/20260810230000_the-closing-balance-becomes-the-opening-balance.sql'),
+  'utf8',
+);
+
+describe('the opening balance is derived, not stored per year', () => {
+  it('the report does not look up opening_balances by fiscal year', () => {
+    // The exact shape of the old bug: .from('opening_balances') … .eq('fiscal_year', year)
+    const readsTable = /from\(\s*['"]opening_balances['"]\s*\)/.test(hook);
+    expect(
+      readsTable,
+      'useAccounting must not read opening_balances directly — a year without a row would open at zero. Use opening_balances_for_year().',
+    ).toBe(false);
+  });
+
+  it('both the balance sheet and the account ledger use the same rule', () => {
+    // One rule in one place. When these diverged, the balance sheet and the
+    // account ledger could disagree about the same account on the same day.
+    const calls = hook.match(/opening_balances_for_year/g) ?? [];
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('derives from entries posted BEFORE the year starts', () => {
+    expect(migration).toMatch(/entry_date\s*<\s*v_start/);
+    expect(migration).toMatch(/status\s*=\s*'posted'/);
+  });
+
+  it('counts only balance-sheet accounts, by account_type — never by digit', () => {
+    // 2641 is an asset in class 2, and class 8 holds income, revenue and
+    // expense side by side. Prefix logic gets both wrong. Same ruling as the
+    // 8999 result-carrier incident: classification belongs to the chart.
+    expect(migration).toMatch(/account_type\s+IN\s*\(\s*'asset',\s*'equity',\s*'liability'\s*\)/);
+    expect(
+      /left\(\s*(c\.)?account_code\s*,\s*1\s*\)/.test(migration),
+      'classification must come from the chart of accounts, not from the leading digit',
+    ).toBe(false);
+  });
+
+  it('treats only the EARLIEST stored year as the bridge', () => {
+    // Later years are legacy copies of a carry-forward. Honouring them would
+    // re-create the drift this replaces.
+    expect(migration).toMatch(/min\(fiscal_year\)/);
+  });
+
+  it('does not double-count entries that predate the bridge', () => {
+    // The bridge already states the position at its own start; entries before
+    // it are inside that number.
+    expect(migration).toMatch(/entry_date\s*>=\s*make_date\(\s*v_bridge_year/);
+  });
+
+  it('does not apply a bridge dated after the year being asked about', () => {
+    expect(migration).toMatch(/p_year\s*>=\s*v_bridge_year/);
+  });
+});
+
+describe('one piece of state, one control', () => {
+  const tab = readFileSync(
+    join(ROOT, 'src/components/admin/accounting/OpeningBalancesTab.tsx'),
+    'utf8',
+  );
+
+  it('the opening balances tab has no year picker of its own', () => {
+    // It used to carry a second one, hardcoded to the current year ±2 — so
+    // picking 2022 in the page header left this control blank while the table
+    // below showed a year the control could not represent.
+    expect(tab).not.toMatch(/currentYear\s*[-+]\s*\d/);
+    expect(tab).not.toMatch(/setFiscalYear/);
+  });
+});

--- a/supabase/migrations/20260810230000_the-closing-balance-becomes-the-opening-balance.sql
+++ b/supabase/migrations/20260810230000_the-closing-balance-becomes-the-opening-balance.sql
@@ -1,0 +1,142 @@
+-- ============================================================================
+-- UB blir IB. The opening balance is derived, never stored twice.
+--
+-- The balance sheet read `opening_balances` for the SELECTED year, so a year
+-- with no stored row got no opening balance at all. On liteit — 2022 through
+-- 2026 bookkept and reconciled against three annual reports — only 2026 had
+-- rows. 2023, 2024 and 2025 opened at zero.
+--
+-- But the missing rows were the symptom. The defect is that an opening balance
+-- was STORED per year, which puts the same number in two places: 2025's closing
+-- balance and 2026's opening balance. Two records of one fact drift, and these
+-- already had:
+--
+--     derived from the ledger        stored as opening balance 2026
+--     151 983 on 1351               151 983 on 1350
+--    -166 549,84 on 2893           -166 550 on 2393
+--
+-- Same money, different accounts — and 2393 is a long-term liability while 2893
+-- is short-term, so the two records disagreed about the SHAPE of the balance
+-- sheet, not merely about ören. Nothing could detect it, because the two were
+-- never compared. (Magnus confirmed 1351 and 2893 — the ledger — are correct.)
+--
+-- The rule that replaces it:
+--
+--     opening balance of year Y = everything posted before Y-01-01
+--
+-- No storage, no copy, no drift. Correct a prior year and every later year's
+-- opening balance follows automatically, which is precisely what a carry-forward
+-- means.
+--
+-- `opening_balances` keeps exactly one job: the BRIDGE into the system — the
+-- first year, where the numbers come from somewhere else (a Bokio SIE file, a
+-- previous accountant). After that the ledger is the only source. On liteit the
+-- bridge is already a verification (IB-2022, nine lines from the SIE), so the
+-- rule needs no special case there at all: the bridge is simply the oldest
+-- entries.
+--
+-- Result accounts do not carry forward — they reset each year and the net goes
+-- to equity. Which accounts those are is read from `account_type` in the chart,
+-- NOT inferred from the leading digit: 2641 is an asset in class 2, and class 8
+-- holds income, revenue and expense side by side. Same ruling as the 8999
+-- result-carrier incident — classification belongs to the chart of accounts.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.opening_balances_for_year(p_year integer)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_start date;
+  v_bridge_year int;
+  v_rows jsonb;
+BEGIN
+  IF auth.uid() IS NULL AND coalesce(auth.role(), '') <> 'service_role' THEN
+    RAISE EXCEPTION 'Sign in to read opening balances';
+  END IF;
+  IF p_year IS NULL THEN
+    RAISE EXCEPTION 'p_year is required (the fiscal year whose OPENING balance you want)';
+  END IF;
+
+  v_start := make_date(p_year, 1, 1);
+
+  -- The bridge is the earliest year anyone entered opening balances for. Later
+  -- years are legacy copies of a carry-forward and are deliberately ignored —
+  -- they are the drift this function exists to end.
+  SELECT min(fiscal_year) INTO v_bridge_year FROM public.opening_balances;
+
+  WITH bridge AS (
+    SELECT ob.account_code,
+           ob.account_name,
+           sum(CASE WHEN ob.balance_type = 'credit' THEN -ob.amount_cents ELSE ob.amount_cents END)::bigint AS net_cents
+      FROM public.opening_balances ob
+     WHERE v_bridge_year IS NOT NULL
+       AND ob.fiscal_year = v_bridge_year
+       -- A bridge dated after the year being asked about has not happened yet.
+       AND p_year >= v_bridge_year
+     GROUP BY 1, 2
+  ),
+  movements AS (
+    SELECT l.account_code,
+           max(l.account_name)                            AS account_name,
+           sum(l.debit_cents - l.credit_cents)::bigint    AS net_cents
+      FROM public.journal_entry_lines l
+      JOIN public.journal_entries je ON je.id = l.journal_entry_id
+     WHERE je.status = 'posted'
+       AND je.entry_date < v_start
+       -- Only what the bridge covers; entries before the bridge year would be
+       -- counted twice, since the bridge already states the position then.
+       AND (v_bridge_year IS NULL OR je.entry_date >= make_date(v_bridge_year, 1, 1))
+     GROUP BY 1
+  ),
+  combined AS (
+    SELECT coalesce(b.account_code, m.account_code)                       AS account_code,
+           coalesce(b.account_name, m.account_name)                       AS account_name,
+           coalesce(b.net_cents, 0) + coalesce(m.net_cents, 0)            AS net_cents
+      FROM bridge b FULL OUTER JOIN movements m ON m.account_code = b.account_code
+  )
+  SELECT jsonb_agg(jsonb_build_object(
+           'account_code', c.account_code,
+           'account_name', coalesce(c.account_name, coa.account_name),
+           -- Signed against the debit side. The caller applies normal_balance.
+           'net_cents',    c.net_cents
+         ) ORDER BY c.account_code)
+    INTO v_rows
+    FROM combined c
+    JOIN public.chart_of_accounts coa ON coa.account_code = c.account_code
+   WHERE c.net_cents <> 0
+     -- Balance-sheet accounts only. A result account opens every year at zero.
+     AND coa.account_type IN ('asset', 'equity', 'liability');
+
+  RETURN COALESCE(v_rows, '[]'::jsonb);
+END; $function$;
+
+COMMENT ON FUNCTION public.opening_balances_for_year(integer) IS
+  'The opening balance of each balance-sheet account at the start of p_year, derived: the bridge (earliest year in opening_balances, if any) plus every posted entry after it and before p_year. net_cents is signed against the debit side — apply normal_balance to display. Result accounts are excluded because they open at zero. Storing an opening balance per year is what this replaces: it puts one number in two places and they drift.';
+
+GRANT EXECUTE ON FUNCTION public.opening_balances_for_year(integer) TO authenticated, service_role;
+
+-- ── Does this instance still hold a stored carry-forward? ───────────────────
+DO $$
+DECLARE
+  v_years int;
+  v_bridge int;
+  v_list text;
+BEGIN
+  SELECT count(DISTINCT fiscal_year), min(fiscal_year) INTO v_years, v_bridge
+    FROM public.opening_balances;
+
+  IF v_years > 1 THEN
+    SELECT string_agg(DISTINCT fiscal_year::text, ', ' ORDER BY fiscal_year::text)
+      INTO v_list FROM public.opening_balances WHERE fiscal_year <> v_bridge;
+    RAISE WARNING 'Opening balances: % is the bridge year, but rows also exist for %. Those are stored carry-forwards — they are IGNORED from now on and the ledger decides. Compare them before deleting: a disagreement is a real bookkeeping difference, not a formatting one.',
+      v_bridge, v_list;
+  ELSIF v_years = 1 THEN
+    RAISE NOTICE 'Opening balances: one bridge year (%). Every later year now carries forward from the ledger.', v_bridge;
+  ELSE
+    RAISE NOTICE 'Opening balances: none stored — the bridge is a verification in the ledger, and carry-forward is derived.';
+  END IF;
+END $$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260810160000",
-      "migrations_count": 379,
+      "migration_head": "20260810230000",
+      "migrations_count": 380,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1521,6 +1521,10 @@
         {
           "version": "20260810160000",
           "name": "the-ledger-decides-which-fiscal-years-exist"
+        },
+        {
+          "version": "20260810230000",
+          "name": "the-closing-balance-becomes-the-opening-balance"
         }
       ]
     },


### PR DESCRIPTION
## Vad Magnus såg

Bara 2026 fick en ingående balans i balansräkningen. 2023, 2024 och 2025 öppnade på noll — trots fyra års bokföring avstämd mot tre årsredovisningar.

Och hans diagnos var rätt: rapporten läste `opening_balances` för det **valda** året. Bara 2026 hade rader.

## Men de saknade raderna var symptomet

Felet var att en balansräkning **lagrades per år**. Det sätter samma siffra på två ställen — 2025 års utgående balans och 2026 års ingående. Två register över ett faktum driver isär. Dessa hade redan gjort det:

| | härlett ur huvudboken | lagrat som IB 2026 |
|---|---|---|
| värdepapper | 151 983 på **1351** | 151 983 på **1350** |
| lån närstående | −166 549,84 på **2893** | −166 550 på **2393** |

Totalen stämde på öret. Men **2393 är en långfristig skuld och 2893 en kortfristig** — de två registren var oense om balansräkningens *form*, inte om beloppet. Ingenting kunde upptäcka det, eftersom de aldrig jämfördes med varandra.

Magnus bekräftade att huvudboken (1351, 2893) är rätt, och tog bort 2026 års rader.

## Regeln

> **ingående balans år Y = allt som bokförts före Y-01-01**

Ingen lagring, ingen kopia, ingen drift. Rätta ett tidigare år och alla senare års IB följer med — vilket är precis vad en balansräkning ska göra.

`opening_balances` behåller ett enda jobb: **bryggan in i systemet**. Första året, där siffrorna kommer någon annanstans ifrån — en Bokio-SIE, en tidigare redovisningskonsult. Efter det är huvudboken enda källan.

## Detaljer värda att nämna

- **Balansräkningen och huvudbokens kontovy** använder nu samma regel. Förut kunde de vara oense om samma konto samma dag.
- **Resultatkonton bär inte över** — de nollas varje år. Vilka de är läses ur `account_type` i kontoplanen, aldrig ur begynnelsesiffran: 2641 är ett `asset` i klass 2, och klass 8 rymmer `income`, `revenue` och `expense` sida vid sida. Prefixlogik får båda fel. Samma domslut som 8999-incidenten.
- **IB-fliken hade en egen årsväljare** hårdkodad till innevarande år ±2 — samma hårdkodade reserv som togs bort ur huvudväljaren i [#191](https://github.com/magnusfroste/flowwink/pull/191). Att välja 2022 i sidhuvudet lämnade den blank. Ett tillstånd, ett reglage.
- **Bryggan behöver inget specialfall** när den är en verifikation, som `IB-2022` på liteit: den är helt enkelt de äldsta raderna.

## Verifierat

Lackmustest skarpt mot liteit:

```
ar_UB | ar_IB | konton | avvikelser
 2022 |  2023 |      8 |          0
 2023 |  2024 |     10 |          0
 2024 |  2025 |      9 |          0
 2025 |  2026 |      9 |          0
```

**IB(Y) = UB(Y−1) för varje konto och varje årsskifte.** Nettot summerar till 0,00 varje år — tillgångar = eget kapital + skulder vid varje årsingång. Alla år har nu en IB (2023: 8 konton, 2024: 10, 2025: 9, 2026: 9); 2022 har ingen, vilket är rätt för bryggåret.

2 232 tester gröna, typecheck ren, migrationen körd på alla fem instanser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)