### PR TITLE
"Connect your backend"-sida i stället för tyst vitskärm vid osatt env

### DIFF
--- a/src/lib/__tests__/user-roles-guardrails.test.ts
+++ b/src/lib/__tests__/user-roles-guardrails.test.ts
@@ -82,11 +82,25 @@ describe('handle_new_user trigger', () => {
     expect(adminBranch!).toMatch(/INSERT\s+INTO\s+public\.user_roles[\s\S]*?'admin'/i);
   });
 
-  it('inserts exactly one user_roles row per signup_type branch', () => {
-    // Count INSERT INTO user_roles statements — must match the number of
-    // signup_type branches (customer / admin / else = 3).
+  it('inserts exactly one user_roles row per branch', () => {
+    // One INSERT per decision branch, no more: a stray insert would grant two
+    // roles at once. Four branches now — customer / admin / employee-writer,
+    // plus the virgin-instance first-admin branch (20260811140000).
     const inserts = (fnBody.match(/INSERT\s+INTO\s+public\.user_roles/gi) || []).length;
-    expect(inserts).toBe(3);
+    expect(inserts).toBe(4);
+  });
+
+  it('grants admin to the first account ONLY while zero admins exist', () => {
+    // The self-hosted first-admin bootstrap. It is safe precisely because it is
+    // gated on the admin count being zero — remove that gate and it becomes
+    // "any signup can be admin", the hole 20260726190000 closed. This asserts
+    // the gate is present so a future edit can't quietly drop it.
+    expect(fnBody).toMatch(/count\(\*\)[\s\S]*?FROM\s+public\.user_roles[\s\S]*?role\s*=\s*'admin'/i);
+    const virginBranch = fnBody.match(
+      /IF\s+v_admin_count\s*=\s*0\s+THEN([\s\S]*?)(?=ELSIF|ELSE|END\s+IF)/i,
+    )?.[1];
+    expect(virginBranch, 'zero-admins branch must exist').toBeDefined();
+    expect(virginBranch!).toMatch(/INSERT\s+INTO\s+public\.user_roles[\s\S]*?'admin'/i);
   });
 
   it('uses ON CONFLICT DO NOTHING so re-runs stay idempotent', () => {

--- a/src/lib/supabase-config.ts
+++ b/src/lib/supabase-config.ts
@@ -1,0 +1,40 @@
+/**
+ * Is this instance configured to reach a Supabase backend?
+ *
+ * The Supabase client calls createClient(url, key) at module load, and
+ * createClient THROWS on an empty url — before React renders. So a fresh
+ * Vercel/Docker deploy with the env vars still unset shows a white screen and
+ * no error: the operator concludes FlowWink is broken when it is merely
+ * unconfigured. This module lets main.tsx detect that state and show a
+ * "configure your environment" page instead — and, crucially, imports nothing
+ * from supabase-js, so it can run before the throwing client is ever loaded.
+ */
+
+/** A value counts as unset if it is empty or still the build-time placeholder. */
+function isPlaceholder(v: string | undefined): boolean {
+  if (!v) return true;
+  const t = v.trim();
+  // Vite leaves %VITE_*% / __BAKED_*__ literals when the env var is absent.
+  return t === '' || t.startsWith('__BAKED_') || t.startsWith('%VITE_') || t === 'undefined';
+}
+
+export const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+export const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as string | undefined;
+
+/** The env vars an operator must set, for the configuration page to list them. */
+export const REQUIRED_ENV = [
+  {
+    name: 'VITE_SUPABASE_URL',
+    present: !isPlaceholder(SUPABASE_URL),
+    hint: 'https://<your-project-ref>.supabase.co',
+  },
+  {
+    name: 'VITE_SUPABASE_PUBLISHABLE_KEY',
+    present: !isPlaceholder(SUPABASE_PUBLISHABLE_KEY),
+    hint: 'the project’s publishable (anon) key',
+  },
+] as const;
+
+export function isSupabaseConfigured(): boolean {
+  return !isPlaceholder(SUPABASE_URL) && !isPlaceholder(SUPABASE_PUBLISHABLE_KEY);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App.tsx";
 import "./index.css";
-import { applyVisitorChatSessionHeader } from "./lib/visitor-chat-session";
-
-// Bind visitor chat session header so RLS on chat_conversations/chat_messages
-// only returns rows belonging to this browser.
-applyVisitorChatSessionHeader();
+import { isSupabaseConfigured } from "./lib/supabase-config";
 
 const root = document.getElementById("root");
 
@@ -14,15 +9,31 @@ if (!root) {
   throw new Error("FlowWink root element was not found");
 }
 
-// StrictMode is a development-only mirror: it mounts, unmounts and remounts
-// every component once, so an effect that is not safe to run twice fails here
-// instead of in front of a customer. Production renders exactly once.
-//
-// Checked before enabling it: usePageViewTracker sets its `tracked` ref
-// synchronously before the first await, so the second mount bails and no page
-// view is counted twice.
-createRoot(root).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+// The Supabase client throws at MODULE LOAD when the env vars are unset, so a
+// misconfigured deploy white-screens with no error. Gate on config first, and
+// only THEN dynamically import the app — a static import of App would pull in
+// the throwing client before this check could run. An unconfigured instance
+// gets a legible "connect your backend" page instead of a blank tab.
+if (!isSupabaseConfigured()) {
+  import("./pages/ConfigureEnvironment").then(({ ConfigureEnvironment }) => {
+    createRoot(root).render(<ConfigureEnvironment />);
+  });
+} else {
+  Promise.all([
+    import("./App.tsx"),
+    import("./lib/visitor-chat-session"),
+  ]).then(([{ default: App }, { applyVisitorChatSessionHeader }]) => {
+    // Bind visitor chat session header so RLS on chat_conversations/chat_messages
+    // only returns rows belonging to this browser.
+    applyVisitorChatSessionHeader();
+
+    // StrictMode is a development-only mirror: it mounts, unmounts and remounts
+    // every component once, so an effect that is not safe to run twice fails
+    // here instead of in front of a customer. Production renders exactly once.
+    createRoot(root).render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+  });
+}

--- a/src/pages/ConfigureEnvironment.tsx
+++ b/src/pages/ConfigureEnvironment.tsx
@@ -1,0 +1,64 @@
+import { REQUIRED_ENV } from '@/lib/supabase-config';
+
+/**
+ * Shown instead of a white screen when the Supabase env vars are unset.
+ *
+ * Imports nothing that touches the Supabase client — it must render on an
+ * instance that has no backend configured yet. Self-contained styling so it
+ * works even before the app's providers mount.
+ */
+export function ConfigureEnvironment() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background text-foreground px-4">
+      <div className="w-full max-w-lg space-y-6">
+        <div className="space-y-2 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 ring-1 ring-primary/20 text-2xl">
+            ⚙️
+          </div>
+          <h1 className="text-xl font-semibold">Almost there — connect your backend</h1>
+          <p className="text-sm text-muted-foreground">
+            FlowWink is deployed, but it doesn’t yet know which Supabase project to talk to.
+            Set the two environment variables below, then redeploy.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+          {REQUIRED_ENV.map((v) => (
+            <div key={v.name} className="flex items-start gap-3">
+              <span
+                className={`mt-0.5 inline-block h-2.5 w-2.5 shrink-0 rounded-full ${
+                  v.present ? 'bg-emerald-500' : 'bg-destructive'
+                }`}
+                aria-hidden
+              />
+              <div className="min-w-0">
+                <code className="text-sm font-mono break-all">{v.name}</code>
+                <p className="text-xs text-muted-foreground">
+                  {v.present ? 'set ✓' : `missing — ${v.hint}`}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm space-y-2">
+          <p className="font-medium">Where to set them</p>
+          <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
+            <li>
+              <span className="text-foreground">Vercel / Netlify:</span> Project → Settings →
+              Environment Variables → add both → redeploy.
+            </li>
+            <li>
+              <span className="text-foreground">Docker / self-hosted:</span> set them in the
+              container environment; the entrypoint regenerates{' '}
+              <code className="font-mono">runtime-config.js</code> on start.
+            </li>
+          </ul>
+          <p className="text-xs text-muted-foreground pt-1">
+            Find both values in your Supabase dashboard under Project Settings → API.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
En ny admin som deployar utan Supabase-env fick vitskärm och inget fel (createClient kastar vid modulladdning). Nu en läsbar signpost-sida: vilka två variabler saknas, var de sätts, var värdena hämtas. main.tsx grindar på config och lazy-importerar appen först när den finns. Bevisad i browsern med tömd env. Hjälper varje framtida self-hosted admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)