### PR TITLE
Nåbarhet och behörighet är två villkor — inte ett

### DIFF
--- a/src/lib/__tests__/staged-operations.guardrails.test.ts
+++ b/src/lib/__tests__/staged-operations.guardrails.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
-import { describeIfLiveDb } from '@/test/live-db';
+import { describeIfServiceKey } from '@/test/live-db';
 
 /**
  * Staged-Operation Envelope guardrail.
@@ -35,7 +35,7 @@ const MUST_BE_STAGED = [
 /** Approve/reject helpers must exist and be MCP-exposed. */
 const STAGING_HELPERS = ['approve_pending_operation', 'reject_pending_operation'] as const;
 
-describeIfLiveDb('Accounting staged-operation envelope', () => {
+describeIfServiceKey('Accounting staged-operation envelope', () => {
   it('every high-risk ledger skill is requires_staging=true and MCP-exposed', async () => {
     const supabase = createClient(SUPABASE_URL!, SERVICE_KEY!);
     const { data, error } = await supabase

--- a/src/lib/__tests__/voucher-gaps.guardrails.test.ts
+++ b/src/lib/__tests__/voucher-gaps.guardrails.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
-import { describeIfLiveDb } from '@/test/live-db';
+import { describeIfServiceKey } from '@/test/live-db';
 
 /**
  * Voucher-integrity guardrail.
@@ -19,7 +19,7 @@ const SERVICE_KEY =
 // a service-role key is available.
 const itIfService = SUPABASE_URL && SERVICE_KEY ? it : it.skip;
 
-describeIfLiveDb('Voucher integrity primitives', () => {
+describeIfServiceKey('Voucher integrity primitives', () => {
   it('list_voucher_gaps RPC is callable and returns an array', async () => {
     const supabase = createClient(SUPABASE_URL!, SUPABASE_KEY!);
     const year = new Date().getFullYear();

--- a/src/test/live-db.ts
+++ b/src/test/live-db.ts
@@ -19,3 +19,24 @@ export const describeIfLiveDb = ((...args: Parameters<typeof describe>) => {
   if (LIVE_DB_STATE() === 'up') return describe(...args);
   return describe.skip(...args);
 }) as typeof describe;
+
+/**
+ * For suites that need a SERVICE-ROLE key on top of a reachable instance —
+ * they read tables whose RLS blocks anon (agent_skills, ledger internals), so
+ * the publishable key is not enough.
+ *
+ * Exists because the first version of this helper dropped that second
+ * condition: the suites had hand-rolled `URL && SERVICE_KEY ? describe :
+ * describe.skip`, the rewrite replaced it with the reachability check alone,
+ * and the moment the instance came back up they ran keyless and died on
+ * "supabaseKey is required". Reachability and authorisation are two different
+ * preconditions; a helper that collapses them turns one green build into a red
+ * one for the wrong reason.
+ */
+export const describeIfServiceKey = ((...args: Parameters<typeof describe>) => {
+  const hasKey = Boolean(
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY,
+  );
+  if (LIVE_DB_STATE() === 'up' && hasKey) return describe(...args);
+  return describe.skip(...args);
+}) as typeof describe;


### PR DESCRIPTION
Regression från min egen probe-fix (#214), som visade sig **i samma stund dev kom tillbaka**.

Två sviter — `staged-operations` och `voucher-gaps` — läser tabeller vars RLS blockerar anon, och krävde därför **både** en nåbar instans **och** en service-role-nyckel. Deras handrullade `URL && SERVICE_KEY ? describe : describe.skip` ersattes av `describeIfLiveDb`, som bara kollar nåbarhet. Så länge dev låg nere märktes inget; när den kom upp körde de nyckellöst och dog på `supabaseKey is required`.

Alltså **ett rött bygge av fel skäl — precis det probe-fixen fanns för att avskaffa.** Nu finns `describeIfServiceKey` som kollar båda villkoren, med en kommentar om varför de inte får slås ihop.

**Verifierat med dev uppe:** 2293 gröna, 2 filer skippade (ingen service-nyckel lokalt), noll fel — och tre live-sviter kördes faktiskt mot instansen, vilket är hela poängen med att ha dem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)