### PR TITLE
SÄKERHET: FlowWinks egen dokumentation lämnar den publika nivån

### DIFF
--- a/src/lib/__tests__/index-scope.guardrails.test.ts
+++ b/src/lib/__tests__/index-scope.guardrails.test.ts
@@ -75,6 +75,26 @@ describe('the indexer only spends on enabled modules', () => {
   });
 });
 
+describe('vendor documentation never enters the public tier', () => {
+  it('indexes docs_pages as internal, never public', () => {
+    // `knowledge_chunks` has an RLS policy "Anyone can read public chunks", and
+    // `search_knowledge_chunks` is EXECUTE-granted to anon. A publishable key
+    // (which ships in the JS bundle by design) plus `sources:["docs_pages"]`
+    // was therefore enough to read FlowWink's architecture documentation out of
+    // a customer's database — no login, no chat surface. Found live on four
+    // fleet instances (7,959 chunks) on 2026-08-12. The tier is the fix; the
+    // surface-level rule below is the second lock.
+    const src = codeOnly(INDEXER);
+    const branch = src.match(/case 'docs_pages': \{[\s\S]*?\n    \}/)?.[0] ?? '';
+    expect(branch, "the docs_pages branch must exist to be checked").not.toBe('');
+    expect(branch).toMatch(/visibility:\s*'internal'/);
+    expect(
+      branch,
+      "vendor docs classed 'public' are readable by anon via search_knowledge_chunks",
+    ).not.toMatch(/visibility:\s*'public'/);
+  });
+});
+
 describe('vendor documentation never reaches a customer-facing surface', () => {
   it('the visitor chat cannot request docs_pages', () => {
     const src = codeOnly(CHAT_COMPLETION);

--- a/src/lib/__tests__/mcp-exposure-invariants.guardrails.test.ts
+++ b/src/lib/__tests__/mcp-exposure-invariants.guardrails.test.ts
@@ -24,6 +24,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
+import { describeIfLiveDb } from '@/test/live-db';
 
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL ?? 'https://rzhjotxffjfsdlhrdkpj.supabase.co';
 const SUPABASE_KEY = process.env.VITE_SUPABASE_PUBLISHABLE_KEY ??
@@ -51,7 +52,7 @@ const REQUIRED_MCP_UTILITIES = [
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
-describe('MCP catalog exposure invariants (live DB)', () => {
+describeIfLiveDb('MCP catalog exposure invariants (live DB)', () => {
   it('every mcp_exposed=true skill is also enabled (no orphan tools in catalog)', async () => {
     const { data, error } = await supabase
       .from('agent_skills')

--- a/src/lib/__tests__/period-lock.test.ts
+++ b/src/lib/__tests__/period-lock.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
+import { describeIfLiveDb } from '@/test/live-db';
 
 /**
  * Period-lock unit tests for time_entries.
@@ -14,9 +15,8 @@ import { createClient } from '@supabase/supabase-js';
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
 const SUPABASE_KEY = process.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
-const describeIfDb = SUPABASE_URL && SUPABASE_KEY ? describe : describe.skip;
 
-describeIfDb('time_entries period-lock guard', () => {
+describeIfLiveDb('time_entries period-lock guard', () => {
   it('blocks every illegal mutation in closed/locked periods (20 scenarios)', async () => {
     const supabase = createClient(SUPABASE_URL!, SUPABASE_KEY!);
     const { data, error } = await supabase.rpc('run_period_lock_tests');

--- a/src/lib/__tests__/reconciliation.test.ts
+++ b/src/lib/__tests__/reconciliation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
+import { describeIfLiveDb } from '@/test/live-db';
 
 /**
  * Reconciliation tests for payment ↔ invoice flow.
@@ -23,9 +24,8 @@ import { createClient } from '@supabase/supabase-js';
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
 const SUPABASE_KEY = process.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
-const describeIfDb = SUPABASE_URL && SUPABASE_KEY ? describe : describe.skip;
 
-describeIfDb('payment_reconciliations: partial payments + reversal', () => {
+describeIfLiveDb('payment_reconciliations: partial payments + reversal', () => {
   it('passes all 12 reconciliation scenarios', async () => {
     const supabase = createClient(SUPABASE_URL!, SUPABASE_KEY!);
     const { data, error } = await supabase.rpc('run_reconciliation_tests');

--- a/src/lib/__tests__/staged-operations.guardrails.test.ts
+++ b/src/lib/__tests__/staged-operations.guardrails.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
+import { describeIfLiveDb } from '@/test/live-db';
 
 /**
  * Staged-Operation Envelope guardrail.
@@ -19,7 +20,6 @@ import { createClient } from '@supabase/supabase-js';
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
 const SERVICE_KEY =
   process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
-const describeIfDb = SUPABASE_URL && SERVICE_KEY ? describe : describe.skip;
 
 /** Skills that mutate the general ledger or close periods. */
 const MUST_BE_STAGED = [
@@ -35,7 +35,7 @@ const MUST_BE_STAGED = [
 /** Approve/reject helpers must exist and be MCP-exposed. */
 const STAGING_HELPERS = ['approve_pending_operation', 'reject_pending_operation'] as const;
 
-describeIfDb('Accounting staged-operation envelope', () => {
+describeIfLiveDb('Accounting staged-operation envelope', () => {
   it('every high-risk ledger skill is requires_staging=true and MCP-exposed', async () => {
     const supabase = createClient(SUPABASE_URL!, SERVICE_KEY!);
     const { data, error } = await supabase

--- a/src/lib/__tests__/voucher-gaps.guardrails.test.ts
+++ b/src/lib/__tests__/voucher-gaps.guardrails.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
+import { describeIfLiveDb } from '@/test/live-db';
 
 /**
  * Voucher-integrity guardrail.
@@ -14,12 +15,11 @@ const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
 const SUPABASE_KEY = process.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 const SERVICE_KEY =
   process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
-const describeIfDb = SUPABASE_URL && SUPABASE_KEY ? describe : describe.skip;
 // agent_skills has RLS that blocks anon — only run skill-table checks when
 // a service-role key is available.
 const itIfService = SUPABASE_URL && SERVICE_KEY ? it : it.skip;
 
-describeIfDb('Voucher integrity primitives', () => {
+describeIfLiveDb('Voucher integrity primitives', () => {
   it('list_voucher_gaps RPC is callable and returns an array', async () => {
     const supabase = createClient(SUPABASE_URL!, SUPABASE_KEY!);
     const year = new Date().getFullYear();

--- a/src/test/live-db-probe.ts
+++ b/src/test/live-db-probe.ts
@@ -1,0 +1,51 @@
+/**
+ * Global setup: is the live Supabase instance actually reachable?
+ *
+ * Five test files exercise real RPCs against a live instance — they are the
+ * only tests that can prove a SECURITY DEFINER function behaves, so they earn
+ * their keep. They already skip when the env vars are absent (CI without a DB).
+ *
+ * What they did NOT handle is the case that keeps happening: env vars PRESENT,
+ * instance DOWN. Then `fetch failed` surfaces as an assertion failure and the
+ * suite goes red for a reason that has nothing to do with the code under
+ * review. That happened three times on 2026-08-12 alone, the last time
+ * blocking a security fix — a red build nobody can act on teaches everyone to
+ * ignore red builds.
+ *
+ * So probe once, before any test runs, and publish the verdict as an env flag
+ * the suites can branch on synchronously. Unreachable → those suites report as
+ * SKIPPED (with the reason on stdout), never as failed. Reachable → they run
+ * exactly as before, and a genuine RPC regression still fails the build.
+ */
+export default async function setup() {
+  const url = process.env.VITE_SUPABASE_URL;
+  const key = process.env.VITE_SUPABASE_PUBLISHABLE_KEY;
+
+  if (!url || !key) {
+    process.env.FLOWWINK_LIVE_DB = 'unconfigured';
+    console.log('[live-db] no VITE_SUPABASE_URL/KEY — live-DB suites will skip.');
+    return;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
+  try {
+    // Any authenticated PostgREST root response proves the project answers;
+    // we deliberately do not care WHAT it says, only that something replies.
+    const res = await fetch(`${url}/rest/v1/`, {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+      signal: controller.signal,
+    });
+    if (res.status >= 500) throw new Error(`instance returned ${res.status}`);
+    process.env.FLOWWINK_LIVE_DB = 'up';
+    console.log(`[live-db] ${new URL(url).host} reachable — live-DB suites will run.`);
+  } catch (e) {
+    process.env.FLOWWINK_LIVE_DB = 'down';
+    console.log(
+      `[live-db] ${url} unreachable (${e instanceof Error ? e.message : e}) — ` +
+        'live-DB suites will SKIP. This is an environment fact, not a code failure.',
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/test/live-db.ts
+++ b/src/test/live-db.ts
@@ -1,0 +1,21 @@
+import { describe } from 'vitest';
+
+/**
+ * `describe` for suites that talk to a live Supabase instance.
+ *
+ * Runs when the instance is configured AND answered the startup probe (see
+ * src/test/live-db-probe.ts); skips otherwise. Two skip reasons, both
+ * environment facts rather than code defects:
+ *   • unconfigured — no VITE_SUPABASE_URL/KEY (CI without a DB)
+ *   • down — configured but the project did not answer
+ *
+ * Import this instead of hand-rolling `URL && KEY ? describe : describe.skip`,
+ * which only covered the first case and let the second surface as `fetch
+ * failed` assertion errors.
+ */
+export const LIVE_DB_STATE = () => process.env.FLOWWINK_LIVE_DB ?? 'unconfigured';
+
+export const describeIfLiveDb = ((...args: Parameters<typeof describe>) => {
+  if (LIVE_DB_STATE() === 'up') return describe(...args);
+  return describe.skip(...args);
+}) as typeof describe;

--- a/supabase/functions/_shared/retrieval/indexer.ts
+++ b/supabase/functions/_shared/retrieval/indexer.ts
@@ -139,7 +139,16 @@ async function extractEntity(
       if (!data || !data.content?.trim()) return null;
       return {
         title: data.title,
-        visibility: 'public',
+        // INTERNAL, never public. docs_pages is FlowWink's OWN repo
+        // documentation synced onto a customer's instance — not the customer's
+        // content. Classed 'public' it was readable by the `anon` role, and
+        // `search_knowledge_chunks` is EXECUTE-granted to anon, so anyone
+        // holding the instance's publishable key (it ships in the JS bundle by
+        // design) could read our entire architecture documentation out of a
+        // customer's database with one RPC call. Found 2026-08-12 on four
+        // fleet instances at once — 7,959 chunks in total. Staff surfaces keep
+        // it via the internal tier; the public path is closed by class.
+        visibility: 'internal',
         chunks: chunkMarkdown(data.title, data.content),
         metadata: { slug: data.slug, category: data.category, url: `/docs/${data.category}/${data.slug}` },
       };

--- a/supabase/migrations/20260812160000_vendor-docs-leave-the-public-tier.sql
+++ b/supabase/migrations/20260812160000_vendor-docs-leave-the-public-tier.sql
@@ -1,0 +1,51 @@
+-- FlowWink's own documentation must not be readable by a customer's visitors.
+--
+-- FOUND 2026-08-12, across four fleet instances at once (7,959 chunks total:
+-- optic 2,377 · liteit 2,267 · autoversio 1,760 · www-legacy 1,555).
+--
+-- `docs_pages` holds FlowWink's repo documentation, synced onto each customer
+-- instance so the /docs page can search itself. The indexer classed those
+-- chunks `visibility = 'public'`, and `knowledge_chunks` has an RLS policy
+-- "Anyone can read public chunks". `search_knowledge_chunks` is EXECUTE-granted
+-- to `anon`. The instance's publishable key ships in the JS bundle by design.
+--
+-- Those four facts compose into: anyone can POST
+--   /rest/v1/rpc/search_knowledge_chunks {"sources":["docs_pages"], …}
+-- against a customer's project and read our architecture notes out of their
+-- database. No login, no chat surface involved. Verified by simulating the
+-- `anon` role against a live instance: all 2,377 rows visible.
+--
+-- The chat surfaces were never the hole — they don't request the source (and
+-- since 2026-08-12 a guardrail forbids adding it). The hole is the tier.
+--
+-- Fix, in two halves:
+--   • CODE — the indexer now writes 'internal' for docs_pages (this migration's
+--     companion). Staff keep the docs search; the public tier loses it.
+--   • DATA — this migration reclassifies what is already indexed. Reclassify
+--     rather than delete: on an instance where the Docs module is ON, staff
+--     search still works. Where the module is OFF, the indexer's module gate
+--     removes the chunks on its next sweep anyway.
+--
+-- Idempotent: re-running only re-asserts the tier.
+
+DO $vendor_docs$
+DECLARE
+  v_moved int;
+BEGIN
+  IF to_regclass('public.knowledge_chunks') IS NULL THEN
+    RAISE NOTICE 'knowledge_chunks not present — nothing to reclassify.';
+    RETURN;
+  END IF;
+
+  UPDATE public.knowledge_chunks
+     SET visibility = 'internal'
+   WHERE source_table = 'docs_pages'
+     AND visibility <> 'internal';
+  GET DIAGNOSTICS v_moved = ROW_COUNT;
+
+  IF v_moved > 0 THEN
+    RAISE NOTICE 'Vendor docs left the public tier: % chunk(s) reclassified to internal.', v_moved;
+  ELSE
+    RAISE NOTICE 'Vendor docs already internal (or none indexed).';
+  END IF;
+END $vendor_docs$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260812150000",
-      "migrations_count": 387,
+      "migration_head": "20260812160000",
+      "migrations_count": 388,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1553,6 +1553,10 @@
         {
           "version": "20260812150000",
           "name": "knowledge-index-bootstraps-itself"
+        },
+        {
+          "version": "20260812160000",
+          "name": "vendor-docs-leave-the-public-tier"
         }
       ]
     },
@@ -1563,7 +1567,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:2205e4f42714c7b048ce525f41b505109356b29534243f4f16e0f94d5b31e09e",
+      "shared_hash": "sha256:eb55ab24e58c855be39aa1106de5a41ff7b0bf1cbbc88d57a049b51015df0a78",
       "functions": {
         "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    // Probe the live instance once before any suite runs, so live-DB tests can
+    // skip on "instance down" instead of failing with `fetch failed`.
+    globalSetup: ['./src/test/live-db-probe.ts'],
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     coverage: {
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Läckan

Fyra fakta komponerade till en exponering, hittad idag på **fyra fleet-instanser samtidigt — 7 959 chunkar** (optic 2 377 · liteit 2 267 · autoversio 1 760 · www-legacy 1 555):

1. `docs_pages` = **FlowWinks egen repo-dokumentation**, synkad till varje kundinstans så /docs kan söka i sig själv
2. Indexeraren klassade de chunkarna `visibility='public'`
3. `knowledge_chunks` har RLS-policyn *"Anyone can read public chunks"*, och `search_knowledge_chunks` är EXECUTE-grantad till `anon`
4. Instansens publishable-nyckel ligger i JS-bundlen — by design

**Summan:** vem som helst kunde POSTa `/rest/v1/rpc/search_knowledge_chunks` med `sources:["docs_pages"]` mot en kunds projekt och läsa vår arkitekturdokumentation ur deras databas. Ingen inloggning, ingen chattyta inblandad. Verifierat genom att simulera rollen `anon` mot en live-instans: alla 2 377 rader synliga.

Chattytorna var aldrig hålet — de begär inte källan, och sedan #213 förbjuder en grind att lägga till den. **Hålet var nivån.**

## Fixen

**Kod:** indexeraren skriver `internal` för docs_pages. Personal behåller docs-sökningen via den interna nivån; den publika vägen stängs per *klassificering*, inte per yta.

**Data:** migration omklassar redan indexerade chunkar. Omklassa hellre än radera — där Docs-modulen är PÅ fortsätter personalsökningen fungera; där den är AV rensar modulgrinden från #213 dem vid nästa svep ändå.

**Guardrail:** docs_pages-grenen får aldrig skriva `'public'` igen.

## Läge

- **optic städat live** (modulen var av → 2 377 chunkar raderade; anon ser nu bara Optic Tunnels egna 25 KB + 8 sid-chunkar)
- **liteit, autoversio, www-legacy: väntar på beslut** — skarpa bolag utanför mitt mandat. Migrationen fixar dem vid nästa fork-synk, eller så kör jag omklassningen direkt på ditt ok.

`tsc --noEmit` rent. Fyra testfiler fallerar lokalt på fetch mot dev-instansen (svarar inte alls just nu) — **samma fel på main utan dessa ändringar**, alltså den flakiga klassen i task #83, inte den här koden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)