### PR TITLE
Aktivitetsloggen känner alla sina aktörer

### DIFF
--- a/supabase/migrations/20260811120000_the-activity-log-knows-all-its-actors.sql
+++ b/supabase/migrations/20260811120000_the-activity-log-knows-all-its-actors.sql
@@ -1,0 +1,20 @@
+-- ============================================================================
+-- The activity log must know every actor that acts.
+--
+-- agent_activity.agent is the enum agent_type — and it stopped growing when
+-- the platform didn't: 'admin_ui' (the B1a callSkill rail) and 'flowwork'
+-- (the employee dispatch surface) were never added. Every logActivity insert
+-- for those actors has failed silently ever since: the skill executed, the
+-- evidence did not land.
+--
+-- On a platform whose objectives close on EVIDENCE from agent_activity —
+-- never on prose — a caller whose actions cannot be logged is a caller whose
+-- work cannot be proven. The monitors watching for FlowWork's first live
+-- calls were blind by construction.
+--
+-- ALTER TYPE ... ADD VALUE cannot run inside a DO block; plain statements,
+-- idempotent via IF NOT EXISTS.
+-- ============================================================================
+
+ALTER TYPE public.agent_type ADD VALUE IF NOT EXISTS 'admin_ui';
+ALTER TYPE public.agent_type ADD VALUE IF NOT EXISTS 'flowwork';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260811021000",
-      "migrations_count": 382,
+      "migration_head": "20260811120000",
+      "migrations_count": 383,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1533,6 +1533,10 @@
         {
           "version": "20260811021000",
           "name": "the-extractor-says-success-the-indexer-heard-completed"
+        },
+        {
+          "version": "20260811120000",
+          "name": "the-activity-log-knows-all-its-actors"
         }
       ]
     },


### PR DESCRIPTION
agent_type-enumen saknade `admin_ui` och `flowwork` — varje aktivitetslogg för dem har felat tyst (skillen kördes, evidensen landade aldrig; vakterna var blinda per konstruktion). Idempotent `ADD VALUE IF NOT EXISTS`, redan körd på alla fem instanser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)