### PR TITLE
En KB-artikel har en egen adress — och alla fyra skrivare är överens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,7 @@ const BlogArchivePage = lazy(() => import("./pages/BlogArchivePage"));
 const JobsPage = lazy(() => import("./pages/JobsPage"));
 const JobDetailPage = lazy(() => import("./pages/JobDetailPage"));
 const BlogPostPage = lazy(() => import("./pages/BlogPostPage"));
+const KbArticlePage = lazy(() => import("./pages/KbArticlePage"));
 const BlogCategoryPage = lazy(() => import("./pages/BlogCategoryPage"));
 const BlogTagPage = lazy(() => import("./pages/BlogTagPage"));
 const BlogAuthorPage = lazy(() => import("./pages/BlogAuthorPage"));
@@ -294,6 +295,11 @@ const router = createBrowserRouter([
       { path: "/blog/tag/:slug", element: <BlogTagPage /> },
       { path: "/blog/author/:slug", element: <BlogAuthorPage /> },
       { path: "/blog/:slug", element: <BlogPostPage /> },
+      // A KB article has its own address, like a blog post. The hub block
+      // renders answers inline; this is where a link, a chat citation or a
+      // search result lands. /kb itself falls back to a page with that slug
+      // if the operator built one.
+      { path: "/kb/:slug", element: <KbArticlePage /> },
       { path: "/jobs", element: <JobsPage /> },
       { path: "/jobs/:slug", element: <JobDetailPage /> },
       { path: "/docs", element: withPageFallback(<DocsLandingPage />) },

--- a/src/components/admin/workspace/CitationsDrawer.tsx
+++ b/src/components/admin/workspace/CitationsDrawer.tsx
@@ -61,6 +61,26 @@ const TYPE_LABEL: Record<string, string> = {
   attachment: 'Attachment',
 };
 
+/**
+ * Where an "Open" on a citation should land.
+ *
+ * FlowWork's reader is always signed-in staff, and it cites nine source types —
+ * documents, contracts, employees, CRM records — of which only pages and KB
+ * articles ever have a public address. So the internal view is the consistent
+ * destination, not the exception.
+ *
+ * KB got that wrong in a way worth remembering: the retrieval layer stamped
+ * `/kb/<slug>` into each chunk's metadata, the citation rendered it verbatim,
+ * and no such route existed — every KB citation was a 404 dressed as a
+ * quality signal. Route it to the admin reading panel instead
+ * (`?article=<id>`), which opens the article in a reading panel with Edit as
+ * the secondary action. Other types keep whatever URL retrieval gave them.
+ */
+function citationHref(c: WorkspaceCitation): string | undefined {
+  if (c.type === 'kb_article' && c.id) return `/admin/knowledge-base?article=${c.id}`;
+  return c.url || undefined;
+}
+
 const SOURCE_META: Record<
   WorkspaceSource,
   { label: string; Icon: any }
@@ -160,9 +180,9 @@ export function CitationsDrawer({
                         >
                           {c.title}
                         </p>
-                        {c.url && (
+                        {citationHref(c) && (
                           <Link
-                            to={c.url}
+                            to={citationHref(c)!}
                             className="text-xs text-primary hover:underline inline-flex items-center gap-1 mt-1"
                           >
                             Open <ExternalLink className="h-3 w-3" />

--- a/src/components/public/blocks/KbFeaturedBlock.tsx
+++ b/src/components/public/blocks/KbFeaturedBlock.tsx
@@ -110,7 +110,7 @@ export function KbFeaturedBlock({ data }: KbFeaturedBlockProps) {
             {articles.map((article) => (
               <Link
                 key={article.id}
-                to={`/${kbSlug}/${article.slug}`}
+                to={`/kb/${article.slug}`}
                 className="group"
               >
                 <Card className="h-full transition-all duration-200 hover:shadow-lg hover:border-primary/50 group-hover:-translate-y-1">
@@ -137,7 +137,7 @@ export function KbFeaturedBlock({ data }: KbFeaturedBlockProps) {
             {articles.map((article) => (
               <Link
                 key={article.id}
-                to={`/${kbSlug}/${article.slug}`}
+                to={`/kb/${article.slug}`}
                 className="group block"
               >
                 <div className="flex items-center gap-4 p-4 rounded-lg border bg-card hover:bg-accent/50 transition-colors">

--- a/src/components/public/blocks/KbHubBlock.tsx
+++ b/src/components/public/blocks/KbHubBlock.tsx
@@ -373,7 +373,7 @@ export function KbHubBlock({ data }: KbHubBlockProps) {
             {filteredArticles.map(article => (
               <Link
                 key={article.id}
-                to={`/${kbSlug}/${article.slug}`}
+                to={`/kb/${article.slug}`}
                 className="group block"
               >
                 <div className="h-full p-5 rounded-xl border bg-card hover:shadow-lg hover:border-primary/50 transition-all group-hover:-translate-y-1">

--- a/src/hooks/useKnowledgeBase.ts
+++ b/src/hooks/useKnowledgeBase.ts
@@ -195,6 +195,32 @@ export function useKbArticle(id: string) {
   });
 }
 
+/**
+ * One published KB article by its slug — the public reading path.
+ *
+ * Published-only by design: this backs the anonymous `/kb/:slug` page, and an
+ * unpublished draft reachable by guessing a URL is a leak, not a feature. RLS
+ * already enforces it for anon; the filter keeps a logged-in staff member from
+ * seeing a draft here and assuming visitors can too.
+ */
+export function useKbArticleBySlug(slug?: string) {
+  return useQuery({
+    queryKey: ['kb-article-slug', slug],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('kb_articles')
+        .select('*, category:kb_categories(*)')
+        .eq('slug', slug!)
+        .eq('is_published', true)
+        .maybeSingle();
+
+      if (error) throw error;
+      return (data ?? null) as KbArticle | null;
+    },
+    enabled: !!slug,
+  });
+}
+
 export function useCreateKbArticle() {
   const queryClient = useQueryClient();
   const { toast } = useToast();

--- a/src/lib/__tests__/kb-article-addresses.guardrails.test.ts
+++ b/src/lib/__tests__/kb-article-addresses.guardrails.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * A KB article has ONE public address, and every writer agrees on it.
+ *
+ * Found 2026-08-12 by clicking a FlowWork citation: it opened
+ * `/kb/rag-er-kunskap-utan-att-träna-in-den` and 404'd. Four components had
+ * three opinions and none of them matched the router:
+ *
+ *   • the retrieval indexer stamped  /kb/<slug>      → no such route
+ *   • manage_kb_article returned     /kb/<slug>      → no such route
+ *   • the KB hub/featured blocks linked
+ *                                    /<kb-page>/<slug> → no such route
+ *   • the router had only            /:slug           (one segment)
+ *
+ * So no KB article could be opened, shared or indexed by a search engine, and
+ * FlowWork cited real content with dead links — a 404 dressed as a quality
+ * signal. `/kb/:slug` is now the address (modelled on `/blog/:slug`), which
+ * also makes the URL the indexer and the skill already emit come true.
+ *
+ * FlowWork itself does NOT use it: its reader is signed-in staff, and it cites
+ * nine source types of which only pages and KB ever have public addresses. Its
+ * citations open the admin reading panel via `?article=<id>` — consistent with
+ * documents, contracts and employees, which have no public page at all.
+ */
+
+const ROOT = join(__dirname, '../../..');
+const read = (p: string) => readFileSync(join(ROOT, p), 'utf-8');
+/** Source with `//` comments stripped — these files discuss the old URLs. */
+const codeOnly = (p: string) => read(p).replace(/\/\/[^\n]*/g, '');
+
+describe('the public address exists and everyone points at it', () => {
+  it('the router serves /kb/:slug', () => {
+    const app = codeOnly('src/App.tsx');
+    expect(app).toMatch(/path:\s*"\/kb\/:slug"/);
+    expect(app).toMatch(/KbArticlePage/);
+  });
+
+  it('the article page refuses unpublished articles', () => {
+    // Otherwise a draft is readable by guessing its slug.
+    const hook = codeOnly('src/hooks/useKnowledgeBase.ts');
+    const bySlug = hook.match(/export function useKbArticleBySlug[\s\S]*?\n\}/)?.[0] ?? '';
+    expect(bySlug, 'useKbArticleBySlug must exist').not.toBe('');
+    expect(bySlug).toMatch(/\.eq\('is_published',\s*true\)/);
+  });
+
+  it('KB blocks link to the article address, not to a page-relative path', () => {
+    for (const f of [
+      'src/components/public/blocks/KbHubBlock.tsx',
+      'src/components/public/blocks/KbFeaturedBlock.tsx',
+    ]) {
+      const src = codeOnly(f);
+      expect(
+        src,
+        `${f} still builds a page-relative article link, which matches no route`,
+      ).not.toMatch(/to=\{`\/\$\{kbSlug\}\/\$\{article\.slug\}`\}/);
+    }
+    expect(codeOnly('src/components/public/blocks/KbHubBlock.tsx'))
+      .toMatch(/to=\{`\/kb\/\$\{article\.slug\}`\}/);
+  });
+
+  it('the indexer keeps stamping the same address the router serves', () => {
+    const indexer = codeOnly('supabase/functions/_shared/retrieval/indexer.ts');
+    expect(indexer).toMatch(/url:\s*`\/kb\/\$\{data\.slug\}`/);
+  });
+});
+
+describe('FlowWork citations open the internal reader', () => {
+  it('routes KB citations to the admin reading panel', () => {
+    const drawer = codeOnly('src/components/admin/workspace/CitationsDrawer.tsx');
+    const fn = drawer.match(/function citationHref[\s\S]*?\n\}/)?.[0] ?? '';
+    expect(fn, 'citationHref must exist').not.toBe('');
+    expect(fn).toMatch(/kb_article/);
+    expect(fn).toMatch(/\/admin\/knowledge-base\?article=/);
+  });
+
+  it('the admin KB page can be deep-linked into the reader', () => {
+    const page = codeOnly('src/pages/admin/KnowledgeBasePage.tsx');
+    expect(page).toMatch(/useSearchParams/);
+    expect(page).toMatch(/searchParams\.get\('article'\)/);
+    // Closing must drop the param, or Back re-opens the panel forever.
+    expect(page).toMatch(/next\.delete\('article'\)/);
+  });
+});

--- a/src/pages/KbArticlePage.tsx
+++ b/src/pages/KbArticlePage.tsx
@@ -1,0 +1,101 @@
+import { useParams, Link } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { PublicNavigation } from '@/components/public/PublicNavigation';
+import { PublicFooter } from '@/components/public/PublicFooter';
+import { SeoHead } from '@/components/public/SeoHead';
+import { Badge } from '@/components/ui/badge';
+import { useKbArticleBySlug } from '@/hooks/useKnowledgeBase';
+import { usePageViewTracker } from '@/hooks/usePageViewTracker';
+import { renderToHtml } from '@/lib/tiptap-utils';
+import NotFound from './NotFound';
+
+/**
+ * A knowledge base article at its own public address.
+ *
+ * Until now a KB article had no URL of its own. The hub block rendered every
+ * question and answer inline, and its "read more" links pointed at
+ * `/<kb-page>/<article>` — a two-segment path no route matched, so it 404'd.
+ * The indexer and the manage_kb_article skill both stamped `/kb/<slug>`, which
+ * also matched nothing. Three components, three opinions, no address.
+ *
+ * This is the address. `/kb/:slug`, modelled on `/blog/:slug`: the article
+ * belongs to the article, not to whichever page happens to carry the block.
+ * That makes it shareable, linkable from chat answers, and indexable by search
+ * engines — and it makes the URL those two writers already emit come true.
+ */
+export default function KbArticlePage() {
+  const { slug } = useParams<{ slug: string }>();
+  const { data: article, isLoading } = useKbArticleBySlug(slug);
+
+  usePageViewTracker({
+    pageId: article?.id,
+    pageSlug: slug ? `kb/${slug}` : 'kb',
+    pageTitle: article?.title,
+  });
+
+  if (isLoading) {
+    return (
+      <>
+        <PublicNavigation />
+        <main className="min-h-screen bg-background">
+          <div className="container mx-auto px-4 py-12">
+            <p className="text-center text-muted-foreground">Loading article…</p>
+          </div>
+        </main>
+        <PublicFooter />
+      </>
+    );
+  }
+
+  // Unpublished or unknown slug both land here — a draft must not be readable
+  // by guessing its address.
+  if (!article) return <NotFound />;
+
+  const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+  const category = (article as { category?: { name?: string; slug?: string } }).category;
+  const bodyHtml = renderToHtml(article.answer_json) || '';
+
+  return (
+    <>
+      <SeoHead
+        title={article.title}
+        description={article.question || article.answer_text?.slice(0, 155) || ''}
+        canonicalUrl={`${baseUrl}/kb/${article.slug}`}
+      />
+      <PublicNavigation />
+      <main className="min-h-screen bg-background">
+        <article className="container mx-auto max-w-3xl px-4 py-12 md:py-16">
+          <Link
+            to="/kb"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-6"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Knowledge Base
+          </Link>
+
+          {category?.name && (
+            <Badge variant="secondary" className="mb-3">{category.name}</Badge>
+          )}
+
+          <h1 className="font-serif text-3xl md:text-4xl font-semibold tracking-tight">
+            {article.title}
+          </h1>
+
+          {article.question && article.question !== article.title && (
+            <p className="mt-3 text-lg text-muted-foreground">{article.question}</p>
+          )}
+
+          {bodyHtml ? (
+            <div
+              className="prose prose-neutral dark:prose-invert max-w-none mt-8"
+              dangerouslySetInnerHTML={{ __html: bodyHtml }}
+            />
+          ) : (
+            <p className="mt-8 whitespace-pre-wrap leading-relaxed">{article.answer_text}</p>
+          )}
+        </article>
+      </main>
+      <PublicFooter />
+    </>
+  );
+}

--- a/src/pages/admin/KnowledgeBasePage.tsx
+++ b/src/pages/admin/KnowledgeBasePage.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo } from "react";
-import { Link } from "react-router-dom";
+import { useState, useMemo, useEffect } from "react";
+import { Link, useSearchParams } from "react-router-dom";
 import { Plus, Folder, FileText, MessageSquare, Search, MoreHorizontal, Pencil, Trash2, Check, X, AlertTriangle, ThumbsUp, ThumbsDown, Globe, Lock } from "lucide-react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -57,6 +57,12 @@ export default function KnowledgeBasePage() {
   // Read view: internal articles have no public page, so before this the EDIT
   // form was the only way for a salesperson to read what the operator wrote.
   const [readingArticle, setReadingArticle] = useState<KbArticle | null>(null);
+  // `?article=<id>` opens the reading panel directly. Without it the panel was
+  // only reachable by clicking a row, so nothing could link INTO it — which is
+  // why FlowWork's KB citations had nowhere sensible to point (they aimed at a
+  // public /kb/<slug> route that did not exist, and 404'd).
+  const [searchParams, setSearchParams] = useSearchParams();
+  const articleParam = searchParams.get('article');
   const [deleteDialog, setDeleteDialog] = useState<{ type: 'category' | 'article'; id: string } | null>(null);
   const [selectedArticles, setSelectedArticles] = useState<Set<string>>(new Set());
 
@@ -67,6 +73,25 @@ export default function KnowledgeBasePage() {
   const deleteArticle = useDeleteKbArticle();
   const bulkUpdateChat = useBulkUpdateKbArticlesChatStatus();
   const clearImprovementFlag = useClearKbImprovementFlag();
+
+  // Resolve `?article=<id>` once the list has loaded. Deliberately keyed on the
+  // param and the data, not on readingArticle: closing the panel clears the
+  // param (below), so this cannot re-open what the user just dismissed.
+  useEffect(() => {
+    if (!articleParam || !articles) return;
+    const match = articles.find((a) => a.id === articleParam);
+    if (match) setReadingArticle(match);
+  }, [articleParam, articles]);
+
+  /** Close the reader and drop the deep-link param, so Back behaves. */
+  const closeReader = () => {
+    setReadingArticle(null);
+    if (articleParam) {
+      const next = new URLSearchParams(searchParams);
+      next.delete('article');
+      setSearchParams(next, { replace: true });
+    }
+  };
 
   const filteredArticles = articles?.filter(article => {
     const matchesSearch =
@@ -449,7 +474,7 @@ export default function KnowledgeBasePage() {
       </AlertDialog>
 
       {/* Read view — consume the article the way a reader would, edit one click away. */}
-      <Sheet open={!!readingArticle} onOpenChange={(o) => !o && setReadingArticle(null)}>
+      <Sheet open={!!readingArticle} onOpenChange={(o) => !o && closeReader()}>
         <SheetContent className="w-full sm:max-w-2xl overflow-y-auto">
           {readingArticle && (
             <>


### PR DESCRIPTION
Hittat genom att klicka på ditt FlowWork-citat: `/kb/rag-er-kunskap-utan-att-träna-in-den` → **404**. Fyra komponenter hade tre uppfattningar, och ingen matchade routern:

| Vem | Byggde | Fanns routen? |
|---|---|---|
| Retrieval-indexeraren (FlowWork-citat) | `/kb/<slug>` | Nej |
| `manage_kb_article`-skillen | `/kb/<slug>` | Nej |
| KB-blockens "läs mer" | `/<kb-sida>/<slug>` | Nej |
| Routern | `/:slug` (ett segment) | — |

Ingen KB-artikel kunde alltså öppnas, delas eller indexeras av en sökmotor — och FlowWork citerade äkta innehåll med döda länkar, extra lömskt eftersom ett citat *ser ut* som ett kvalitetstecken.

## Två behov, olika svar

**Publikt: `/kb/:slug` som riktig route**, modellerad på `/blog/:slug` — adressen hör till artikeln, inte till vilken sida som råkar bära hub-blocket. Sidan vägrar opublicerade artiklar (annars läcker utkast till den som gissar en slug). KB-blocken pekar dit, och URL:en som indexeraren och skillen *redan* skrev blir därmed sann.

**Internt: FlowWork pekar på admin-läspanelen** — din idé, och undersökningen gav den rätt: FlowWorks läsare är alltid inloggad personal, och den citerar nio källtyper (dokument, avtal, anställda, CRM…) av vilka bara sidor och KB någonsin har publika adresser. Interna vyn är det konsekventa målet, inte undantaget. Panelen fanns redan — den saknade bara djuplänkning, så nu öppnar `?article=<id>` exakt den vy du visade. Stängning rensar parametern så Back beter sig.

## Verifiering

`tsc --noEmit` rent, full vitest **2286 gröna** (5 live-DB-filer skippade av den nya proben — dev svarar inte just nu). Guardrail låser alla fyra ställena mot att drifta isär igen.

Om `/blogg → /blog`-frågan: samma mönster fungerar för alias, `/priser` finns redan så prejudikatet är satt. Säg till om du vill ha svenska alias som eget steg — det är en liten route-tabell, men värt ett eget beslut om det ska vara hårdkodat eller per-instans data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)