### PR TITLE
FlowWork agerar — med människans klick som initiativöverlämning

### DIFF
--- a/src/components/admin/workspace/StagedActionCard.tsx
+++ b/src/components/admin/workspace/StagedActionCard.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { CheckCircle2, XCircle, Loader2, ShieldAlert, Play } from 'lucide-react';
+import { callSkill } from '@/lib/call-skill';
+import { supabase } from '@/integrations/supabase/client';
+import type { StagedAction } from '@/hooks/useWorkspaceChat';
+
+/**
+ * The approval card — where initiative changes hands.
+ *
+ * FlowWork's model can PREPARE a write (the platform stages it as a
+ * pending_operation) but can never execute one: the approval flags are
+ * stripped from model arguments server-side. This card is the only path from
+ * proposal to execution, and the click is the human's — approve runs
+ * approve_pending_operation and then re-invokes the skill with the operation
+ * id, which agent-execute verifies is genuinely approved and unexpired.
+ */
+interface Props {
+  action: StagedAction;
+  onResolved: (resolution: 'approved' | 'rejected' | 'failed', note?: string) => void;
+}
+
+const HIDDEN_ARGS = new Set(['_approved', '_approved_operation_id']);
+
+export function StagedActionCard({ action, onResolved }: Props) {
+  const [busy, setBusy] = useState<'approve' | 'reject' | null>(null);
+
+  const argRows = Object.entries(action.args || {}).filter(
+    ([k, v]) => !HIDDEN_ARGS.has(k) && v !== undefined && v !== null && v !== '',
+  );
+
+  const approve = async () => {
+    setBusy('approve');
+    try {
+      await callSkill('approve_pending_operation', { p_id: action.operation_id });
+      // Re-invoke with the operation id — agent-execute verifies the approval
+      // server-side. Direct invoke (not callSkill) so a pending_approval on a
+      // double-gated skill surfaces as text instead of a thrown error.
+      const { data, error } = await supabase.functions.invoke('agent-execute', {
+        body: {
+          skill_name: action.skill,
+          arguments: { ...action.args, ...action.reinvoke_args },
+          agent_type: 'admin_ui',
+        },
+      });
+      if (error) throw new Error(error.message);
+      if (data?.status === 'pending_approval') {
+        onResolved('approved', 'Kräver även beslut i /admin/approvals (dubbelgrindad åtgärd).');
+      } else if (data?.status === 'failed' || data?.error) {
+        onResolved('failed', String(data?.error ?? 'Utförandet misslyckades'));
+      } else {
+        const summary = typeof data?.result === 'object' && data?.result
+          ? Object.entries(data.result as Record<string, unknown>)
+              .slice(0, 3)
+              .map(([k, v]) => `${k}: ${typeof v === 'object' ? '…' : String(v)}`)
+              .join(' · ')
+          : undefined;
+        onResolved('approved', summary);
+      }
+    } catch (e) {
+      onResolved('failed', e instanceof Error ? e.message : 'Kunde inte utföra');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const reject = async () => {
+    setBusy('reject');
+    try {
+      await callSkill('reject_pending_operation', {
+        p_id: action.operation_id,
+        p_reason: 'Avvisad i FlowWork',
+      });
+      onResolved('rejected');
+    } catch (e) {
+      onResolved('failed', e instanceof Error ? e.message : 'Kunde inte avvisa');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (action.resolution) {
+    const meta = {
+      approved: { Icon: CheckCircle2, cls: 'text-emerald-600 dark:text-emerald-400', label: 'Utförd' },
+      rejected: { Icon: XCircle, cls: 'text-muted-foreground', label: 'Avvisad' },
+      failed: { Icon: ShieldAlert, cls: 'text-destructive', label: 'Misslyckades' },
+    }[action.resolution];
+    const Icon = meta.Icon;
+    return (
+      <div className="flex items-start gap-2 rounded-lg border border-border/60 bg-muted/30 px-3 py-2 text-sm max-w-[90%]">
+        <Icon className={`h-4 w-4 mt-0.5 shrink-0 ${meta.cls}`} />
+        <div className="min-w-0">
+          <span className="font-medium">{meta.label}:</span>{' '}
+          <span className="font-mono text-xs">{action.skill}</span>
+          {action.result_note && (
+            <p className="text-xs text-muted-foreground mt-0.5 break-words">{action.result_note}</p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-primary/30 bg-primary/5 p-3 max-w-[90%] space-y-2">
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <Play className="h-4 w-4 text-primary" />
+        Föreslagen åtgärd
+        <Badge variant="outline" className="text-[10px] font-mono">{action.skill}</Badge>
+      </div>
+      {argRows.length > 0 && (
+        <dl className="text-xs space-y-0.5">
+          {argRows.slice(0, 8).map(([k, v]) => (
+            <div key={k} className="flex gap-2">
+              <dt className="text-muted-foreground shrink-0 font-mono">{k}</dt>
+              <dd className="truncate">{typeof v === 'object' ? JSON.stringify(v) : String(v)}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      {action.resolved?.map((r) => (
+        <p key={r} className="text-[11px] text-muted-foreground font-mono">↳ {r}</p>
+      ))}
+      <p className="text-[11px] text-muted-foreground">
+        Inget är utfört ännu. Åtgärden väntar på ditt beslut.
+      </p>
+      <div className="flex items-center gap-2 pt-0.5">
+        <Button size="sm" className="h-7 text-xs gap-1" onClick={approve} disabled={busy !== null}>
+          {busy === 'approve' ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle2 className="h-3 w-3" />}
+          Godkänn & utför
+        </Button>
+        <Button size="sm" variant="ghost" className="h-7 text-xs" onClick={reject} disabled={busy !== null}>
+          Avvisa
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useWorkspaceChat.ts
+++ b/src/hooks/useWorkspaceChat.ts
@@ -39,6 +39,20 @@ export interface ConsultedSkill {
   ms: number;
 }
 
+/** A write the assistant prepared. A human click executes it — never the model. */
+export interface StagedAction {
+  operation_id: string;
+  skill: string;
+  args: Record<string, unknown>;
+  reinvoke_args: Record<string, unknown>;
+  preview?: unknown;
+  /** Server-side name→uuid substitutions, shown on the card. */
+  resolved?: string[];
+  /** UI-side lifecycle. 'pending' until someone decides. */
+  resolution?: 'approved' | 'rejected' | 'failed';
+  result_note?: string;
+}
+
 export interface WorkspaceMessage {
   id: string;
   role: 'user' | 'assistant';
@@ -46,6 +60,8 @@ export interface WorkspaceMessage {
   citations?: WorkspaceCitation[];
   /** Live skills the assistant executed to ground this answer. */
   consulted?: ConsultedSkill[];
+  /** Writes staged for approval in this turn. */
+  staged?: StagedAction[];
   createdAt: string;
 }
 
@@ -87,6 +103,24 @@ export function useWorkspaceChat({ sources, mode, onError, onPersistUser, onPers
     setMessages(msgs);
     setLastContextMeta(null);
   }, []);
+
+  const resolveStaged = useCallback(
+    (messageId: string, operationId: string, resolution: 'approved' | 'rejected' | 'failed', note?: string) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === messageId && m.staged
+            ? {
+                ...m,
+                staged: m.staged.map((a) =>
+                  a.operation_id === operationId ? { ...a, resolution, result_note: note } : a,
+                ),
+              }
+            : m,
+        ),
+      );
+    },
+    [],
+  );
 
   const stop = useCallback(() => {
     abortRef.current?.abort();
@@ -220,6 +254,20 @@ export function useWorkspaceChat({ sources, mode, onError, onPersistUser, onPers
                 continue;
               }
 
+              if (currentEvent === 'staged') {
+                try {
+                  const st = JSON.parse(data);
+                  if (Array.isArray(st)) {
+                    setMessages((prev) =>
+                      prev.map((m) => (m.id === assistantId ? { ...m, staged: st } : m)),
+                    );
+                  }
+                } catch (err) {
+                  logger.error('parse staged failed', err);
+                }
+                continue;
+              }
+
               if (currentEvent === 'consulted') {
                 try {
                   const cs = JSON.parse(data);
@@ -325,5 +373,6 @@ export function useWorkspaceChat({ sources, mode, onError, onPersistUser, onPers
     });
   }, [send]);
 
-  return { messages, isStreaming, send, stop, reset, loadHistory, lastContextMeta, regenerate };
+  return {
+    resolveStaged, messages, isStreaming, send, stop, reset, loadHistory, lastContextMeta, regenerate };
 }

--- a/src/lib/__tests__/flowwork-read-surface.guardrails.test.ts
+++ b/src/lib/__tests__/flowwork-read-surface.guardrails.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isReadSkill, isReadCall, WRITE_REFUSAL } from '../../../supabase/functions/_shared/skills/read-surface';
+import { isReadSkill, isReadCall, classifyCall, WRITE_REFUSAL, STAGE_NOTICE } from '../../../supabase/functions/_shared/skills/read-surface';
 
 /**
  * FlowWork mounts the MCP gateway's dispatch pattern INSIDE the employee chat:
@@ -104,6 +104,53 @@ describe('the call gate judges manage_* by its action', () => {
   });
 });
 
+describe('staged writes: propose, never execute', () => {
+  it('classifies calls into three tiers', () => {
+    expect(classifyCall('list_tickets')).toBe('read');
+    expect(classifyCall('manage_ticket', { action: 'list' })).toBe('read');
+    expect(classifyCall('manage_ticket', { action: 'create', subject: 'x' })).toBe('stage');
+    expect(classifyCall('send_invoice', { invoice_id: 'x' })).toBe('stage');
+    expect(classifyCall('write_blog_post', {})).toBe('stage');
+    // The deny tier never reaches staging — secrets and deletion-shaped names
+    // are untouchable from chat even with a human click downstream.
+    expect(classifyCall('get_api_keys')).toBe('deny');
+    expect(classifyCall('delete_user', {})).toBe('deny');
+    expect(classifyCall('')).toBe('deny');
+  });
+
+  it('the stage notice forbids claiming completion', () => {
+    expect(STAGE_NOTICE).toMatch(/NOT executed/i);
+    expect(STAGE_NOTICE).toMatch(/Never claim/i);
+  });
+
+  it('the model cannot hold the approval pen', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const src = readFileSync(
+      join(__dirname, '../../../supabase/functions/workspace-chat/index.ts'),
+      'utf8',
+    );
+    // Approval flags are stripped from model-supplied arguments BEFORE any
+    // call — a prompt injection must not be able to self-approve.
+    expect(src).toMatch(/delete \(args as any\)\._approved;/);
+    expect(src).toMatch(/delete \(args as any\)\._approved_operation_id;/);
+    expect(src).toMatch(/delete \(args as any\)\.force_staged;/);
+    // Writes go out with force_staged set by the SERVER, from the tier.
+    expect(src).toMatch(/tier === 'stage' \? \{ force_staged: true \}/);
+  });
+
+  it('agent-execute honours force_staged in the body, not in args', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const src = readFileSync(
+      join(__dirname, '../../../supabase/functions/agent-execute/index.ts'),
+      'utf8',
+    );
+    expect(src).toMatch(/\(body as any\)\.force_staged === true/);
+    expect(src).toMatch(/requires_staging === true \|\| forceStaged/);
+  });
+});
+
 describe('workspace-chat mounts the surface', () => {
   it('execute_skill is gated by isReadSkill and runs as flowwork', async () => {
     const { readFileSync } = await import('fs');
@@ -113,7 +160,7 @@ describe('workspace-chat mounts the surface', () => {
       'utf8',
     );
     // The gate must sit inside the executor, not in the prompt.
-    expect(src).toMatch(/if \(!isReadCall\(name, args\)\) return \{ ok: false, body: \{ error: WRITE_REFUSAL \}, name \};/);
+    expect(src).toMatch(/if \(tier === 'deny'\) return \{ ok: false, body: \{ error: WRITE_REFUSAL \}, name \};/);
     // The activity trail must name the surface, so agent_activity shows WHO acted.
     expect(src).toMatch(/agent_type: 'flowwork'/);
     expect(src).toMatch(/caller_user_id: userId/);

--- a/src/pages/admin/WorkspaceChatPage.tsx
+++ b/src/pages/admin/WorkspaceChatPage.tsx
@@ -38,6 +38,7 @@ import {
   type CoworkAttachment,
 } from '@/components/admin/workspace/AttachmentChip';
 import { MessageBubble } from '@/components/admin/workspace/MessageBubble';
+import { StagedActionCard } from '@/components/admin/workspace/StagedActionCard';
 import {
   Send,
   Square,
@@ -124,7 +125,7 @@ export default function WorkspaceChatPage() {
 
   const effectiveMode: 'strict' | 'cowork' = modeOverride ?? settings?.mode ?? 'cowork';
 
-  const { messages, isStreaming, send, stop, reset, loadHistory, lastContextMeta, regenerate } = useWorkspaceChat({
+  const { messages, isStreaming, send, stop, reset, loadHistory, lastContextMeta, regenerate, resolveStaged } = useWorkspaceChat({
     sources,
     mode: effectiveMode,
     onError: (msg) =>
@@ -562,8 +563,8 @@ export default function WorkspaceChatPage() {
                   {messages.map((m, idx) => {
                     const isLast = idx === messages.length - 1;
                     return (
+                      <div key={m.id} className="space-y-2">
                       <MessageBubble
-                        key={m.id}
                         role={m.role}
                         content={m.content}
                         consulted={m.consulted}
@@ -588,6 +589,16 @@ export default function WorkspaceChatPage() {
                           setSheetOpen(true);
                         }}
                       />
+                      {m.staged?.map((a) => (
+                        <StagedActionCard
+                          key={a.operation_id}
+                          action={a}
+                          onResolved={(resolution, note) =>
+                            resolveStaged(m.id, a.operation_id, resolution, note)
+                          }
+                        />
+                      ))}
+                      </div>
                     );
                   })}
                 </div>

--- a/supabase/functions/_shared/skills/read-surface.ts
+++ b/supabase/functions/_shared/skills/read-surface.ts
@@ -90,8 +90,30 @@ export function isReadCall(name: string, args?: Record<string, unknown>): boolea
   return READ_ACTIONS.has(action);
 }
 
+/**
+ * Three tiers, decided per CALL:
+ *   'read'  — execute immediately (isReadCall)
+ *   'stage' — a write: create a pending operation, human click executes
+ *   'deny'  — never touched from chat (secrets, deletion-shaped, empty)
+ * Fail-closed: the deny pattern wins over everything.
+ */
+export function classifyCall(
+  name: string,
+  args?: Record<string, unknown>,
+): 'read' | 'stage' | 'deny' {
+  const n = String(name || '').toLowerCase().trim();
+  if (!n || DENY_PATTERN.test(n)) return 'deny';
+  if (isReadCall(name, args)) return 'read';
+  return 'stage';
+}
+
 /** What the model is told when it reaches for a skill outside the surface. */
 export const WRITE_REFUSAL =
   'FlowWork runs a read-only tool surface. This skill would change data, so it was not executed. ' +
   'Describe the action you recommend and point the user to the right admin page — or, if they ask, ' +
   'draft the exact skill call so an admin can run it.';
+
+/** What the model is told when a write was staged instead of executed. */
+export const STAGE_NOTICE =
+  'The action was NOT executed. It is staged as a pending operation awaiting the user\'s approval — an approval card is shown in the chat. ' +
+  'Summarize exactly what will happen when approved. Never claim the action is done.';

--- a/supabase/functions/agent-execute/index.ts
+++ b/supabase/functions/agent-execute/index.ts
@@ -467,7 +467,12 @@ serve(async (req) => {
     //     Skills flagged requires_staging=true return a staged envelope on first call,
     //     creating a pending_operations row. Caller must approve_pending_operation, then
     //     re-invoke with _approved_operation_id=<uuid> to actually execute.
-    const requiresStaging = (skill as any).requires_staging === true;
+    // force_staged: the caller demands the staging envelope regardless of the
+    // skill's own flags. FlowWork's write path sets this — an employee's chat
+    // proposes, a human click executes. The flag lives in the BODY, never in
+    // skill arguments, so a model cannot un-set it.
+    const forceStaged = (body as any).force_staged === true;
+    const requiresStaging = (skill as any).requires_staging === true || forceStaged;
     const approvedOpId = (args as any)?._approved_operation_id as string | undefined;
     if (approvedOpId) delete (args as any)._approved_operation_id;
 

--- a/supabase/functions/workspace-chat/index.ts
+++ b/supabase/functions/workspace-chat/index.ts
@@ -24,7 +24,7 @@ import { resolveAiConfig, isAnthropicProvider } from '../_shared/ai-config.ts';
 import { logAiUsage } from '../_shared/ai-usage-logger.ts';
 import { knowledgeChunksSource, flowtableSource, type SourceCtx } from '../_shared/retrieval/sources.ts';
 import { scoreSkillsByIntent } from '../_shared/skills/intent-scorer.ts';
-import { isReadSkill, isReadCall, WRITE_REFUSAL } from '../_shared/skills/read-surface.ts';
+import { isReadSkill, isReadCall, classifyCall, WRITE_REFUSAL, STAGE_NOTICE } from '../_shared/skills/read-surface.ts';
 import { embedQuery } from '../_shared/retrieval/embedder.ts';
 
 const corsHeaders = {
@@ -457,7 +457,7 @@ const DISPATCH_TOOLS = [
     function: {
       name: 'execute_skill',
       description:
-        'Execute a read-only skill from search_skills and get its live result. Pass arguments matching the skill\'s parameter contract. Results are workspace facts — cite them.',
+        'Execute a skill from search_skills. READS return their live result immediately — cite it. WRITES (create/update/send/book) are automatically STAGED for the user\'s approval and never run directly, so calling this for a write is always safe: it produces an approval card, not a side effect.',
       parameters: {
         type: 'object',
         properties: {
@@ -474,27 +474,58 @@ const DISPATCH_TOOLS = [
 async function runSearchSkills(service: any, query: string) {
   const { data: skills } = await service
     .from('agent_skills')
-    .select('name, description, category, instructions')
+    .select('name, description, category, instructions, tool_definition')
     .limit(1000);
   const readable = (skills || []).filter(
     (sk: any) => isReadSkill(sk.name) || isReadCall(sk.name, { action: 'list' }),
   );
-  const ranked = scoreSkillsByIntent(readable, String(query || ''), { maxSkills: 8, alwaysInclude: ['get_customer_360'] });
+  // Compound anchoring: Swedish (and German, and …) glues entity words
+  // together — "supportticket" hides "ticket" from word-level scoring, and the
+  // scorer demonstrably ranked manage_ticket outside top-8 for exactly that
+  // message. If a catalog name TOKEN appears inside a query word, that skill
+  // is always in the list. Pure string containment against the catalog — no
+  // intent routing (Law 1).
+  const queryWords = String(query || '').toLowerCase().split(/[^\p{L}\p{N}_]+/u).filter((w) => w.length >= 5);
+  const anchors = new Set<string>(['get_customer_360']);
+  for (const sk of readable) {
+    const tokens = String(sk.name).split('_').filter((t: string) => t.length >= 4);
+    if (tokens.some((t: string) => queryWords.some((w) => w.includes(t)))) {
+      anchors.add(sk.name);
+      if (anchors.size >= 6) break;
+    }
+  }
+  // The scorer expects OpenAI tool shape (skill.function.name) — feeding it
+  // raw catalog rows scored EMPTY STRINGS for every skill and turned the whole
+  // ranking into noise (observed live: get_agent_trace topping a ticket
+  // question). Wrap rows before scoring.
+  const scorable = readable.map((sk: any) => ({
+    ...sk,
+    function: { name: sk.name, description: sk.description },
+  }));
+  const ranked = scoreSkillsByIntent(scorable, String(query || ''), { maxSkills: 8, alwaysInclude: [...anchors] });
   return {
-    skills: ranked.map((sk: any) => ({
-      name: sk.name,
-      description: String(sk.description || '').slice(0, 240),
-      has_instructions: !!sk.instructions,
-      ...(String(sk.name).startsWith('manage_')
-        ? { read_only_with: 'arguments.action must be one of list|get|search|view|check|status' }
-        : {}),
-    })),
-    note: 'Read-only surface. manage_* skills are readable ONLY with a read action argument; anything that would CHANGE data must be proposed to the user instead.',
+    skills: ranked.map((sk: any) => {
+      // Parameter NAMES up front: a bounced call costs a whole tool round, and
+      // weak models burn their patience on rounds. Contract-first beats
+      // guess-and-bounce.
+      const props = sk.tool_definition?.function?.parameters?.properties;
+      const params = props && typeof props === 'object' ? Object.keys(props).slice(0, 20).join(', ') : undefined;
+      return {
+        name: sk.name,
+        description: String(sk.description || '').slice(0, 240),
+        has_instructions: !!sk.instructions,
+        ...(params ? { params } : {}),
+        ...(String(sk.name).startsWith('manage_')
+          ? { actions: 'read with {"action":"list"|"get"|"search"}; a write action (create/update/…) STAGES the change for user approval' }
+          : {}),
+      };
+    }),
+    note: 'Reads execute immediately. Writes are staged for the user\'s approval — never executed directly — so proposing an action = calling execute_skill with the write arguments.',
   };
 }
 
 async function runReadSkillTool(service: any, name: string) {
-  if (!isReadCall(name, { action: 'list' })) return { error: WRITE_REFUSAL };
+  if (classifyCall(name, { action: 'list' }) === 'deny') return { error: WRITE_REFUSAL };
   const { data } = await service
     .from('agent_skills')
     .select('name, description, instructions, tool_definition')
@@ -523,28 +554,142 @@ async function resolveSkillName(service: any, name: string): Promise<string> {
   return candidates.find((c) => found.has(c)) ?? name;
 }
 
+interface StagedAction {
+  operation_id: string;
+  skill: string;
+  args: Record<string, unknown>;
+  reinvoke_args: Record<string, unknown>;
+  preview?: unknown;
+  /** Server-side name→uuid substitutions, shown on the card. */
+  resolved?: string[];
+}
+
 async function runExecuteSkill(
   service: any,
   supabaseUrl: string,
   serviceKey: string,
   rawName: string,
-  args: Record<string, unknown>,
+  rawArgs: Record<string, unknown>,
   userId: string,
-): Promise<{ ok: boolean; body: unknown; name: string }> {
+): Promise<{ ok: boolean; body: unknown; name: string; staged?: StagedAction }> {
   const name = await resolveSkillName(service, rawName);
-  if (!isReadCall(name, args)) return { ok: false, body: { error: WRITE_REFUSAL }, name };
+
+  // The model must NEVER hold the approval pen. These flags are how a human
+  // click executes a staged operation — strip them from model-supplied args so
+  // a prompt injection cannot self-approve.
+  const args: Record<string, unknown> = { ...(rawArgs ?? {}) };
+  delete (args as any)._approved;
+  delete (args as any)._approved_operation_id;
+  delete (args as any).force_staged;
+
+  const tier = classifyCall(name, args);
+  if (tier === 'deny') return { ok: false, body: { error: WRITE_REFUSAL }, name };
+
+  // A write must match the skill's parameter contract BEFORE a human is asked
+  // to approve it. A model that grabs the wrong skill and invents parameters
+  // (manage_automations with entity_type:'ticket', observed live) would
+  // otherwise stage garbage that LOOKS approvable. Unknown keys → bounce with
+  // the real contract so the model self-corrects — the PGRST202 philosophy,
+  // applied pre-flight.
+  if (tier === 'stage') {
+    const { data: skillRow } = await service
+      .from('agent_skills')
+      .select('tool_definition')
+      .eq('name', name)
+      .maybeSingle();
+    const props = skillRow?.tool_definition?.function?.parameters?.properties;
+    if (props && typeof props === 'object') {
+      const valid = new Set(Object.keys(props));
+      const unknown = Object.keys(args).filter((k) => !valid.has(k));
+      if (unknown.length) {
+        return {
+          ok: false,
+          name,
+          body: {
+            error: `Not staged: unknown parameter(s) ${unknown.join(', ')} for skill "${name}".`,
+            valid_parameters: [...valid],
+            hint: 'If these parameters do not fit what you are trying to do, this is probably the wrong skill — call search_skills for the module that owns the entity (e.g. manage_ticket for tickets).',
+          },
+        };
+      }
+      // Reference args must be REFERENCES. A name in an _id field ("company_id":
+      // "Nordisk Fiber AB", observed live) passes the key check, gets approved
+      // by a human, and then dies on the uuid cast — the card ends up wearing
+      // an error a lookup would have prevented. Bounce it pre-stage instead.
+      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const badRefs = Object.entries(args).filter(([k, v]) =>
+        k.endsWith('_id') && typeof v === 'string' && v.trim() !== '' && !UUID_RE.test(v.trim()));
+      // A name in an _id field is usually RESOLVABLE: company_id="Nordisk
+      // Fiber AB" names exactly one row in companies. Resolve it server-side —
+      // deterministic, and the approval card shows the substitution. Only an
+      // ambiguous or unknown name bounces back to the model. (Weak models
+      // repeatedly promised "jag skapar den nu…" instead of doing this lookup
+      // themselves; eleven live smokes said stop asking them to.)
+      const resolvedNotes: string[] = [];
+      for (const [k, v] of badRefs) {
+        const entity = k.slice(0, -3);
+        const table = entity.endsWith('y') ? `${entity.slice(0, -1)}ies` : `${entity}s`;
+        try {
+          const { data: matches } = await service
+            .from(table).select('id, name').ilike('name', String(v).trim()).limit(2);
+          if (matches?.length === 1) {
+            args[k] = matches[0].id;
+            resolvedNotes.push(`${k}: "${v}" → ${matches[0].id}`);
+            continue;
+          }
+          return {
+            ok: false,
+            name,
+            body: {
+              error: `Not staged: ${k}="${v}" ${matches?.length ? 'matches several rows' : `has no match in ${table}`} — an _id parameter needs a UUID.`,
+              hint: 'Look the id up (e.g. a list/search skill for that entity, or get_customer_360), then stage again with the real id — or omit the field if it is optional.',
+            },
+          };
+        } catch {
+          return {
+            ok: false,
+            name,
+            body: {
+              error: `Not staged: ${k}="${v}" is not a UUID and could not be resolved.`,
+              hint: 'Look the id up first, then stage again — or omit the field if optional.',
+            },
+          };
+        }
+      }
+      if (resolvedNotes.length) (args as any).__resolved = resolvedNotes;
+    }
+  }
+
   try {
     const resp = await fetch(`${supabaseUrl}/functions/v1/agent-execute`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${serviceKey}`, 'Content-Type': 'application/json' },
       body: JSON.stringify({
         skill_name: name,
-        arguments: args ?? {},
+        arguments: (() => { const a = { ...args }; delete (a as any).__resolved; return a; })(),
         agent_type: 'flowwork',
         caller_user_id: userId,
+        // Writes NEVER execute from chat: they stage, and the approval card's
+        // human click is the initiative transfer.
+        ...(tier === 'stage' ? { force_staged: true } : {}),
       }),
     });
-    let body = await resp.json().catch(() => ({ error: `agent-execute returned ${resp.status}` }));
+    let body: any = await resp.json().catch(() => ({ error: `agent-execute returned ${resp.status}` }));
+
+    if (tier === 'stage' && body?.staged === true && body?.operation_id) {
+      const resolved = (args as any).__resolved as string[] | undefined;
+      delete (args as any).__resolved;
+      const staged: StagedAction = {
+        operation_id: String(body.operation_id),
+        skill: name,
+        args,
+        ...(resolved ? { resolved } : {}),
+        reinvoke_args: body?.next?.reinvoke_args ?? { _approved_operation_id: body.operation_id },
+        preview: body?.preview,
+      };
+      return { ok: true, body: { status: 'staged', operation_id: staged.operation_id, note: STAGE_NOTICE }, name, staged };
+    }
+
     if (!resp.ok && JSON.stringify(body).includes('Skill not found')) {
       body = { ...body, hint: 'That skill name does not exist. Call search_skills to discover the correct name — many modules expose manage_<entity> with arguments {"action":"list"}.' };
     }
@@ -677,7 +822,7 @@ Deno.serve(async (req) => {
       `2. You ${allowWorld ? 'MAY' : 'MUST NOT'} use your own training knowledge when context is insufficient. Be explicit when you do (e.g. "Outside your workspace: …").`,
       `3. You ${webSearchOn ? 'MAY' : 'MUST NOT'} call the web_search tool for current/live external info — but only when the answer is not in the workspace context.`,
       '4. Workspace items must be cited with [N] markers. Web results should be cited as plain markdown links.',
-      '5. Tools are READ-ONLY: look up live module data freely, but never change anything. For mutations, describe the action and point to the relevant admin page.',
+      '5. Reads execute immediately. WRITES never execute from chat: when the user asks you to DO something (create, update, send, book), call execute_skill with complete arguments RIGHT AWAY — the platform stages it and shows an approval card, and THE CARD IS THE CONFIRMATION. Do NOT ask "shall I?" first when the request already contains the details; staging is safe by construction. If a staging attempt bounces (unknown parameters / wrong skill), do NOT give up: call search_skills with the entity word (ticket, invoice, …) and stage again with the correct skill — you have tool rounds left. IDs you learned from earlier tool results (a company_id from manage_company or get_customer_360) are yours to use — never ask the user for an id a tool already gave you. And NEVER end your reply with a promise (\'jag genomför det nu\') — either the tool call happens in THIS turn, or you say the action awaits approval.',
       '7. When the question concerns a SPECIFIC customer, company, order, invoice, ticket or deal and the CONTEXT block does not already answer it, you MUST call search_skills and then execute_skill BEFORE answering (e.g. get_customer_360 for a full customer picture, list_tickets, list_invoices). NEVER ask the user for permission to look something up, and never answer "I could not find it" without having executed at least one skill. Always call search_skills FIRST to get exact names — many modules expose manage_<entity>, readable with arguments {"action":"list", ...filters}. Max 4 tool rounds; be economical.',
       '8. HONESTY: claim "no tickets / no unpaid invoices / no X" ONLY when a skill you executed returned an empty result for exactly that entity and that company. If your executed skills did not cover something, say plainly that you could not check it. Never present a lookup of the wrong module as an answer.',
       '9. AMOUNTS: money fields in skill results are minor units — a field ending in _cents holds hundredths (total_cents: 2312500 means 23 125,00 kr). Always divide by 100 before presenting, and never invent a currency.',
@@ -695,7 +840,7 @@ Deno.serve(async (req) => {
           '',
           '--- LIVE TOOLS RANKED FOR THIS QUESTION (execute_skill) ---',
           ...pre.skills.map((sk: any) =>
-            `- ${sk.name}${sk.read_only_with ? ' (read via arguments {"action":"list"|"get"|"search"})' : ''}: ${sk.description}`),
+            `- ${sk.name}: ${sk.description}${sk.params ? `\n  params: ${sk.params}` : ''}`),
           'Use exact names. For other needs, call search_skills.',
           '--- END LIVE TOOLS ---',
         ].join('\n');
@@ -727,6 +872,13 @@ Deno.serve(async (req) => {
     // modes want. Web search remains cowork-only and settings-gated.
     const tools = [...(webSearchOn ? [WEB_SEARCH_TOOL] : []), ...DISPATCH_TOOLS];
     const consulted: Array<{ skill: string; ok: boolean; ms: number }> = [];
+    const stagedActions: StagedAction[] = [];
+    // Weak models fetch the missing id and then EXIT with "jag skapar den nu…"
+    // — a promise, no call. Mechanical backstop: if a write bounced and nothing
+    // got staged, the first attempt to finalize earns exactly one reminder
+    // round. Counts, not text-sniffing.
+    let bouncedStage = false;
+    let nudged = false;
 
     // First, run a (non-streaming) pass if tools are enabled, so we can resolve tool calls.
     // If no tools needed → switch to streaming on the second pass.
@@ -767,9 +919,18 @@ Deno.serve(async (req) => {
         const choice = json.choices?.[0];
         const toolCalls = choice?.message?.tool_calls;
         if (!toolCalls || toolCalls.length === 0) {
+          if (bouncedStage && stagedActions.length === 0 && !nudged && round < 3) {
+            nudged = true;
+            conversation.push(choice.message);
+            conversation.push({
+              role: 'system',
+              content: 'Nothing has been staged. If the user asked for a write, call execute_skill NOW with the corrected arguments (use ids from your tool results). If you truly cannot, say exactly what is missing. Do not promise future action.',
+            });
+            continue;
+          }
           // No tool calls — we have the final assistant message. Stream it back as a single chunk.
           const finalText: string = choice?.message?.content || '';
-          return streamFinal(citations, finalText, contextMeta, consulted);
+          return streamFinal(citations, finalText, contextMeta, consulted, stagedActions);
         }
         // Execute tool calls
         conversation.push(choice.message);
@@ -791,10 +952,19 @@ Deno.serve(async (req) => {
             conversation.push({ role: 'tool', tool_call_id: tc.id, content: JSON.stringify(out) });
           } else if (tc.function?.name === 'execute_skill') {
             const t0 = Date.now();
-            const out = await runExecuteSkill(
-              supabaseAdmin, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY,
-              String(args.name || ''), args.arguments ?? {}, user.id,
-            );
+            let out: Awaited<ReturnType<typeof runExecuteSkill>>;
+            if (stagedActions.length >= 2 && classifyCall(String(args.name || ''), args.arguments ?? {}) === 'stage') {
+              // Two proposals per turn is plenty — more reads as spam, and each
+              // card demands a human decision.
+              out = { ok: false, body: { error: 'Max 2 staged actions per message. Summarize what is already staged.' }, name: String(args.name || '') };
+            } else {
+              out = await runExecuteSkill(
+                supabaseAdmin, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY,
+                String(args.name || ''), args.arguments ?? {}, user.id,
+              );
+            }
+            if (out.staged) stagedActions.push(out.staged);
+            if (!out.ok && classifyCall(out.name, args.arguments ?? {}) === 'stage') bouncedStage = true;
             const skillName = out.name;
             consulted.push({ skill: skillName, ok: out.ok, ms: Date.now() - t0 });
             let refNote = '';
@@ -838,7 +1008,7 @@ Deno.serve(async (req) => {
         userId: user.id, metadata: { mode, phase: 'force-final' },
       });
       const finalText: string = json.choices?.[0]?.message?.content || '';
-      return streamFinal(citations, finalText, contextMeta, consulted);
+      return streamFinal(citations, finalText, contextMeta, consulted, stagedActions);
     }
 
     /* -------- No tools: stream straight through -------- */
@@ -925,6 +1095,7 @@ function streamFinal(
   text: string,
   contextMeta?: ContextMeta,
   consulted?: Array<{ skill: string; ok: boolean; ms: number }>,
+  staged?: StagedAction[],
 ): Response {
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
@@ -935,6 +1106,9 @@ function streamFinal(
       }
       if (consulted && consulted.length) {
         controller.enqueue(encoder.encode(`event: consulted\ndata: ${JSON.stringify(consulted)}\n\n`));
+      }
+      if (staged && staged.length) {
+        controller.enqueue(encoder.encode(`event: staged\ndata: ${JSON.stringify(staged)}\n\n`));
       }
       // Emit as a single OpenAI-style delta so the existing client parser handles it.
       const payload = { choices: [{ delta: { content: text } }] };

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1543,11 +1543,11 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:dbad9ea72e69bc21770ef215dde90e809b8d7123750096beb867df27fbbe08b3",
+      "shared_hash": "sha256:dd2c3efd6a17077a9e6144756df3ba8bebd6a37d523d10d7c66824bbf685e85f",
       "functions": {
         "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
-        "agent-execute": "sha256:8fb1e303c4028132c2a9c88f591c33fdfbdae8a8c11a3b1aa2c1036c2e610c85",
+        "agent-execute": "sha256:f04b7c54ca448a7c4011d245db03f028ec2a4659c6a769ad0296f34e191e65ab",
         "agent-operate": "sha256:72cdafe207ae2a5630e3263e6c993a55aade47c679f2cc200465cb3a17f30689",
         "ai-task": "sha256:6a0c6b21f9f0575650d9e478bc9184ce24541d3a18d00bb6c80c64a60f5e28aa",
         "automation-dispatcher": "sha256:3cb8681d7acce65624bd7957a432b143a2d959d769845dc71696b95c2ea2012b",
@@ -1621,7 +1621,7 @@
         "voice-recording": "sha256:41391de110f7f3e138df5c50b1901dd6c7928d2be18ad82fa5e166d48f66cca2",
         "web-scrape": "sha256:f0948362eb60ff2d597de407af0f3eedb3b0f892b75ce4acff960e0b6ebf146f",
         "web-search": "sha256:6002f6b14ad490cfa0b444129694f123fad021050234cc8f87ee04ebb16c5320",
-        "workspace-chat": "sha256:1fa2caaec72883e0481233db2d35489440d933d7dad5d3f869dc222ac39328f3"
+        "workspace-chat": "sha256:a7bda6127a892d590e794601d94f222e998c929ede08d591394b7fe5a6299c61"
       }
     },
     "frontend": {


### PR DESCRIPTION
## Från svara till agera

FlowWork kan nu **förbereda skrivningar** — men aldrig utföra dem. En skrivning stageas som `pending_operations`-rad (samma räls som FlowPilots staged-läge) och blir ett **godkännandekort i chatten**: skill, argument, eventuella namnupplösningar, Godkänn/Avvisa. Klicket är initiativöverlämningen; agent-execute verifierar server-side att operationen är äkta godkänd och oförfallen innan något körs.

Governance blir därmed **en mekanism för båda initiativmodellerna**: FlowPilot (klockan äger initiativet, trust-dialen godkänner) och FlowWork (människan äger det, kortet godkänner) delar räls, beslutslogg och evidensspår.

## Säkerhetsmodellen

- **Modellen håller aldrig godkännandepennan**: `_approved`, `_approved_operation_id`, `force_staged` strippas ur modellens argument — en promptinjektion kan inte självgodkänna
- Tre nivåer per ANROP (`classifyCall`): read → kör, write → stagea, deny (secrets/delete-format) → rör aldrig
- `force_staged` i agent-execute-kroppen (2 rader): FlowWorks skrivningar stagear oavsett skillens egen trustnivå
- Max 2 kort per meddelande

## Tolv live-smokes — och varje brist blev struktur, inte prompt

Den svaga "fast"-modellen på demo tvingade fram rätt arkitektur:

| Brist (observerad live) | Strukturell fix |
|---|---|
| Frågade om lov i stället för att stagea | "Kortet ÄR bekräftelsen" + verktygsbeskrivningar synkade |
| Gissade skillnamn/plural | Namnupplösning mot katalogen |
| **Rankningen var brus** — `get_agent_trace` toppade en ticketfråga | **Rotorsak: scorern fick råa DB-rader, förväntade tool-form — varje skill fick namnet `''`**. Fixad + kompoundankring (svenska sammansättningar) |
| Stagade fel skill med påhittade argument | **Kontraktsvalidering före staging** — okända parametrar studsar med rätt kontrakt |
| Brände rundor på studsar | **Parameterkontrakten direkt i den för-rankade listan** |
| Namn i `_id`-fält dog på uuid-cast EFTER godkännande | **Server-side namnupplösning**: `company_id:"Nordisk Fiber AB"` → uuid, redovisat på kortet; tvetydigt/okänt studsar |
| Lovade "jag skapar den nu" och slutade | Mekanisk påminnelserunda (räknare, inte textsniffning) |

## Slutbevis (demo, inloggad admin, riktigt godkännandeflöde)

> *"Skapa en supportticket för Nordisk Fiber AB: ämne 'Uppföljning omförhandling' … hög prioritet."*
>
> **Runda 1**: staged — `manage_ticket`, `company_id: "Nordisk Fiber AB" → bbbbbbbb-…` upplöst server-side. Svar: *"…väntar nu på din godkännande."* Inget utfört (verifierat: 0 tickets).
> **Godkänn** (exakt kortets anrop): `approve_pending_operation` ✓ → återanrop ✓ → **ticket skapad med rätt bolagskoppling** → operationen `executed` med tidsstämpel.
> Fel-fallet också bevisat: ett ogiltigt argument efter godkännande ger `failed` på både kort och operation — aldrig en tyst lögn.

## Utrullning

2 247 tester gröna (15 grindtester på ytan). `workspace-chat` + `agent-execute` deployade på optic, www, demo, autoversio. **liteit**: ägaren deployar båda (403 för mina tokens). Forkar behöver frontendsynk för kortet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)