### PR TITLE
Chatten fick noll sidor trots 'alla sidor' — wildcard-kontraktet lagat

### DIFF
--- a/src/lib/__tests__/chat-context-wildcard.guardrails.test.ts
+++ b/src/lib/__tests__/chat-context-wildcard.guardrails.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * `includedPageSlugs: ['*']` means EVERY page — on every reader.
+ *
+ * The wildcard is the contract three parties share: templates ship `['*']` so
+ * a freshly installed site grounds its chat in its own content, the frontend
+ * context indicator renders it as "All pages", and the edge readers select
+ * the content. Two of the three used to disagree — the edge treated `'*'` as
+ * a literal slug, so `.in('slug', ['*'])` matched nothing and the chunk
+ * filter dropped every page chunk.
+ *
+ * The failure was invisible in the settings UI (the flags read as ON, because
+ * they WERE on) and looked like a model problem: asked to list the site's
+ * process pages, the assistant invented seven that do not exist, while KB
+ * answers stayed correct because KB travels a different path. Worse, each
+ * template reinstall overwrote an admin's hand-picked slug list with `['*']`,
+ * silently switching page grounding back off.
+ *
+ * These tests pin the shared helper's semantics AND that both edge readers
+ * route through it — a future reader reintroducing `.length > 0` is the exact
+ * regression to catch.
+ */
+
+const ROOT = join(__dirname, '../../..');
+const CHAT_CONTEXT = join(ROOT, 'supabase/functions/_shared/chat-context.ts');
+const CHAT_COMPLETION = join(ROOT, 'supabase/functions/chat-completion/index.ts');
+
+/** Pull the pure helper out of the Deno module and run it in vitest. */
+function extractHelper(): (slugs: string[] | null | undefined) => boolean {
+  const src = readFileSync(CHAT_CONTEXT, 'utf-8');
+  const start = src.indexOf('export function allowsAllPages');
+  expect(start, 'allowsAllPages must exist in _shared/chat-context.ts').toBeGreaterThan(-1);
+  const end = src.indexOf('\n}\n', start);
+  const js = src
+    .slice(start, end + 2)
+    .replace('export function', 'function')
+    .replace('(slugs: string[] | null | undefined): boolean', '(slugs)');
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function(`${js}; return allowsAllPages;`)() as (s: string[] | null | undefined) => boolean;
+}
+
+describe('page-slug wildcard semantics', () => {
+  const allowsAllPages = extractHelper();
+
+  it('treats the template wildcard as every page', () => {
+    expect(allowsAllPages(['*'])).toBe(true);
+  });
+
+  it('treats an empty list as unrestricted (historical meaning)', () => {
+    expect(allowsAllPages([])).toBe(true);
+    expect(allowsAllPages(undefined)).toBe(true);
+    expect(allowsAllPages(null)).toBe(true);
+  });
+
+  it('honours a hand-picked allowlist', () => {
+    expect(allowsAllPages(['home', 'pricing'])).toBe(false);
+  });
+
+  it('lets the wildcard win when mixed with explicit slugs', () => {
+    // An admin who adds pages to a list that already contains '*' still means
+    // "all of them" — never "these two only".
+    expect(allowsAllPages(['home', '*'])).toBe(true);
+  });
+});
+
+describe('every edge reader routes through the shared helper', () => {
+  it('the legacy KB builder does not filter when the wildcard is present', () => {
+    const src = readFileSync(CHAT_CONTEXT, 'utf-8');
+    expect(src).toMatch(/if\s*\(!allowsAllPages\(includedSlugs\)\)\s*query\s*=\s*query\.in\('slug'/);
+    expect(
+      src,
+      "buildKnowledgeBase must not gate on list length — '*' has length 1 and would filter everything out",
+    ).not.toMatch(/includedSlugs\.length\s*>\s*0/);
+  });
+
+  it('the retrieval chunk filter does not filter when the wildcard is present', () => {
+    const src = readFileSync(CHAT_COMPLETION, 'utf-8');
+    expect(src).toMatch(/if\s*\(!allowsAllPages\(slugAllowlist\)\)/);
+    expect(
+      src,
+      "the chunk filter must not gate on list length — '*' would drop every page chunk",
+    ).not.toMatch(/slugAllowlist\.length\s*>\s*0/);
+  });
+});

--- a/supabase/functions/_shared/chat-context.ts
+++ b/supabase/functions/_shared/chat-context.ts
@@ -87,6 +87,28 @@ export function extractTextFromBlock(block: any): string {
 }
 
 /**
+ * Does this page-slug allowlist mean "every published page"?
+ *
+ * `includedPageSlugs` has always had a wildcard: the frontend context
+ * indicator reads `['*']` as "all pages", and every template ships it that way
+ * so a site's chat is grounded in its own content from the moment it is
+ * installed — including pages created later.
+ *
+ * Both EDGE readers used to treat `'*'` as a literal slug. `.in('slug', ['*'])`
+ * matches nothing and the chunk filter dropped every page chunk, so a chat
+ * configured for "all pages" received exactly zero of them — and answered from
+ * the model's imagination instead (found live on www.flowwink.com 2026-08-12:
+ * asked to list the site's process pages, it invented seven that do not
+ * exist). KB articles travel a different path, which is why the failure looked
+ * like "KB works, pages don't" rather than an outage.
+ *
+ * An empty list keeps its historical meaning: unrestricted.
+ */
+export function allowsAllPages(slugs: string[] | null | undefined): boolean {
+  return !slugs?.length || slugs.includes('*');
+}
+
+/**
  * Build a token-budgeted knowledge base string from published pages
  * (optionally filtered by slug) and KB articles flagged include_in_chat.
  */
@@ -100,7 +122,7 @@ export async function buildKnowledgeBase(
   let estimatedTokens = 0;
 
   let query = supabase.from('pages').select('title, slug, content_json').eq('status', 'published');
-  if (includedSlugs.length > 0) query = query.in('slug', includedSlugs);
+  if (!allowsAllPages(includedSlugs)) query = query.in('slug', includedSlugs);
   const { data: pages } = await query;
 
   if (pages) {

--- a/supabase/functions/chat-completion/index.ts
+++ b/supabase/functions/chat-completion/index.ts
@@ -23,6 +23,7 @@ import {
   extractTextFromBlock,
   buildKnowledgeBase,
   loadVisitorContext,
+  allowsAllPages,
 } from "../_shared/chat-context.ts";
 // Chat-kernel helpers — formerly standalone edge functions called over HTTP
 // (edge-surface B1b): now direct library imports, one hop less each.
@@ -516,9 +517,10 @@ serve(async (req) => {
       // Per-article chat opt-out (kb.include_in_chat=false) — indexed for
       // other surfaces, excluded here.
       chunks = chunks.filter((c) => !(c.sourceTable === 'kb_articles' && c.metadata.include_in_chat === false));
-      // Admin-curated page allowlist, when configured.
+      // Admin-curated page allowlist, when configured. `['*']` (what every
+      // template ships) and `[]` both mean "every page" — see allowsAllPages.
       const slugAllowlist = settings?.includeContentAsContext ? (settings?.includedPageSlugs || []) : [];
-      if (slugAllowlist.length > 0) {
+      if (!allowsAllPages(slugAllowlist)) {
         chunks = chunks.filter((c) => c.sourceTable !== 'pages' || slugAllowlist.includes(String(c.metadata.slug)));
       }
       if (!chunks.length) return '';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1559,7 +1559,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:dd2c3efd6a17077a9e6144756df3ba8bebd6a37d523d10d7c66824bbf685e85f",
+      "shared_hash": "sha256:7072915683e35429bc39ddd81c25a958c1ccbd2be34538942e9f0e2309c4275d",
       "functions": {
         "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
@@ -1569,7 +1569,7 @@
         "automation-dispatcher": "sha256:3cb8681d7acce65624bd7957a432b143a2d959d769845dc71696b95c2ea2012b",
         "blog-rss": "sha256:dd57f6386804f1e0a4b8e0db3cdb83abc386c5790a677c7fdfe145067ae51be6",
         "browser-fetch": "sha256:762a956222c98ae99b4a361bec94c3d31fcbde6c0d96512755bd50caefa6d652",
-        "chat-completion": "sha256:dbb10e660cc8e976a35829d60c2d61edf1b9dc9c46175bef9bb9ce2e316cb471",
+        "chat-completion": "sha256:e228e6440d9b4b71161a9516e486057f6207402546f038126f08954244226c38",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:7d51782c0c965937199c1eb471c2664b867a37a32382fba2ecf20f3999bf86aa",
         "comms-send": "sha256:4f927ad7f19925b9ba5d0541d4258ec4e2400cc9242c601d3e89d7fb85942b5f",


### PR DESCRIPTION
## Symptomet

Chatten på www.flowwink.com ombads lista sajtens processidor och **hittade på sju** som inte finns (de riktiga heter Record-to-Report, Quote-to-Cash osv.). Inställningarna var korrekta i databasen — `includeContentAsContext: true`, `includeKbArticles: true`, `includedPageSlugs: ['*']`, allt satt av templaten.

## Rotorsaken

Wildcarden `'*'` är ett kontrakt mellan tre parter. Templaten skeppar den, frontendens kontextindikator läser den som "All pages" — men **båda edge-läsarna tolkade den som en bokstavlig slug**. `.in('slug', ['*'])` matchar ingen rad och chunk-filtret slängde varje sid-chunk. Noll sidor nådde modellen; KB reser en annan väg och fungerade, vilket maskerade felet som "modellen är dum" i stället för "kontexten är tom".

Följdeffekten Magnus märkte i drift: varje **ominstallation av templaten** skrev över hans handplockade sluglista med `['*']` och stängde därmed tyst av sidgrundningen igen — medan KB (en ren boolean) låg kvar och såg opåverkad ut. Exakt det mönstret pekade ut buggen.

## Fixen

En delad `allowsAllPages()` som båda edge-läsarna går genom: `['*']` och `[]` = alla sidor, handplockad lista respekteras, `'*'` vinner i blandad lista. Guardrailen kör helpern på riktigt **och** assertar att ingen läsare gatear på `.length > 0` igen — det var precis den formuleringen som orsakade buggen.

Svar på ursprungsfrågan: templaten **kunde** redan sätta flaggorna, den gjorde det hela tiden — plattformen kunde bara inte läsa dem. Efter den här fixen behöver du aldrig bocka i pages manuellt efter en ominstallation.

Full vitest grön.

🤖 Generated with [Claude Code](https://claude.com/claude-code)