### PR TITLE
Handboken var indexerad men oåtkomlig från FlowWork

### DIFF
--- a/src/components/admin/workspace/CitationsDrawer.tsx
+++ b/src/components/admin/workspace/CitationsDrawer.tsx
@@ -48,6 +48,12 @@ const TYPE_LABEL: Record<string, string> = {
   lead: 'Lead',
   deal: 'Deal',
   employee: 'Employee',
+  // These were missing, so a wiki citation rendered the raw string 'wiki'.
+  // The citation TYPES come from the retrieval layer, not from the source
+  // keys above — two lists that drift unless both are extended together.
+  wiki: 'Wiki',
+  doc: 'Handbook',
+  flowtable: 'Flowtable',
 };
 
 const SOURCE_META: Record<
@@ -61,6 +67,7 @@ const SOURCE_META: Record<
   crm: { label: 'CRM', Icon: Users },
   employees: { label: 'Employees', Icon: UserCheck },
   wiki: { label: 'Wiki', Icon: BookOpen },
+  docs: { label: 'Handbook & Docs', Icon: BookOpen },
   flowtable: { label: 'Flowtable', Icon: Table2 },
 };
 

--- a/src/components/admin/workspace/SourceFilterPanel.tsx
+++ b/src/components/admin/workspace/SourceFilterPanel.tsx
@@ -13,6 +13,7 @@ const SOURCE_META: Record<WorkspaceSource, { label: string; description: string;
   crm: { label: 'CRM', description: 'Leads & deals', Icon: Users },
   employees: { label: 'Employees', description: 'HR records', Icon: UserCheck },
   wiki: { label: 'Wiki', description: 'Internal intranet pages', Icon: BookOpen },
+  docs: { label: 'Handbook & Docs', description: 'Internal handbook and product documentation', Icon: BookOpen },
   flowtable: { label: 'Flowtable', description: 'Shared tables (imported sheets, catalogs)', Icon: Table2 },
 };
 

--- a/src/hooks/useWorkspaceChat.ts
+++ b/src/hooks/useWorkspaceChat.ts
@@ -10,6 +10,7 @@ export type WorkspaceSource =
   | 'crm'
   | 'employees'
   | 'wiki'
+  | 'docs'
   | 'flowtable';
 
 export const ALL_WORKSPACE_SOURCES: WorkspaceSource[] = [
@@ -20,6 +21,7 @@ export const ALL_WORKSPACE_SOURCES: WorkspaceSource[] = [
   'crm',
   'employees',
   'wiki',
+  'docs',
   'flowtable',
 ];
 

--- a/supabase/functions/workspace-chat/index.ts
+++ b/supabase/functions/workspace-chat/index.ts
@@ -40,6 +40,7 @@ type SourceKey =
   | 'crm'
   | 'employees'
   | 'wiki'
+  | 'docs'
   | 'flowtable';
 
 const ALL_SOURCES: SourceKey[] = [
@@ -50,6 +51,7 @@ const ALL_SOURCES: SourceKey[] = [
   'crm',
   'employees',
   'wiki',
+  'docs',
   'flowtable',
 ];
 
@@ -200,6 +202,10 @@ async function buildContext(
     kb: 'kb_articles',
     pages: 'pages',
     wiki: 'wiki_pages',
+    // The handbook/docs corpus. It was indexed all along (docs_pages, the
+    // largest chunk source on most instances) but no SourceKey mapped to it,
+    // so FlowWork could never reach a single page of it.
+    docs: 'docs_pages',
   };
   const chunkTables = sources.map((s) => KNOWLEDGE_TABLES[s]).filter(Boolean) as string[];
   if (chunkTables.length && query) {

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1613,7 +1613,7 @@
         "voice-recording": "sha256:41391de110f7f3e138df5c50b1901dd6c7928d2be18ad82fa5e166d48f66cca2",
         "web-scrape": "sha256:f0948362eb60ff2d597de407af0f3eedb3b0f892b75ce4acff960e0b6ebf146f",
         "web-search": "sha256:6002f6b14ad490cfa0b444129694f123fad021050234cc8f87ee04ebb16c5320",
-        "workspace-chat": "sha256:357dcc372b82c181c9f865576891c2b20511bd2672afc5d52accbfa16d8e832e"
+        "workspace-chat": "sha256:b8953ceb63442009a777c23e94c975cc25b1f48b57542346bf920bcf6feb1328"
       }
     },
     "frontend": {


### PR DESCRIPTION
## Fyndet

`docs_pages` är den största kunskapssamlingen på en typisk instans — **2 377 chunks på optic, 2 267 på liteit**. Indexeraren indexerar den. Retrieval-lagret känner igen citattypen `doc`.

Men `workspace-chat` hade ingen `SourceKey` som pekade dit. FlowWork kunde alltså aldrig nå en enda sida av handboken.

Ingenting felade. Ingen tom lista, inget felmeddelande — bara svar som saknade det bästa underlaget, utan att någon kunde se att det fanns. Samma tysta klass som resten av dagens fynd: en yta som frågar fel register, och tiger om det.

## Ändringen

- `'docs'` → `docs_pages` i `workspace-chat`, med i `ALL_SOURCES`
- samma nyckel i `useWorkspaceChat`, `SourceFilterPanel` och `CitationsDrawer`
- `TYPE_LABEL` saknade dessutom `wiki`, `doc` och `flowtable` — ett wiki-citat renderade råsträngen `wiki`. Citattyperna kommer från retrieval-lagret, källnycklarna från chatten: två listor som glider isär om man bara utökar den ena.

## Vad som INTE ändrades, men bör vägas

Under samma undersökning framkom två saker som är designval, inte buggar — men som ändrar vem som ser vad när kollegor kommer in i FlowWork:

**Live-källorna läser med servicenyckeln.** Kunskapsspåret (documents/kb/pages/wiki/docs) hämtar med anroparens egen klient, så RLS gäller. Men `contracts`, `crm` och `employees` använder servicenyckeln — koden säger det själv: *"entity/live sources keep the service client as before"*. `contracts` hämtar `body_markdown` och `value_cents`; `employees` hämtar namn, mejl, roll och avdelning. Flowtable är gated på `workspace_shared`; de tre andra har ingen motsvarande grind.

**CRM betyder bara `leads`.** Topp-N efter score. Inte företag, affärer, kontakter eller aktiviteter — trots att panelen beskriver källan som "Leads & deals".

**Bloggen finns inte som källa alls**, varken i chatten eller i indexeraren.

Inget av detta är åtgärdat här; det förtjänar ett eget beslut.

## Verifierat

2 232 tester gröna, typecheck mot `tsconfig.app.json` ren. `workspace-chat` deployad på **optic** (där teamet sitter). **liteit ger 403** på functions deploy — kontot mina tokens inte når — och behöver köras av ägaren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)