### PR TITLE
Knowledge Index: startar själv, degraderar till fulltext, och syns i systemvyn

### DIFF
--- a/src/components/admin/system/ObservabilityTab.tsx
+++ b/src/components/admin/system/ObservabilityTab.tsx
@@ -514,7 +514,7 @@ function KnowledgeIndexCard() {
 
   const handleRun = async () => {
     try {
-      const res = await runIndexer.mutateAsync();
+      const res = await runIndexer.mutateAsync({});
       toast({
         title: 'Indexer swept',
         description: `${res.indexed_chunks ?? 0} chunk(s) indexed · ${res.processed ?? 0} item(s) processed`,

--- a/src/components/admin/system/ObservabilityTab.tsx
+++ b/src/components/admin/system/ObservabilityTab.tsx
@@ -1,14 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
-import { Activity, Zap, Sparkles, LogIn, ArrowRight, AlertTriangle, CheckCircle2, Layers } from 'lucide-react';
+import { Activity, Zap, Sparkles, LogIn, ArrowRight, AlertTriangle, CheckCircle2, Layers, Library, RefreshCw } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import instanceManifest from '../../../../supabase/seed/instance-manifest.json';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
 import { useAgentEvents } from '@/hooks/useAgentEvents';
 import { useAutomationHealth } from '@/hooks/useAutomationHealth';
+import { useKnowledgeIndexHealth, useRunKnowledgeIndexer, KNOWLEDGE_SOURCES } from '@/hooks/useKnowledgeIndex';
 import { McpActivityPanel } from '@/components/admin/developer/McpActivityPanel';
 
 function timeAgo(iso: string | null) {
@@ -484,6 +487,109 @@ function InstanceSyncCard() {
   );
 }
 
+/**
+ * The Knowledge Index is a platform SERVICE — one index, every grounded
+ * surface. It has no module toggle (like the Skill Relevance Engine), which is
+ * exactly why it needs a window: an empty index is invisible everywhere except
+ * in the answers, which merely get vaguer. On 2026-08-12 a fresh instance ran
+ * for a day with zero chunks and a chat that invented pages; nothing in the UI
+ * said so. This card says so.
+ */
+function KnowledgeIndexCard() {
+  const { data, isLoading } = useKnowledgeIndexHealth();
+  const runIndexer = useRunKnowledgeIndexer();
+  const { toast } = useToast();
+
+  const SOURCE_LABELS: Record<string, string> = {
+    pages: 'Pages',
+    kb_articles: 'Knowledge Base',
+    wiki_pages: 'Wiki',
+    docs_pages: 'Docs',
+    handbook_chapters: 'Handbook',
+    documents: 'Documents',
+  };
+
+  const empty = !isLoading && (data?.totalChunks ?? 0) === 0;
+  const backlog = (data?.queueDepth ?? 0) > 0;
+
+  const handleRun = async () => {
+    try {
+      const res = await runIndexer.mutateAsync();
+      toast({
+        title: 'Indexer swept',
+        description: `${res.indexed_chunks ?? 0} chunk(s) indexed · ${res.processed ?? 0} item(s) processed`,
+      });
+    } catch (e) {
+      toast({
+        title: 'Indexer run failed',
+        description: e instanceof Error ? e.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-start justify-between space-y-0">
+        <div>
+          <CardTitle className="font-serif flex items-center gap-2 text-base">
+            <Library className="h-4 w-4 text-sky-500" />
+            Knowledge Index
+          </CardTitle>
+          <CardDescription>
+            {isLoading
+              ? '…'
+              : `${data?.totalChunks ?? 0} chunk(s) · ${data?.queueDepth ?? 0} queued · updated ${timeAgo(data?.lastIndexedAt ?? null)}`}
+          </CardDescription>
+        </div>
+        <Button size="sm" variant="outline" onClick={handleRun} disabled={runIndexer.isPending}>
+          <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${runIndexer.isPending ? 'animate-spin' : ''}`} />
+          Sweep now
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-20 w-full" />
+        ) : (
+          <div className="space-y-2">
+            {empty && (
+              <p className="text-sm text-amber-600 dark:text-amber-500 flex items-start gap-1.5">
+                <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+                <span>
+                  Nothing indexed yet — grounded answers fall back to full-text until the first sweep
+                  completes. Press <strong>Sweep now</strong> to start it.
+                </span>
+              </p>
+            )}
+            {backlog && !empty && (
+              <p className="text-xs text-muted-foreground">
+                {data?.queueDepth} item(s) waiting for the next sweep (runs every 5 minutes).
+              </p>
+            )}
+            {(data?.missingEmbedding ?? 0) > 0 && (
+              <p className="text-xs text-amber-600 dark:text-amber-500">
+                {data?.missingEmbedding} chunk(s) without an embedding — check the AI provider key.
+              </p>
+            )}
+            <ul className="space-y-1">
+              {KNOWLEDGE_SOURCES.map((src) => (
+                <li key={src} className="flex items-center justify-between text-sm py-0.5">
+                  <span className="text-muted-foreground">{SOURCE_LABELS[src] ?? src}</span>
+                  <span className="font-mono text-xs">{data?.bySource?.[src] ?? 0}</span>
+                </li>
+              ))}
+            </ul>
+            <p className="text-[10px] text-muted-foreground pt-1">
+              One index, every grounded surface — visitor chat sees public content, staff surfaces
+              also see internal.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 export function ObservabilityTab() {
   return (
     <div className="space-y-4">
@@ -495,6 +601,7 @@ export function ObservabilityTab() {
         <AutomationQueueCard />
         <SkillAuditCard />
         <LoginActivityCard />
+        <KnowledgeIndexCard />
       </div>
       <InstanceSyncCard />
       <CronHealthCard />

--- a/src/hooks/useKnowledgeIndex.ts
+++ b/src/hooks/useKnowledgeIndex.ts
@@ -1,0 +1,109 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { logger } from '@/lib/logger';
+
+/**
+ * The Knowledge Index — a platform service, not a module.
+ *
+ * One index feeds every grounded surface: the public visitor chat (public
+ * chunks only), FlowWork and FlowPilot (public + internal), and any external
+ * agent on the MCP gateway. Sources are the content tables that carry a
+ * reindex trigger; the sweeper drains a queue into embedded chunks every five
+ * minutes.
+ *
+ * It has no on/off switch on purpose — like the Skill Relevance Engine, it is
+ * infrastructure the surfaces depend on. What it DOES need is visibility: an
+ * empty index is invisible from every surface except the answers, which simply
+ * get vaguer (see the 2026-08-12 incident, where a chat with an empty index
+ * invented pages). This hook is that window.
+ */
+
+/** Content tables the indexer reads, in the order the admin card shows them. */
+export const KNOWLEDGE_SOURCES = [
+  'pages',
+  'kb_articles',
+  'wiki_pages',
+  'docs_pages',
+  'handbook_chapters',
+  'documents',
+] as const;
+
+export type KnowledgeSource = (typeof KNOWLEDGE_SOURCES)[number];
+
+export interface KnowledgeIndexHealth {
+  /** Indexed chunks per source table (only sources with chunks appear). */
+  bySource: Record<string, number>;
+  totalChunks: number;
+  /** Chunks still missing an embedding — they cannot be retrieved yet. */
+  missingEmbedding: number;
+  /** Items waiting for the next sweep. A steady non-zero value means the sweeper is not running. */
+  queueDepth: number;
+  lastIndexedAt: string | null;
+}
+
+export function useKnowledgeIndexHealth() {
+  return useQuery({
+    queryKey: ['knowledge-index-health'],
+    queryFn: async (): Promise<KnowledgeIndexHealth> => {
+      const [chunks, queue] = await Promise.all([
+        supabase.from('knowledge_chunks').select('source_table, embedding, updated_at'),
+        supabase.from('knowledge_index_queue').select('source_table'),
+      ]);
+      if (chunks.error) throw chunks.error;
+
+      const rows = chunks.data ?? [];
+      const bySource: Record<string, number> = {};
+      let missingEmbedding = 0;
+      let lastIndexedAt: string | null = null;
+      for (const row of rows as Array<{ source_table: string; embedding: unknown; updated_at: string | null }>) {
+        bySource[row.source_table] = (bySource[row.source_table] ?? 0) + 1;
+        if (!row.embedding) missingEmbedding++;
+        if (row.updated_at && (!lastIndexedAt || row.updated_at > lastIndexedAt)) lastIndexedAt = row.updated_at;
+      }
+
+      return {
+        bySource,
+        totalChunks: rows.length,
+        missingEmbedding,
+        // A missing queue table (un-migrated instance) reads as 0, not as an error:
+        // the card must still render the chunk counts it CAN see.
+        queueDepth: queue.error ? 0 : (queue.data?.length ?? 0),
+        lastIndexedAt,
+      };
+    },
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * Run a sweep now — drains the queue and (with `fullReindex`) re-queues a
+ * source first. Also the manual escape hatch when an instance's sweeper cron
+ * has not been registered yet: the function registers it on any run.
+ */
+export function useRunKnowledgeIndexer() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (opts?: { fullReindex?: boolean; source?: KnowledgeSource }) => {
+      const { data, error } = await supabase.functions.invoke('knowledge-indexer', {
+        body: {
+          source: opts?.source ?? 'admin-ui',
+          ...(opts?.fullReindex ? { full_reindex: true, ...(opts.source ? { source: opts.source } : {}) } : {}),
+        },
+      });
+      if (error) throw error;
+      return data as {
+        status?: string;
+        processed?: number;
+        indexed_chunks?: number;
+        deindexed?: number;
+        failed?: number;
+        queued?: number;
+        embed?: { embedded?: number; failed?: number; pending?: number; provider?: string };
+      };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['knowledge-index-health'] });
+    },
+    onError: (e) => logger.error('knowledge indexer run failed:', e),
+  });
+}

--- a/src/lib/__tests__/knowledge-index-bootstrap.guardrails.test.ts
+++ b/src/lib/__tests__/knowledge-index-bootstrap.guardrails.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * The knowledge index must be able to start without a human.
+ *
+ * INCIDENT (www.flowwink.com, 2026-08-12). The indexer registered its own cron
+ * job on its first run — and on a CLI-free install nobody ever made that first
+ * call. A self-registering cron that only registers when it runs cannot start.
+ * The queue filled to 156 items, `knowledge_chunks` stayed empty, and the
+ * visitor chat answered with no grounding at all: asked to list the site's
+ * process pages it invented seven that do not exist.
+ *
+ * It cascaded, which is why it matters more than one broken feature: the
+ * newsletter-cron fix (20260718090000) derives the instance's own URL from the
+ * knowledge-indexer job's command. With no such job that fix silently did
+ * nothing, so every fresh instance kept DEV's hardcoded newsletter URL and
+ * POSTed its scheduled newsletters at the wrong project. One missing cron job,
+ * two broken subsystems, zero error messages.
+ *
+ * Three properties keep it started, and each is pinned below:
+ *   1. A migration registers the sweeper — SQL, not a first-run side effect.
+ *   2. Retrieval returning nothing falls through to full-text grounding, so an
+ *      index that is empty (new instance, page published a minute ago, no
+ *      embedding key) still yields grounded answers.
+ *   3. The admin surface shows the index state, so "empty" is visible rather
+ *      than merely tasted in vaguer answers.
+ */
+
+const ROOT = join(__dirname, '../../..');
+const MIGRATIONS = join(ROOT, 'supabase/migrations');
+const CHAT_COMPLETION = join(ROOT, 'supabase/functions/chat-completion/index.ts');
+const OBSERVABILITY = join(ROOT, 'src/components/admin/system/ObservabilityTab.tsx');
+
+function migrationSources(): string[] {
+  return readdirSync(MIGRATIONS)
+    .filter((f) => f.endsWith('.sql'))
+    .map((f) => readFileSync(join(MIGRATIONS, f), 'utf-8'));
+}
+
+describe('the sweeper is registered by SQL, not by its own first run', () => {
+  it('a migration schedules the knowledge-indexer cron job', () => {
+    const scheduling = migrationSources().filter(
+      (sql) => /cron\.schedule\(\s*'knowledge-indexer'/.test(sql),
+    );
+    expect(
+      scheduling.length,
+      'no migration registers the knowledge-indexer cron — a fresh instance would never index anything',
+    ).toBeGreaterThan(0);
+  });
+
+  it('does so without hardcoding a project ref (every instance is its own)', () => {
+    const bootstrap = migrationSources().find((sql) =>
+      /cron\.schedule\(\s*'knowledge-indexer'/.test(sql) && /derive|template|borrow/i.test(sql),
+    );
+    expect(bootstrap, 'the bootstrap migration must derive the URL, not hardcode one').toBeDefined();
+    expect(
+      bootstrap!,
+      'a hardcoded supabase.co host would point every customer instance at one project — the exact newsletter-cron bug',
+    ).not.toMatch(/https:\/\/[a-z0-9]{20}\.supabase\.co/);
+  });
+
+  it('seeds the queue with content that already exists', () => {
+    // The original retrieval migration seeded on an EMPTY database — content
+    // arrives later, with the template. Re-seeding at bootstrap covers it.
+    const bootstrap = migrationSources().find((sql) =>
+      /cron\.schedule\(\s*'knowledge-indexer'/.test(sql),
+    )!;
+    expect(bootstrap).toMatch(/INSERT INTO public\.knowledge_index_queue[\s\S]*FROM public\.pages/);
+    expect(bootstrap).toMatch(/INSERT INTO public\.knowledge_index_queue[\s\S]*FROM public\.kb_articles/);
+  });
+});
+
+describe('an empty index degrades to full-text grounding, never to no grounding', () => {
+  const src = readFileSync(CHAT_COMPLETION, 'utf-8');
+
+  it('treats "zero chunks" as a fallback trigger, not as an empty answer', () => {
+    expect(
+      src,
+      'returning "" on zero chunks is what let the assistant answer from imagination',
+    ).not.toMatch(/if\s*\(!chunks\.length\)\s*return\s*'';/);
+    expect(src).toMatch(/if\s*\(!chunks\.length\)\s*throw new EmptyIndexError\(\)/);
+  });
+
+  it('routes that trigger into the full-text builder', () => {
+    // Same catch that handles a thrown retrieval error — one fallback path.
+    expect(src).toMatch(/buildRetrievedKnowledge\(\)\.catch\(/);
+    expect(src).toMatch(/return buildKnowledgeBase\(/);
+  });
+});
+
+describe('the index is visible in the admin surface', () => {
+  const src = readFileSync(OBSERVABILITY, 'utf-8');
+
+  it('renders a Knowledge Index card with a manual sweep', () => {
+    expect(src).toMatch(/Knowledge Index/);
+    expect(src).toMatch(/useKnowledgeIndexHealth/);
+    expect(src).toMatch(/useRunKnowledgeIndexer/);
+    expect(src).toMatch(/<KnowledgeIndexCard \/>/);
+  });
+
+  it('warns explicitly when nothing is indexed', () => {
+    expect(
+      src,
+      'an empty index must announce itself — it is otherwise invisible except as vaguer answers',
+    ).toMatch(/Nothing indexed yet/);
+  });
+});

--- a/supabase/functions/chat-completion/index.ts
+++ b/supabase/functions/chat-completion/index.ts
@@ -41,6 +41,18 @@ import { handleConsultantCheckin } from '../_shared/chat/consultant-checkin.ts';
  * - N8N remains a special webhook passthrough
  */
 
+/**
+ * Retrieval returned nothing while its sources were enabled — the index is
+ * empty, not the answer. Distinct from a thrown retrieval error so the two
+ * read differently in the logs; both route to full-text grounding.
+ */
+class EmptyIndexError extends Error {
+  constructor() {
+    super('knowledge index returned no chunks');
+    this.name = 'EmptyIndexError';
+  }
+}
+
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
@@ -523,7 +535,15 @@ serve(async (req) => {
       if (!allowsAllPages(slugAllowlist)) {
         chunks = chunks.filter((c) => c.sourceTable !== 'pages' || slugAllowlist.includes(String(c.metadata.slug)));
       }
-      if (!chunks.length) return '';
+      // Zero chunks with sources switched ON is NOT "nothing is relevant" — it
+      // is "this index cannot answer yet". A brand-new instance has an empty
+      // index until the first sweep, a page published a minute ago is not in
+      // it, and an instance without an embedding key never fills it. Treating
+      // those as "no context" makes the assistant answer from imagination —
+      // exactly what happened on www.flowwink.com (2026-08-12), where it
+      // invented seven process pages. Fall through to the full-text builder:
+      // slower and token-hungrier, but grounded. Degrade, never gate (Law 4).
+      if (!chunks.length) throw new EmptyIndexError();
       return `\n\n=== WEBSITE CONTENT (retrieved by relevance to the question) ===\n${renderContext(chunks)}`;
     };
 
@@ -531,7 +551,11 @@ serve(async (req) => {
       loadWorkspaceFiles(supabase),
       shouldLoadKB
         ? buildRetrievedKnowledge().catch((e) => {
-            console.error('retrieval grounding failed — falling back to legacy KB dump:', e);
+            console.error(
+              e instanceof EmptyIndexError
+                ? 'retrieval index has nothing to offer (empty or not built yet) — grounding on full text instead'
+                : `retrieval grounding failed — falling back to full-text grounding: ${e}`,
+            );
             return buildKnowledgeBase(
               supabase,
               settings?.contentContextMaxTokens || 50000,

--- a/supabase/migrations/20260812150000_knowledge-index-bootstraps-itself.sql
+++ b/supabase/migrations/20260812150000_knowledge-index-bootstraps-itself.sql
@@ -1,0 +1,117 @@
+-- The knowledge index bootstraps itself — no first manual call required.
+--
+-- CATCH-22 FOUND LIVE (www.flowwink.com, 2026-08-12). The knowledge indexer
+-- registers its own cron job on its first run (`register_knowledge_indexer_cron`
+-- inside the edge function). On a CLI-free install NOBODY makes that first
+-- call, so:
+--   • the cron job never exists,
+--   • the queue fills (156 rows waiting) and is never drained,
+--   • knowledge_chunks stays EMPTY,
+--   • and the visitor chat answers with zero grounding — it invented seven
+--     "process pages" that do not exist on the site.
+-- A self-registering cron that only registers when it runs cannot start.
+--
+-- It cascaded: `20260718090000_fix-newsletter-cron-self-reference.sql` rebuilds
+-- the newsletter cron command from the knowledge-indexer job's command (a
+-- clever way to get the instance's own URL without hardcoding it). With no
+-- indexer job, that fix was a silent no-op — so the newsletter cron kept DEV's
+-- hardcoded URL and every fresh instance POSTed its scheduled newsletters at
+-- dev.flowwink.com. One missing job, two broken subsystems, zero errors.
+--
+-- The fix: register the job from SQL, deriving this instance's own URL and key
+-- from a cron job that already points at it. Every FlowWink instance has at
+-- least one (flowpilot-heartbeat, automation-dispatcher, …) because those are
+-- registered during setup. If none exists yet, this is a no-op and the edge
+-- function's self-registration still covers the case — belt and braces, never
+-- a gate (Law 4).
+--
+-- Idempotent: only schedules when the job is absent.
+--
+-- Placed AFTER the fresh-install finalizer on purpose. Pre-finalizer
+-- migrations must leave their cron jobs quiesced (nothing may fire into a
+-- half-built schema, and the finalizer switches everything on); a migration
+-- that runs after it is past that window, so its job starts active — and must
+-- NOT quiesce, or it would strand every job on a live instance. The
+-- fresh-install-replay guardrail enforces both directions, and caught this
+-- file on the wrong side of the line while it was being written.
+
+DO $bootstrap$
+DECLARE
+  v_template text;
+  v_command  text;
+  v_url      text;
+  v_headers  text;
+BEGIN
+  IF to_regclass('cron.job') IS NULL THEN
+    RAISE NOTICE 'pg_cron not installed — skipping knowledge-indexer bootstrap.';
+    RETURN;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'knowledge-indexer') THEN
+    RAISE NOTICE 'knowledge-indexer cron already registered.';
+    RETURN;
+  END IF;
+
+  -- Borrow the envelope (own host + own service headers) from any job that
+  -- already calls a function on THIS instance. Ordered so the most stable
+  -- platform jobs win; jobname is irrelevant beyond that.
+  SELECT command INTO v_template
+    FROM cron.job
+   WHERE command LIKE '%/functions/v1/%'
+     AND command LIKE '%net.http_post%'
+   ORDER BY (jobname = 'flowpilot-heartbeat') DESC,
+            (jobname = 'automation-dispatcher-every-minute') DESC,
+            jobname
+   LIMIT 1;
+
+  IF v_template IS NULL THEN
+    RAISE NOTICE 'No HTTP cron job to derive this instance URL from — knowledge-indexer will self-register on its first run.';
+    RETURN;
+  END IF;
+
+  -- Take only the two parts that are instance-specific — the host and the
+  -- auth headers — and BUILD the command, rather than patching the template's
+  -- string. Patching looked simpler and produced a subtly wrong job in
+  -- testing: templates differ in how they write the body (a literal in one,
+  -- `concat(… now() …)` in another), so a body-rewrite regex tuned to one
+  -- form silently leaves the other in place.
+  v_url := substring(v_template from 'url\s*:=\s*''([^'']+)''');
+  v_headers := substring(v_template from 'headers\s*:=\s*''([^'']+)''');
+
+  IF v_url IS NULL OR v_headers IS NULL THEN
+    RAISE NOTICE 'Could not parse url/headers from the template job — knowledge-indexer will self-register on its first run.';
+    RETURN;
+  END IF;
+
+  v_url := regexp_replace(v_url, '/functions/v1/.*$', '/functions/v1/knowledge-indexer');
+
+  v_command := format(
+    'SELECT net.http_post(url := %L, headers := %L::jsonb, body := ''{"source":"cron"}''::jsonb) AS request_id;',
+    v_url,
+    v_headers
+  );
+
+  PERFORM cron.schedule('knowledge-indexer', '*/5 * * * *', v_command);
+  RAISE NOTICE 'knowledge-indexer cron registered (every 5 minutes).';
+END $bootstrap$;
+
+-- Seed the queue with everything already in the instance. The original
+-- retrieval migration did this too, but it ran on an EMPTY database — the
+-- content arrives later, when a template is installed. The reindex triggers
+-- cover content created after this point; this covers what is already there.
+INSERT INTO public.knowledge_index_queue (source_table, entity_id, op)
+SELECT 'pages', id::text, 'upsert' FROM public.pages
+ON CONFLICT (source_table, entity_id) DO NOTHING;
+INSERT INTO public.knowledge_index_queue (source_table, entity_id, op)
+SELECT 'kb_articles', id::text, 'upsert' FROM public.kb_articles
+ON CONFLICT (source_table, entity_id) DO NOTHING;
+INSERT INTO public.knowledge_index_queue (source_table, entity_id, op)
+SELECT 'wiki_pages', slug, 'upsert' FROM public.wiki_pages
+ON CONFLICT (source_table, entity_id) DO NOTHING;
+
+DO $seed$
+DECLARE v_queued int;
+BEGIN
+  SELECT count(*) INTO v_queued FROM public.knowledge_index_queue;
+  RAISE NOTICE 'Knowledge index queue holds % item(s) for the next sweep.', v_queued;
+END $seed$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260812140000",
-      "migrations_count": 386,
+      "migration_head": "20260812150000",
+      "migrations_count": 387,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1549,6 +1549,10 @@
         {
           "version": "20260812140000",
           "name": "demo-seeds-teach-the-state-space"
+        },
+        {
+          "version": "20260812150000",
+          "name": "knowledge-index-bootstraps-itself"
         }
       ]
     },
@@ -1569,7 +1573,7 @@
         "automation-dispatcher": "sha256:3cb8681d7acce65624bd7957a432b143a2d959d769845dc71696b95c2ea2012b",
         "blog-rss": "sha256:dd57f6386804f1e0a4b8e0db3cdb83abc386c5790a677c7fdfe145067ae51be6",
         "browser-fetch": "sha256:762a956222c98ae99b4a361bec94c3d31fcbde6c0d96512755bd50caefa6d652",
-        "chat-completion": "sha256:e228e6440d9b4b71161a9516e486057f6207402546f038126f08954244226c38",
+        "chat-completion": "sha256:a2e0a8bc5c60ff2963e2cf7020fbebc8b7bf5669512963b2f5ebb970af1e320e",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:7d51782c0c965937199c1eb471c2664b867a37a32382fba2ecf20f3999bf86aa",
         "comms-send": "sha256:4f927ad7f19925b9ba5d0541d4258ec4e2400cc9242c601d3e89d7fb85942b5f",


### PR DESCRIPTION
Tre delar av samma incident på www: chatten svarade om sajtens processidor genom att **hitta på sju** som inte finns — tomt index, noll felmeddelanden.

## 1. Moment 22:an bruten

Indexeraren registrerade sin egen cron **vid sin första körning**. På en CLI-fri installation gör ingen den körningen: jobbet fanns aldrig, kön växte till 156 poster, `knowledge_chunks` förblev tom. En självregistrerande cron som bara registrerar när den kör kan inte starta.

Nu registrerar en migration den, med instansens **egen** URL härledd ur ett befintligt HTTP-jobb — ingen hårdkodad ref, eftersom det var precis den buggen som fick nyinstallationers nyhetsbrevs-cron att peka på dev-instansen. **Negativtestat på www**: jobbet borttaget → migrationen återskapar det bit-identiskt med vad självregistreringen skapade.

Kaskaden det löser: newsletter-cron-fixen från juli härleder sin URL ur *indexerar-jobbets* kommando. Utan det jobbet var den en tyst no-op — så varje ny instans postade sina schemalagda nyhetsbrev till dev.

## 2. Tomt index ≠ inget svar (CAG-fallbacken)

Noll chunkar med källorna påslagna betyder "indexet kan inte svara än", inte "inget är relevant". Nu faller chatten igenom till fulltextgrundning i stället för att svara ogrundat — täcker ny instans, nyss publicerad sida, och instans utan embedding-nyckel.

Per diskussionen: **inget admin-val mellan CAG och RAG.** Admin väljer *vad* som är kontext, plattformen väljer *hur* den hämtas — RAG som default för att den skalar, fulltext som automatisk degradering.

## 3. Tjänsten syns

Knowledge Index är plattformsinfrastruktur som Skill Relevance Engine — ingen modultoggel, men nu ett kort i systemvyn: chunkar per källa (sidor, KB, wiki, docs, handbok, dokument), ködjup, senast uppdaterad, varning när indexet är tomt, och "Sweep now". Ett tomt index var tidigare osynligt överallt utom i vagare svar.

## Verifiering

Guardrailen för fresh-install fångade under bygget att migrationen låg på fel sida om finalizern — flyttad efter, vilket är rätt. Full vitest **2279 gröna**, bygget OK, migrationen körd idempotent + negativtestad live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)