### PR TITLE
Ticketdraeern läser den färska raden — tilldelningen 'bet' hela tiden

### DIFF
--- a/src/components/admin/tickets/TicketsKanban.tsx
+++ b/src/components/admin/tickets/TicketsKanban.tsx
@@ -27,7 +27,9 @@ interface TicketsKanbanProps {
 export function TicketsKanban({ tickets, isLoading }: TicketsKanbanProps) {
   const { data: stages = [], isLoading: stagesLoading } = usePipelineStages('ticket');
   const updateTicket = useUpdateTicket();
-  const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
+  // Same rule as TicketsTable: look the drawer's ticket up by id from the
+  // fresh list — a held copy goes stale the moment the drawer mutates it.
+  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
 
   const sensors = useSensors(
@@ -124,7 +126,7 @@ export function TicketsKanban({ tickets, isLoading }: TicketsKanbanProps) {
                 stage={stage}
                 index={idx}
                 tickets={byStage[stage.id] ?? []}
-                onTicketClick={setSelectedTicket}
+                onTicketClick={(t) => setSelectedTicketId(t.id)}
               />
             ))}
           </div>
@@ -142,9 +144,9 @@ export function TicketsKanban({ tickets, isLoading }: TicketsKanbanProps) {
       </DndContext>
 
       <TicketDetailDrawer
-        ticket={selectedTicket}
-        open={!!selectedTicket}
-        onOpenChange={(open) => !open && setSelectedTicket(null)}
+        ticket={tickets.find((t) => t.id === selectedTicketId) ?? null}
+        open={!!selectedTicketId}
+        onOpenChange={(open) => !open && setSelectedTicketId(null)}
       />
     </>
   );

--- a/src/components/admin/tickets/TicketsTable.tsx
+++ b/src/components/admin/tickets/TicketsTable.tsx
@@ -45,7 +45,11 @@ interface TicketsTableProps {
 const BULK_STATUSES: TicketStatus[] = ['new', 'open', 'in_progress', 'waiting', 'resolved', 'closed'];
 
 export function TicketsTable({ tickets, isLoading, autoOpenTicketId }: TicketsTableProps) {
-  const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
+  // The drawer's ticket is LOOKED UP from the fresh list by id — never held
+  // as a copy. A held copy froze at open time, so an assignee change wrote to
+  // the DB, the list refetched, and the drawer still showed the old value:
+  // the update looked like it didn't stick (optic, 2026-08-11).
+  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const { data: assignees = [] } = useTicketAssignees();
   const { data: teams = [] } = useTicketTeams();
@@ -60,7 +64,7 @@ export function TicketsTable({ tickets, isLoading, autoOpenTicketId }: TicketsTa
   useEffect(() => {
     if (!autoOpenTicketId) return;
     const found = tickets.find((t) => t.id === autoOpenTicketId);
-    if (found) setSelectedTicket(found);
+    if (found) setSelectedTicketId(found.id);
   }, [autoOpenTicketId, tickets]);
 
   const allSelected = tickets.length > 0 && selectedIds.length === tickets.length;
@@ -173,7 +177,7 @@ export function TicketsTable({ tickets, isLoading, autoOpenTicketId }: TicketsTa
               <TableRow
                 key={ticket.id}
                 className="cursor-pointer"
-                onClick={() => setSelectedTicket(ticket)}
+                onClick={() => setSelectedTicketId(ticket.id)}
               >
                 <TableCell onClick={(e) => e.stopPropagation()}>
                   <Checkbox
@@ -237,9 +241,9 @@ export function TicketsTable({ tickets, isLoading, autoOpenTicketId }: TicketsTa
       </div>
 
       <TicketDetailDrawer
-        ticket={selectedTicket}
-        open={!!selectedTicket}
-        onOpenChange={(open) => !open && setSelectedTicket(null)}
+        ticket={tickets.find((t) => t.id === selectedTicketId) ?? null}
+        open={!!selectedTicketId}
+        onOpenChange={(open) => !open && setSelectedTicketId(null)}
       />
     </>
   );


### PR DESCRIPTION
Magnus tilldelade en ticket till admin och såg det inte bita. Det bet: `assigned_to` låg rätt i databasen. Draeern höll en **kopia** av ticketen från öppningsögonblicket — mutationen skrev, listan hämtades om, kopian frös. Nu slås draeerns ticket upp ur färska listan per id, i både tabell och kanban. Ett faktum, en källa — samma regel som IB:n fick i går.

🤖 Generated with [Claude Code](https://claude.com/claude-code)