### PR TITLE
search_knowledge söker kundens kunskap, inte vår produktdokumentation

### DIFF
--- a/src/lib/__tests__/index-scope.guardrails.test.ts
+++ b/src/lib/__tests__/index-scope.guardrails.test.ts
@@ -104,6 +104,19 @@ describe('vendor documentation never reaches a customer-facing surface', () => {
       .not.toMatch(/sources[\s\S]{0,200}docs_pages/);
   });
 
+  it('the agent-facing search skill searches the customer\'s knowledge, not ours', () => {
+    // `search_knowledge` is what an external operator calls to look things up
+    // in the business it runs. FlowWink's own product documentation there is
+    // noise in the results and embeddings the customer paid for without
+    // asking — the /docs page has its own search (docs-chat) for the
+    // legitimate case. Not a secrecy rule: the docs are public on GitHub.
+    const src = codeOnly(join(ROOT, 'supabase/functions/agent-execute/index.ts'));
+    const list = src.match(/const SEARCHABLE_KNOWLEDGE_SOURCES = \[[^\]]*\]/)?.[0] ?? '';
+    expect(list, 'SEARCHABLE_KNOWLEDGE_SOURCES must exist').not.toBe('');
+    expect(list).not.toContain('docs_pages');
+    expect(list).toContain('kb_articles');
+  });
+
   it('the workspace chat maps `handbook` to the customer handbook, not vendor docs', () => {
     const src = codeOnly(WORKSPACE_CHAT);
     const map = src.match(/const KNOWLEDGE_TABLES[\s\S]*?\n\s*\};/)?.[0]

--- a/supabase/functions/agent-execute/index.ts
+++ b/supabase/functions/agent-execute/index.ts
@@ -12484,7 +12484,14 @@ async function executeUpdateSkillInstructions(
 // scope enforcement lands, resolve the client from the key's rung instead.
 // Structured rows (orders, Flowtable, …) are NOT here — two-lane rule.
 // ─────────────────────────────────────────────────────────────────────────────
-const SEARCHABLE_KNOWLEDGE_SOURCES = ['pages', 'kb_articles', 'wiki_pages', 'docs_pages', 'documents'];
+// docs_pages is deliberately ABSENT: it holds FlowWink's own product
+// documentation, synced onto each customer instance so the /docs page can
+// search itself (docs-chat does exactly that). An agent calling THIS skill is
+// searching the CUSTOMER's knowledge — vendor docs there are noise in the
+// results and embeddings the customer paid for without asking. Not a secrecy
+// argument (the documentation is public on GitHub); a hygiene and cost one,
+// which is why the fix narrows the source list rather than guarding the data.
+const SEARCHABLE_KNOWLEDGE_SOURCES = ['pages', 'kb_articles', 'wiki_pages', 'documents'];
 
 async function executeSearchKnowledge(
   supabase: any,

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1571,7 +1571,7 @@
       "functions": {
         "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
-        "agent-execute": "sha256:33a18607295c4bd0e104d31e813a4fe58adaa6afbca8a252c7d44a071feb916f",
+        "agent-execute": "sha256:d6684926b29cc719c4e959f438e8d7456691404b2558a1aa4ace996f766e0e20",
         "agent-operate": "sha256:72cdafe207ae2a5630e3263e6c993a55aade47c679f2cc200465cb3a17f30689",
         "ai-task": "sha256:6a0c6b21f9f0575650d9e478bc9184ce24541d3a18d00bb6c80c64a60f5e28aa",
         "automation-dispatcher": "sha256:3cb8681d7acce65624bd7957a432b143a2d959d769845dc71696b95c2ea2012b",


### PR DESCRIPTION
`docs_pages` låg i `SEARCHABLE_KNOWLEDGE_SOURCES` — en extern operatör med gateway-nyckel kunde alltså få träffar ur FlowWinks egen dokumentation när den sökte i den verksamhet den driver.

**Magnus poäng gör motivet ärligare:** dokumentationen ligger öppet på GitHub, så sekretessargumentet håller inte — jag överdrev när jag kallade det en läcka i morse. Det som kvarstår är **hygien och kostnad**: kunden betalar embeddings för vår produktdokumentation, och deras agent får brus i resultaten när den frågar om verksamheten. `/docs`-sidans egen chatt (`docs-chat`) täcker det legitima fallet och rör inte den här källistan.

Därmed är kedjan stängd för vendor-docs i alla kundvända lägen:

| Väg | Stängd av |
|---|---|
| Anonymt via RPC | `visibility: 'internal'` + RLS (#214) |
| Besökarchatten | Källistan har bara pages + kb (grindad #213) |
| FlowWork | `docs_pages` inte bland dess nio källor (grindad #213) |
| Agent via MCP | **den här ändringen** |
| `/docs`-sidans egen chatt | avsiktligt kvar — det är dess syfte |

Negativtestad grind: läggs `docs_pages` tillbaka blir CI röd. `tsc` rent, 2288 tester gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)