### PR TITLE
README: kunskapslagret får ett avsnitt

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,26 @@ All skills follow Anthropic's MCP best practices: self-describing (`Use when:` /
 
 ---
 
+## Knowledge — one index, every surface
+
+**Most products bolt search on top of the systems. FlowWink has the memory built in — the same knowledge, different eyes, no extra product and no data leaving your instance.**
+
+Six content sources — pages, knowledge base, wiki, docs, handbook, documents — feed a single embedded index. Every grounded surface reads from it:
+
+| Who is asking | What they can retrieve |
+|---|---|
+| A visitor in the public chat | Public content only — published pages and KB articles |
+| Staff in FlowWork | Public *and* internal — wiki, handbook, documents, contracts, CRM |
+| An external agent over MCP | Whatever its key's scopes allow |
+
+Visibility is a property of the content, enforced by row-level security — not a filter the calling surface remembers to apply. A source whose module is switched off stops being indexed (nobody pays to embed content they turned off), and answers carry citations that link back to the record they came from.
+
+Retrieval is the default because it scales; when the index cannot answer — a brand-new instance, a page published a minute ago, no embedding key — grounding falls back to full text rather than to nothing. Degrade, never gate.
+
+See [`docs/architecture/retrieval-engine.md`](docs/architecture/retrieval-engine.md) and [`docs/architecture/conversation-and-retrieval.md`](docs/architecture/conversation-and-retrieval.md).
+
+---
+
 ## FlowPilot — the included operator
 
 FlowPilot is FlowWink's **vertically-integrated, local autonomous operator** — one of many possible MCP consumers, but the one that ships in the box. It runs *inside* the platform's trust boundary, which gives it advantages no external operator can replicate: zero-config onboarding, direct DB/event access, brand-aligned defaults, predictable cost.


### PR DESCRIPTION
README:n beskrev moduler, skills, operatörer och federation — men nämnde **kunskapslagret med noll ord**, trots att det är det som gör svaren grundade och det som skiljer plattformen från en sökprodukt.

Kärnformuleringen, den som håller i granskning:

> **Most products bolt search on top of the systems. FlowWink has the memory built in — the same knowledge, different eyes, no extra product and no data leaving your instance.**

Medvetet *utan* superlativet "först i världen": behörighetsmedveten RAG finns hos Glean, Guru och Copilot, och ett påstående som fälls i ett säljsamtal kostar mer än det ger. Skillnaden som faktiskt håller är strukturell — hos dem är sökningen en produkt **ovanpå** systemen med eget lager och egen datakopia; här föder **ett** index besökarchatt, medarbetaryta och externa agenter, med synligheten avgjord av vem som frågar och upprätthållen av RLS, självhostat.

Avsnittet tar också med de två driftsegenskaperna som visade sitt värde genom att saknas i veckan: avstängd modul slutar indexeras, och tomt index degraderar till fulltext i stället för till ogrundade svar.

Doc-drift grön, alla länkar verifierade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)