### PR TITLE
config.toml deklarerar alla edge-funktioner (annars föds GitHub-synkad instans utan mejl/inbjudningar/fakturering)

### DIFF
--- a/src/lib/__tests__/config-toml-declares-every-function.guardrails.test.ts
+++ b/src/lib/__tests__/config-toml-declares-every-function.guardrails.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Every edge function on disk must be declared in supabase/config.toml.
+ *
+ * The Supabase GitHub integration deploys, on merge, exactly the functions
+ * declared as [functions.<name>] — nothing else. When 17 real functions
+ * (including the mail router, the invite flows and the billing crons) had no
+ * declaration, a fresh GitHub-synced instance was born unable to send mail,
+ * invite colleagues, or bill. The gap was invisible: the instance looked live.
+ *
+ * This gate makes the manifest and the directory agree, so the next function
+ * added without a declaration fails CI instead of shipping a silent hole.
+ */
+
+const ROOT = join(__dirname, '../../..');
+const FUNCTIONS_DIR = join(ROOT, 'supabase/functions');
+const CONFIG = join(ROOT, 'supabase/config.toml');
+
+// Not deployable functions — shared utilities and test fixtures.
+const NON_FUNCTIONS = new Set(['_shared', 'shared', 'tests']);
+
+function declaredFunctions(): Set<string> {
+  const txt = readFileSync(CONFIG, 'utf8');
+  const names = [...txt.matchAll(/^\[functions\.([^\]]+)\]/gm)].map((m) => m[1]);
+  return new Set(names);
+}
+
+function functionDirs(): string[] {
+  return readdirSync(FUNCTIONS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && !NON_FUNCTIONS.has(d.name))
+    .map((d) => d.name)
+    // A real function has an entry file.
+    .filter((name) => existsSync(join(FUNCTIONS_DIR, name, 'index.ts')));
+}
+
+describe('config.toml declares every edge function', () => {
+  it('leaves no function on disk undeclared (GitHub sync would skip it)', () => {
+    const declared = declaredFunctions();
+    const undeclared = functionDirs().filter((f) => !declared.has(f));
+    expect(
+      undeclared,
+      `These functions exist but are not in config.toml, so a GitHub-synced deploy would NOT ship them: ${undeclared.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('every declaration sets verify_jwt explicitly (no silent gateway default)', () => {
+    const txt = readFileSync(CONFIG, 'utf8');
+    const blocks = [...txt.matchAll(/\[functions\.([^\]]+)\]([\s\S]*?)(?=\n\[|\s*$)/g)];
+    const missing = blocks
+      .filter(([, , body]) => !/verify_jwt\s*=\s*(true|false)/.test(body))
+      .map(([, name]) => name);
+    expect(
+      missing,
+      `verify_jwt must be explicit — an unset value takes the gateway default (true) and silently 401s any cron/anon caller: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+});

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -230,3 +230,63 @@ verify_jwt = false
 
 [functions.workspace-chat]
 verify_jwt = true
+
+# ── Completed 2026-08-11: functions on disk that lacked a [functions.*]
+#    declaration, so the GitHub integration would not deploy them. A fresh
+#    GitHub-synced instance was born WITHOUT its mail router, invites,
+#    user management or billing. verify_jwt derived per invocation:
+#    pg_cron/anon and browser-media fetches are false (true = silent 401 /
+#    blocked media); admin-UI and service-to-service are true (service key
+#    is itself a valid JWT).
+
+[functions.contract-billing-cron]  # daily pg_cron (pg_net anon key) — verify_jwt=true would be a silent 401
+verify_jwt = false
+
+[functions.subscription-billing-cron]  # daily pg_cron (pg_net anon key)
+verify_jwt = false
+
+[functions.dunning-processor]  # runs on cron (pg_net anon key)
+verify_jwt = false
+
+[functions.voice-recording]  # fetched as a media src by the browser — no auth header is sent
+verify_jwt = false
+
+[functions.email-send]  # service-to-service mail router; service key passes; allowlist-guarded internally
+verify_jwt = true
+
+[functions.invite-colleague]  # admin UI, user JWT
+verify_jwt = true
+
+[functions.invite-employee]  # admin UI, user JWT
+verify_jwt = true
+
+[functions.create-user]  # admin UI, user JWT
+verify_jwt = true
+
+[functions.delete-user]  # admin UI, user JWT
+verify_jwt = true
+
+[functions.document-sign-request]  # admin/service sends a signing request
+verify_jwt = true
+
+[functions.integrations-account]  # admin UI
+verify_jwt = true
+
+[functions.check-secrets]  # admin UI
+verify_jwt = true
+
+[functions.system-integrity-check]  # admin UI / service
+verify_jwt = true
+
+[functions.media-optimize]  # admin UI
+verify_jwt = true
+
+[functions.run-platform-tests]  # admin-triggered
+verify_jwt = true
+
+[functions.run-autonomy-tests]  # admin-triggered
+verify_jwt = true
+
+[functions.setup-database]  # provisioning, admin/service
+verify_jwt = true
+


### PR DESCRIPTION
Sista förutsättningen för CLI-fri provisionering. GitHub-integrationen deployar bara [functions.*]-deklarerade funktioner — 17 saknades, inkl mejlrouter, inbjudningar, användarhantering och fakturakörningar. verify_jwt härledd per anropssätt (croner false, admin/service true), inte gissad. Grind failar CI om en funktion saknar deklaration eller har osatt verify_jwt (negativtestad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)