### PR TITLE
/kb finns — tillbakalänken pekade på en route jag glömde bygga

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,6 +93,7 @@ const JobsPage = lazy(() => import("./pages/JobsPage"));
 const JobDetailPage = lazy(() => import("./pages/JobDetailPage"));
 const BlogPostPage = lazy(() => import("./pages/BlogPostPage"));
 const KbArticlePage = lazy(() => import("./pages/KbArticlePage"));
+const KbLandingPage = lazy(() => import("./pages/KbLandingPage"));
 const BlogCategoryPage = lazy(() => import("./pages/BlogCategoryPage"));
 const BlogTagPage = lazy(() => import("./pages/BlogTagPage"));
 const BlogAuthorPage = lazy(() => import("./pages/BlogAuthorPage"));
@@ -299,6 +300,7 @@ const router = createBrowserRouter([
       // renders answers inline; this is where a link, a chat citation or a
       // search result lands. /kb itself falls back to a page with that slug
       // if the operator built one.
+      { path: "/kb", element: <KbLandingPage /> },
       { path: "/kb/:slug", element: <KbArticlePage /> },
       { path: "/jobs", element: <JobsPage /> },
       { path: "/jobs/:slug", element: <JobDetailPage /> },

--- a/src/lib/__tests__/kb-article-addresses.guardrails.test.ts
+++ b/src/lib/__tests__/kb-article-addresses.guardrails.test.ts
@@ -38,6 +38,15 @@ describe('the public address exists and everyone points at it', () => {
     expect(app).toMatch(/KbArticlePage/);
   });
 
+  it('serves /kb too — every link the KB pages emit must resolve', () => {
+    // Shipped without this once: the article page's "back to Knowledge Base"
+    // pointed at /kb, which matched nothing. Same class of bug the article
+    // route was built to fix, reintroduced one link over. Assert the pair.
+    const app = codeOnly('src/App.tsx');
+    expect(app).toMatch(/path:\s*"\/kb"/);
+    expect(app).toMatch(/KbLandingPage/);
+  });
+
   it('the article page refuses unpublished articles', () => {
     // Otherwise a draft is readable by guessing its slug.
     const hook = codeOnly('src/hooks/useKnowledgeBase.ts');

--- a/src/pages/KbLandingPage.tsx
+++ b/src/pages/KbLandingPage.tsx
@@ -1,0 +1,29 @@
+import { PublicNavigation } from '@/components/public/PublicNavigation';
+import { PublicFooter } from '@/components/public/PublicFooter';
+import { SeoHead } from '@/components/public/SeoHead';
+import { KbHubBlock } from '@/components/public/blocks/KbHubBlock';
+
+/**
+ * The knowledge base at its own address.
+ *
+ * Added because `/kb/:slug` shipped without it: the article page's "back to
+ * Knowledge Base" link pointed at `/kb`, which matched no route — the same
+ * class of bug the article page was built to fix, reintroduced one link over.
+ *
+ * It renders the same hub block operators place on their own pages, so an
+ * instance that put the KB on `/help` and a visitor who arrived at `/kb` from
+ * a chat citation see the same thing. Operators keep full control of their own
+ * page; this is the address that always works.
+ */
+export default function KbLandingPage() {
+  return (
+    <>
+      <SeoHead title="Knowledge Base" description="Browse questions and answers." />
+      <PublicNavigation />
+      <main className="min-h-screen bg-background">
+        <KbHubBlock data={{}} />
+      </main>
+      <PublicFooter />
+    </>
+  );
+}


### PR DESCRIPTION
Direkt uppföljning på #215, hittad av Magnus inom minuter: artikelsidans "Knowledge Base"-länk går till `/kb`, men jag lade bara till `/kb/:slug`. Alltså **exakt den buggklass artikelrouten byggdes för att stänga, återinförd en länk bort**.

`/kb` renderar samma hub-block som operatörer placerar på sina egna sidor. Instanser behåller sina egna KB-sidor orörda (optics `/help` med deras design och copy); `/kb` är plattformsadressen som alltid fungerar — för chattcitat, delning och sökmotorer.

Guardrailen assertar nu **paret**: varje länk KB-sidorna själva skickar ut måste matcha en route.

`tsc --noEmit` rent, full vitest 2287 gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)