### PR TITLE
En uppladdad PDF blir läst, och når precis så långt som den fick

### DIFF
--- a/src/components/admin/system/ObservabilityTab.tsx
+++ b/src/components/admin/system/ObservabilityTab.tsx
@@ -571,6 +571,35 @@ function KnowledgeIndexCard() {
                 {data?.missingEmbedding} chunk(s) without an embedding — check the AI provider key.
               </p>
             )}
+            {/* A file waiting to become text has no chunks, so every count below
+                reports it as absent. Say it out loud instead. */}
+            {(() => {
+              const w = data?.documentsAwaitingText;
+              if (!w) return null;
+              const queued = w.pending + w.processing;
+              return (
+                <>
+                  {queued > 0 && (
+                    <p className="text-xs text-muted-foreground">
+                      {queued} uploaded file(s) still being read — they join the index once
+                      their text is extracted.
+                    </p>
+                  )}
+                  {w.failed > 0 && (
+                    <p className="text-xs text-amber-600 dark:text-amber-500">
+                      {w.failed} upload(s) could not be read. They are not retried
+                      automatically — re-upload to try again.
+                    </p>
+                  )}
+                  {w.unsupported > 0 && (
+                    <p className="text-xs text-muted-foreground">
+                      {w.unsupported} upload(s) are of a file type this instance cannot read
+                      yet (PDF only).
+                    </p>
+                  )}
+                </>
+              );
+            })()}
             <ul className="space-y-1">
               {KNOWLEDGE_SOURCES.map((src) => (
                 <li key={src} className="flex items-center justify-between text-sm py-0.5">

--- a/src/hooks/useKnowledgeIndex.ts
+++ b/src/hooks/useKnowledgeIndex.ts
@@ -39,15 +39,25 @@ export interface KnowledgeIndexHealth {
   /** Items waiting for the next sweep. A steady non-zero value means the sweeper is not running. */
   queueDepth: number;
   lastIndexedAt: string | null;
+  /**
+   * Uploaded files that are not text yet, by extraction state.
+   *
+   * A document waiting for extraction has zero chunks, so every chunk-based
+   * number above reports it as simply absent — which is how a PDF sat pending
+   * on optic for two days without a single surface saying so. The point of
+   * doing things under the hood is not doing them in the dark.
+   */
+  documentsAwaitingText: { pending: number; processing: number; unsupported: number; failed: number };
 }
 
 export function useKnowledgeIndexHealth() {
   return useQuery({
     queryKey: ['knowledge-index-health'],
     queryFn: async (): Promise<KnowledgeIndexHealth> => {
-      const [chunks, queue] = await Promise.all([
+      const [chunks, queue, docs] = await Promise.all([
         supabase.from('knowledge_chunks').select('source_table, embedding, updated_at'),
         supabase.from('knowledge_index_queue').select('source_table'),
+        supabase.from('documents').select('extraction_status').not('file_url', 'is', null),
       ]);
       if (chunks.error) throw chunks.error;
 
@@ -69,6 +79,15 @@ export function useKnowledgeIndexHealth() {
         // the card must still render the chunk counts it CAN see.
         queueDepth: queue.error ? 0 : (queue.data?.length ?? 0),
         lastIndexedAt,
+        documentsAwaitingText: (docs.data ?? []).reduce(
+          (acc, d: { extraction_status: string | null }) => {
+            if (d.extraction_status && d.extraction_status in acc) {
+              acc[d.extraction_status as keyof typeof acc] += 1;
+            }
+            return acc;
+          },
+          { pending: 0, processing: 0, unsupported: 0, failed: 0 },
+        ),
       };
     },
     staleTime: 30_000,

--- a/src/lib/__tests__/document-index-tier.guardrails.test.ts
+++ b/src/lib/__tests__/document-index-tier.guardrails.test.ts
@@ -67,6 +67,17 @@ describe('a document reaches only as far as its own visibility answer', () => {
     }
   });
 
+  it('never de-indexes because a read failed', () => {
+    // extractEntity returning null means "this entity should not be indexed",
+    // and reindexEntity acts on that by DELETING its chunks. A failed read is
+    // not that statement. Without this, an instance missing a column the select
+    // names (autoversio's schema head was three weeks behind on 2026-08-12)
+    // would silently empty its own document index.
+    const branch = codeOnly(INDEXER).match(/case 'documents': \{[\s\S]*?\n    \}/)?.[0] ?? '';
+    expect(branch).toMatch(/const \{ data, error \}/);
+    expect(branch).toMatch(/if \(error\) throw/);
+  });
+
   it('reads the column it branches on', () => {
     // A rule that selects nothing evaluates undefined for every row — which
     // here would silently mean "shared", i.e. exactly the bug being fixed.

--- a/src/lib/__tests__/document-index-tier.guardrails.test.ts
+++ b/src/lib/__tests__/document-index-tier.guardrails.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  documentIndexTier,
+  toStoragePath,
+} from '../../../supabase/functions/_shared/retrieval/indexer.ts';
+
+/**
+ * An uploaded file is the one knowledge source with no purpose of its own.
+ *
+ * Every other source declares what it is by existing — a KB article is written
+ * to be read, a published page is published. `documents` holds a product sheet,
+ * an employment contract, a receipt and a CV in the same table. The upload
+ * dialog therefore asks the only question the uploader can answer honestly
+ * ("who can see this": shared / role / private), and how far the text travels
+ * in the index is a CONSEQUENCE of that answer — never a second switch the
+ * uploader has to get right twice.
+ *
+ * Until 2026-08-12 the indexer selected neither column and stamped every
+ * document 'internal'. Nothing had leaked only because nothing was ever
+ * extracted (see the sweeper tests below) — the fleet's single uploaded file
+ * sat at extraction_status='pending' for two days. Both halves of that near
+ * miss are nailed down here.
+ */
+
+const ROOT = join(__dirname, '../../..');
+const INDEXER = join(ROOT, 'supabase/functions/_shared/retrieval/indexer.ts');
+const EXTRACTOR = join(ROOT, 'supabase/functions/extract-pdf-text/index.ts');
+
+const codeOnly = (path: string) => readFileSync(path, 'utf-8').replace(/\/\/[^\n]*/g, '');
+
+describe('a document reaches only as far as its own visibility answer', () => {
+  it('indexes shared documents at the staff tier', () => {
+    expect(documentIndexTier('shared')).toBe('internal');
+  });
+
+  it('never indexes a private document', () => {
+    // The employment-contract case the upload dialog exists for.
+    expect(documentIndexTier('private')).toBeNull();
+  });
+
+  it('never indexes a role-restricted document', () => {
+    // `knowledge_chunks` has two tiers, and its "internal" policy grants read
+    // to every staff role. Indexing an HR-only file as 'internal' would show it
+    // to warehouse and support — strictly wider than what the uploader chose.
+    // Until the chunk tier can carry a role, the honest answer is to stay out.
+    expect(documentIndexTier('role')).toBeNull();
+  });
+
+  it('treats a missing visibility as the column default', () => {
+    // documents.visibility DEFAULT 'shared' — a row written before the column
+    // existed means "shared", not "unknown, therefore hide".
+    expect(documentIndexTier(null)).toBe('internal');
+    expect(documentIndexTier(undefined)).toBe('internal');
+  });
+
+  it('can never put an uploaded file in the anon-readable tier', () => {
+    // "Anyone can read public chunks" is an RLS policy on knowledge_chunks and
+    // search_knowledge_chunks is EXECUTE-granted to anon, so 'public' here
+    // would hand uploads to the visitor chat with a key that ships in the JS
+    // bundle. This is the docs_pages incident's exact shape (7,959 chunks,
+    // 2026-08-12) — a file is uploaded because it belongs to the business, not
+    // because someone published it.
+    for (const v of ['shared', 'private', 'role', 'public', '', null, undefined, 'nonsense']) {
+      expect(documentIndexTier(v as string | null)).not.toBe('public');
+    }
+  });
+
+  it('reads the column it branches on', () => {
+    // A rule that selects nothing evaluates undefined for every row — which
+    // here would silently mean "shared", i.e. exactly the bug being fixed.
+    const branch = codeOnly(INDEXER).match(/case 'documents': \{[\s\S]*?\n    \}/)?.[0] ?? '';
+    expect(branch, 'the documents branch must exist to be checked').not.toBe('');
+    expect(branch).toMatch(/\.select\([^)]*visibility/);
+    expect(branch).toMatch(/documentIndexTier\(/);
+    expect(branch, 'the tier must be derived, not hardcoded').not.toMatch(/visibility:\s*'internal'/);
+  });
+});
+
+describe('the extractor writes back to whoever uploaded', () => {
+  it('does not scope the write to a single upload path', () => {
+    // Scoped to source='cowork-upload' until 2026-08-12: the extractor would
+    // download the PDF, spend the multimodal call, answer success — and update
+    // zero rows for admin ('manual') or agent uploads. Whose upload it was is
+    // not a property of whether its text may be stored.
+    const src = codeOnly(EXTRACTOR);
+    const fn = src.match(/async function updateDocumentExtraction[\s\S]*?\n\}/)?.[0] ?? '';
+    expect(fn, 'updateDocumentExtraction must exist').not.toBe('');
+    expect(fn).toMatch(/\.eq\('id', documentId\)/);
+    expect(fn, "the write must not be filtered by source").not.toMatch(/\.eq\('source'/);
+  });
+});
+
+describe('the sweeper picks up pending documents', () => {
+  const src = codeOnly(INDEXER);
+  const sweep = src.match(/export async function sweepPendingExtractions[\s\S]*?\n\}\n/)?.[0] ?? '';
+
+  it('exists and claims work before dispatching it', () => {
+    expect(sweep, 'sweepPendingExtractions must exist').not.toBe('');
+    // Without the claim, a 5-minute cron pays for the same PDF again every tick
+    // for as long as extraction takes.
+    expect(sweep).toMatch(/extraction_status:\s*'processing'/);
+    expect(sweep).toMatch(/\.eq\('extraction_status', 'pending'\)/);
+  });
+
+  it('reclaims documents whose extractor died', () => {
+    // Claiming without a reclaim converts a crashed extractor into a document
+    // that is stuck forever — a worse failure than the one being fixed.
+    expect(sweep).toMatch(/EXTRACTION_STALE_MS/);
+    expect(sweep).toMatch(/\.eq\('extraction_status', 'processing'\)/);
+  });
+
+  it('does not retry failures on a loop', () => {
+    // 'failed' means the extractor read it and could not parse it. Re-running
+    // that on a cron is an unbounded AI bill against a file that will not
+    // improve; retrying is a deliberate act.
+    expect(sweep).not.toMatch(/'failed'/);
+  });
+
+  it('spends nothing when the documents module is off', () => {
+    expect(sweep).toMatch(/loadEnabledSources\(service\)/);
+    expect(sweep).toMatch(/if\s*\(!enabled\.has\('documents'\)\)\s*return result/);
+  });
+
+  it('is wired into the indexer cron run', () => {
+    // A sweeper nobody calls is the bug it was written to fix.
+    const fn = readFileSync(join(ROOT, 'supabase/functions/knowledge-indexer/index.ts'), 'utf-8');
+    expect(fn).toMatch(/sweepPendingExtractions\(/);
+  });
+});
+
+describe('storage paths survive both upload formats', () => {
+  it('leaves a bucket-qualified path alone', () => {
+    expect(toStoragePath('cowork-uploads/abc/x.pdf')).toBe('cowork-uploads/abc/x.pdf');
+    expect(toStoragePath('form-uploads/abc/x.pdf')).toBe('form-uploads/abc/x.pdf');
+    expect(toStoragePath('documents/abc/x.pdf')).toBe('documents/abc/x.pdf');
+  });
+
+  it('qualifies an admin upload against the documents bucket', () => {
+    // AddDocumentDialog uploads to the `documents` bucket but stores the path
+    // relative to it, re-attaching the bucket at read time
+    // (createSignedUrl(file_url)). The extractor splits on the first '/' to
+    // find the bucket, so the raw value sent it looking for a bucket named
+    // after a UUID.
+    expect(toStoragePath('d824ec45-34dc-4276-92d6-0a32f9a3076c/1786401408522-q7zddz.pdf')).toBe(
+      'documents/d824ec45-34dc-4276-92d6-0a32f9a3076c/1786401408522-q7zddz.pdf',
+    );
+  });
+});

--- a/supabase/functions/_shared/retrieval/indexer.ts
+++ b/supabase/functions/_shared/retrieval/indexer.ts
@@ -203,11 +203,20 @@ async function extractEntity(
       };
     }
     case 'documents': {
-      const { data } = await service
+      const { data, error } = await service
         .from('documents')
         .select('title, content_md, extraction_status, category, visibility')
         .eq('id', entityId)
         .maybeSingle();
+      // A read that FAILED is not a row that says "de-index me". Returning null
+      // here deletes the entity's chunks, so a transient outage — or an
+      // instance whose schema lacks a column this select names — would quietly
+      // empty the index instead of leaving it as it was. Throwing puts the item
+      // back on the queue with the reason attached.
+      // (autoversio, 2026-08-12: schema head three weeks behind, no
+      // documents.visibility. Zero documents there today, which is the only
+      // reason this was a near miss rather than an incident.)
+      if (error) throw new Error(`documents read failed: ${error.message}`);
       // The platform writes extraction_status='success' (upload_document,
       // extract-pdf-text). This check said 'completed' — a literal that never
       // matched, so NO document was ever indexed, even fully extracted ones.

--- a/supabase/functions/_shared/retrieval/indexer.ts
+++ b/supabase/functions/_shared/retrieval/indexer.ts
@@ -375,6 +375,10 @@ export interface ExtractionSweepResult {
   reclaimed: number;
   /** Extractor call could not even be dispatched. */
   failed: number;
+  /** File types this platform cannot read (marked, not left waiting). */
+  unsupported: number;
+  /** Why, for the failures — the sweep result is the only place they surface. */
+  errors?: string[];
 }
 
 /** A `processing` row older than this lost its extractor; take it back. */
@@ -430,7 +434,7 @@ export async function sweepPendingExtractions(
   service: any,
   opts: { supabaseUrl: string; serviceKey: string; limit?: number },
 ): Promise<ExtractionSweepResult> {
-  const result: ExtractionSweepResult = { started: 0, reclaimed: 0, failed: 0 };
+  const result: ExtractionSweepResult = { started: 0, reclaimed: 0, failed: 0, unsupported: 0 };
 
   // Nobody pays to read files for a module they switched off.
   const enabled = await loadEnabledSources(service);
@@ -455,12 +459,20 @@ export async function sweepPendingExtractions(
   if (error) throw new Error(`pending scan failed: ${error.message}`);
 
   for (const doc of pending ?? []) {
-    // The extractor is PDF-only. Other types keep waiting rather than being
-    // marked failed — we never tried, and saying otherwise would be a lie the
-    // health card then reports.
+    // The extractor is PDF-only. Anything else is marked 'unsupported' rather
+    // than left pending: 'pending' promises someone is coming, and for a .docx
+    // nobody is. 'failed' would be the other lie — we never tried to parse it.
     const isPdf =
       /pdf/i.test(doc.file_type ?? '') || /\.pdf$/i.test(doc.file_name ?? doc.file_url ?? '');
-    if (!isPdf) continue;
+    if (!isPdf) {
+      await service
+        .from('documents')
+        .update({ extraction_status: 'unsupported' })
+        .eq('id', doc.id)
+        .eq('extraction_status', 'pending');
+      result.unsupported += 1;
+      continue;
+    }
 
     const { error: claimError } = await service
       .from('documents')
@@ -468,7 +480,12 @@ export async function sweepPendingExtractions(
       .eq('id', doc.id)
       .eq('extraction_status', 'pending'); // lost race → another sweeper has it
     if (claimError) {
+      // Say why. A swallowed claim error is a document that stays pending with
+      // an empty extraction_error — indistinguishable from never having been
+      // looked at, which is the failure this whole sweeper exists to end.
+      console.error(`claim failed for document ${doc.id}:`, claimError.message ?? claimError);
       result.failed += 1;
+      result.errors = [...(result.errors ?? []), `${doc.id}: ${claimError.message ?? claimError}`];
       continue;
     }
 
@@ -490,6 +507,7 @@ export async function sweepPendingExtractions(
         .update({ extraction_status: 'pending', extraction_error: String(e).slice(0, 500) })
         .eq('id', doc.id);
       result.failed += 1;
+      result.errors = [...(result.errors ?? []), `${doc.id}: ${String(e).slice(0, 200)}`];
     }
   }
 

--- a/supabase/functions/_shared/retrieval/indexer.ts
+++ b/supabase/functions/_shared/retrieval/indexer.ts
@@ -69,6 +69,37 @@ interface ExtractedEntity {
   metadata: Record<string, unknown>;
 }
 
+/**
+ * How far an uploaded file's text may travel in the index.
+ *
+ * Every other source declares its purpose by existing: a KB article is written
+ * to be read, a published page is published. `documents` is the one table where
+ * that is not true — the same table holds a product sheet, an employment
+ * contract, a receipt and a CV. An upload carries no purpose of its own, so the
+ * index must not invent one for it.
+ *
+ * We do NOT solve that with a second question ("should this file be searchable?"
+ * — the AnythingLLM model). The upload dialog already asks the one question the
+ * uploader can actually answer: *who can see this* (shared / role / private).
+ * Reach in the index is a CONSEQUENCE of that answer, never a separate switch.
+ *
+ *   shared  → 'internal'  staff-wide, the same tier the handbook sits on
+ *   role    → not indexed  the index has two tiers (public/internal); a
+ *                          role-restricted file has no honest home here, and
+ *                          'internal' would show HR files to every employee
+ *   private → not indexed  the whole point of the answer
+ *
+ * Note what is missing: nothing here returns 'public'. `knowledge_chunks` has an
+ * RLS policy granting anon read of public chunks, so 'public' would put an
+ * uploaded file in front of the visitor chat. A file is uploaded because it
+ * belongs to the business, not because it was published — the customer-facing
+ * tier stays reserved for content someone deliberately wrote for it.
+ */
+export function documentIndexTier(visibility: string | null | undefined): 'internal' | null {
+  // Default (a NULL from a row predating the column) follows the column default.
+  return (visibility ?? 'shared') === 'shared' ? 'internal' : null;
+}
+
 /** Load one source row and produce its chunks, or null to de-index it. */
 async function extractEntity(
   service: any,
@@ -174,7 +205,7 @@ async function extractEntity(
     case 'documents': {
       const { data } = await service
         .from('documents')
-        .select('title, content_md, extraction_status, category')
+        .select('title, content_md, extraction_status, category, visibility')
         .eq('id', entityId)
         .maybeSingle();
       // The platform writes extraction_status='success' (upload_document,
@@ -183,9 +214,11 @@ async function extractEntity(
       // Same near-miss class as the vat-coverage `<> 'void'` filter. Stated
       // positively, accepting both spellings ever written.
       if (!data || !['success', 'completed'].includes(data.extraction_status) || !data.content_md?.trim()) return null;
+      const tier = documentIndexTier(data.visibility);
+      if (!tier) return null; // private / role-restricted — never enters the shared index
       return {
         title: data.title,
-        visibility: 'internal',
+        visibility: tier,
         chunks: chunkMarkdown(data.title, data.content_md),
         metadata: { category: data.category },
       };
@@ -332,6 +365,134 @@ export async function processQueue(service: any, limit = 50): Promise<SweepResul
         .eq('entity_id', item.entity_id);
     }
   }
+  return result;
+}
+
+export interface ExtractionSweepResult {
+  /** Documents handed to the extractor this run. */
+  started: number;
+  /** Stale `processing` rows reclaimed (an extractor died mid-flight). */
+  reclaimed: number;
+  /** Extractor call could not even be dispatched. */
+  failed: number;
+}
+
+/** A `processing` row older than this lost its extractor; take it back. */
+const EXTRACTION_STALE_MS = 15 * 60 * 1000;
+
+/** Buckets a document row may point into, longest-prefix first. */
+const DOCUMENT_BUCKETS = ['cowork-uploads', 'form-uploads', 'documents'];
+
+/**
+ * `documents.file_url` holds two different things depending on who wrote it.
+ *
+ * The cowork upload path stores a bucket-qualified path (`cowork-uploads/x/y.pdf`);
+ * the admin documents page stores one relative to the `documents` bucket
+ * (`<uuid>/y.pdf`) and re-attaches the bucket at read time
+ * (`storage.from("documents").createSignedUrl(file_url)`). Both are internally
+ * consistent, which is why neither side noticed. The extractor takes a
+ * bucket-qualified path and splits on the first `/`, so an admin upload would
+ * have it look for a bucket named after a UUID.
+ *
+ * Normalising on read is the honest fix while both formats exist in the wild.
+ */
+export function toStoragePath(fileUrl: string): string {
+  const first = fileUrl.split('/')[0];
+  return DOCUMENT_BUCKETS.includes(first) ? fileUrl : `documents/${fileUrl}`;
+}
+
+/**
+ * Hand `pending` PDFs to the extractor.
+ *
+ * Uploading a document used to be where the knowledge chain quietly stopped.
+ * `extract-pdf-text` was only ever called by the three surfaces that upload on
+ * a user's behalf (cowork attachments, job applications, the skill handler) —
+ * an admin uploading through the documents page wrote a row with the column
+ * default `extraction_status='pending'` and nothing ever came for it. No cron,
+ * no trigger, no queue: the platform's own answer to "is this indexed yet" was
+ * *pending*, forever. Found on optic 2026-08-12, on the only uploaded file in
+ * the fleet, two days after upload.
+ *
+ * So: the sweeper, rather than a fourth caller. Any row that reaches `pending`
+ * gets picked up regardless of how it got there, which is the property a new
+ * upload path can't accidentally break.
+ *
+ * Extraction is claimed by flipping to `processing` before dispatch, so the
+ * next 5-minute tick does not pay for the same PDF twice. `failed` rows are
+ * left alone — a retry loop on a corrupt file is an unbounded AI bill; retrying
+ * is a deliberate act (re-upload, or the extract skill).
+ *
+ * Every pending document is extracted, including private ones: the text belongs
+ * to the document (it is what the document viewer shows), and how far that text
+ * travels is decided later and separately by `documentIndexTier`.
+ */
+export async function sweepPendingExtractions(
+  service: any,
+  opts: { supabaseUrl: string; serviceKey: string; limit?: number },
+): Promise<ExtractionSweepResult> {
+  const result: ExtractionSweepResult = { started: 0, reclaimed: 0, failed: 0 };
+
+  // Nobody pays to read files for a module they switched off.
+  const enabled = await loadEnabledSources(service);
+  if (!enabled.has('documents')) return result;
+
+  const staleBefore = new Date(Date.now() - EXTRACTION_STALE_MS).toISOString();
+  const { data: stale } = await service
+    .from('documents')
+    .update({ extraction_status: 'pending' })
+    .eq('extraction_status', 'processing')
+    .lt('updated_at', staleBefore)
+    .select('id');
+  result.reclaimed = (stale ?? []).length;
+
+  const { data: pending, error } = await service
+    .from('documents')
+    .select('id, file_url, file_name, file_type')
+    .eq('extraction_status', 'pending')
+    .not('file_url', 'is', null)
+    .order('created_at', { ascending: true })
+    .limit(opts.limit ?? 5);
+  if (error) throw new Error(`pending scan failed: ${error.message}`);
+
+  for (const doc of pending ?? []) {
+    // The extractor is PDF-only. Other types keep waiting rather than being
+    // marked failed — we never tried, and saying otherwise would be a lie the
+    // health card then reports.
+    const isPdf =
+      /pdf/i.test(doc.file_type ?? '') || /\.pdf$/i.test(doc.file_name ?? doc.file_url ?? '');
+    if (!isPdf) continue;
+
+    const { error: claimError } = await service
+      .from('documents')
+      .update({ extraction_status: 'processing', extraction_error: null })
+      .eq('id', doc.id)
+      .eq('extraction_status', 'pending'); // lost race → another sweeper has it
+    if (claimError) {
+      result.failed += 1;
+      continue;
+    }
+
+    try {
+      const response = await fetch(`${opts.supabaseUrl}/functions/v1/extract-pdf-text`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${opts.serviceKey}`,
+        },
+        body: JSON.stringify({ document_id: doc.id, storage_path: toStoragePath(doc.file_url) }),
+      });
+      if (!response.ok) throw new Error(`extractor returned ${response.status}`);
+      result.started += 1;
+    } catch (e) {
+      // Could not even dispatch — hand it back so the next tick retries.
+      await service
+        .from('documents')
+        .update({ extraction_status: 'pending', extraction_error: String(e).slice(0, 500) })
+        .eq('id', doc.id);
+      result.failed += 1;
+    }
+  }
+
   return result;
 }
 

--- a/supabase/functions/extract-pdf-text/index.ts
+++ b/supabase/functions/extract-pdf-text/index.ts
@@ -242,11 +242,15 @@ async function updateDocumentExtraction(documentId: string, status: 'success' | 
     payload.content_extracted_at = new Date().toISOString();
   }
 
+  // Scoped to source='cowork-upload' until 2026-08-12, back when the cowork
+  // chat was the only caller. It made the write a silent no-op for every other
+  // upload path — the extractor would read the PDF, spend the AI call, report
+  // success and update nothing. Whose upload it was is not a property of
+  // whether its text may be stored.
   const { error } = await supabase
     .from('documents')
     .update(payload)
-    .eq('id', documentId)
-    .eq('source', 'cowork-upload');
+    .eq('id', documentId);
 
   if (error) {
     console.error('updateDocumentExtraction rpc failed:', error);

--- a/supabase/functions/knowledge-indexer/index.ts
+++ b/supabase/functions/knowledge-indexer/index.ts
@@ -9,7 +9,13 @@
 // path (search_knowledge_chunks, SECURITY INVOKER), never to indexing.
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { getServiceClient } from '../_shared/supabase-clients.ts';
-import { processQueue, queueFullReindex, CHUNK_SOURCES, type ChunkSource } from '../_shared/retrieval/indexer.ts';
+import {
+  processQueue,
+  queueFullReindex,
+  sweepPendingExtractions,
+  CHUNK_SOURCES,
+  type ChunkSource,
+} from '../_shared/retrieval/indexer.ts';
 import { embedPendingChunks } from '../_shared/retrieval/embedder.ts';
 
 const corsHeaders = {
@@ -47,6 +53,26 @@ serve(async (req) => {
       queued = await queueFullReindex(service, source);
     }
 
+    // A document has to be READ before it can be indexed. Uploads land as
+    // extraction_status='pending' and nothing used to come for them, so the
+    // chain stopped one step before the queue. Extraction is dispatched (the
+    // extractor answers 202 and finishes in the background) rather than awaited
+    // — a slow PDF must not hold up the queue drain behind it.
+    let extraction: Awaited<ReturnType<typeof sweepPendingExtractions>> | undefined;
+    const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+    if (supabaseUrl && serviceKey) {
+      try {
+        extraction = await sweepPendingExtractions(service, {
+          supabaseUrl,
+          serviceKey,
+          limit: body.extract_limit ?? 5,
+        });
+      } catch (e) {
+        // Extraction trouble must not stop indexing of everything else.
+        console.error('extraction sweep failed (non-fatal):', String(e));
+      }
+    }
+
     const sweep = await processQueue(service, body.limit ?? 50);
 
     // M2: vectorize chunks lacking an embedding (or embedded with an old
@@ -54,7 +80,13 @@ serve(async (req) => {
     const embed = await embedPendingChunks(service, body.embed_limit ?? 80);
 
     return new Response(
-      JSON.stringify({ status: 'ok', ...(queued !== undefined ? { queued } : {}), ...sweep, embed }),
+      JSON.stringify({
+        status: 'ok',
+        ...(queued !== undefined ? { queued } : {}),
+        ...sweep,
+        embed,
+        ...(extraction ? { extraction } : {}),
+      }),
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
     );
   } catch (e) {

--- a/supabase/migrations/20260812170000_extraction-can-be-in-flight.sql
+++ b/supabase/migrations/20260812170000_extraction-can-be-in-flight.sql
@@ -1,0 +1,34 @@
+-- An extraction that is under way needs a name.
+--
+-- The sweeper (knowledge-indexer → sweepPendingExtractions) claims a document
+-- before handing it to extract-pdf-text, so a 5-minute cron does not pay for
+-- the same PDF on every tick while the first extraction is still running. The
+-- claim writes 'processing' — a value documents_extraction_status_check did not
+-- allow, so every claim failed and the sweeper reported `failed: 1` against a
+-- document that stayed pending. Found the first time the sweeper ran live
+-- (optic, 2026-08-12).
+--
+-- 'processing' is not a synonym for any existing value: 'pending' means nobody
+-- has come for it (and the sweeper reclaims a 'processing' row after 15 minutes
+-- precisely by putting it back there), and 'failed' means it was read and could
+-- not be parsed.
+--
+-- Idempotent: the constraint is dropped and re-added, so a re-run and a fresh
+-- install converge on the same definition.
+
+ALTER TABLE public.documents
+  DROP CONSTRAINT IF EXISTS documents_extraction_status_check;
+
+ALTER TABLE public.documents
+  ADD CONSTRAINT documents_extraction_status_check
+  CHECK (extraction_status = ANY (ARRAY[
+    'pending'::text,        -- uploaded, waiting for the sweeper
+    'processing'::text,     -- claimed by a sweeper, extractor running
+    'success'::text,
+    'failed'::text,         -- read but unparseable; never retried on a loop
+    'unsupported'::text,    -- seen, and this platform cannot read this type
+    'not_applicable'::text
+  ]));
+
+-- A row stranded in 'processing' by a deploy that predates this constraint
+-- cannot exist (the write was rejected), so there is nothing to backfill.

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1571,7 +1571,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:2d8eefaa0907a094a4a25f898ec837a833d5c2e207b69ba770eb543e56fb916a",
+      "shared_hash": "sha256:e66e694970c42059f003288b9b3392fc7170034e033cf6587ee8643ac77a356a",
       "functions": {
         "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260812160000",
-      "migrations_count": 388,
+      "migration_head": "20260812170000",
+      "migrations_count": 389,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1557,6 +1557,10 @@
         {
           "version": "20260812160000",
           "name": "vendor-docs-leave-the-public-tier"
+        },
+        {
+          "version": "20260812170000",
+          "name": "extraction-can-be-in-flight"
         }
       ]
     },
@@ -1567,7 +1571,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:4306d15211f8c095fd85a6f6667619d69b572df49ae413b5356ca0d17f638fa1",
+      "shared_hash": "sha256:2d8eefaa0907a094a4a25f898ec837a833d5c2e207b69ba770eb543e56fb916a",
       "functions": {
         "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1567,7 +1567,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:eb55ab24e58c855be39aa1106de5a41ff7b0bf1cbbc88d57a049b51015df0a78",
+      "shared_hash": "sha256:4306d15211f8c095fd85a6f6667619d69b572df49ae413b5356ca0d17f638fa1",
       "functions": {
         "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
@@ -1601,7 +1601,7 @@
         "email-send": "sha256:847dfe00b430b9b8c4a1767d66720cc4e9562404df27403d9d69806b48d3aa03",
         "email-webhook": "sha256:0ab483c28ad242ba4cbadc329f56a029ef246c89e669bd81184ce9017ede007d",
         "event-dispatcher": "sha256:1226b1ce317cb70cfdae46441f59499f8559b159fd08ee5063105ebfd98e5aa0",
-        "extract-pdf-text": "sha256:96f98e21532f261f3e41dc8843dee623e9a010a6106d4e40d3664d743df46304",
+        "extract-pdf-text": "sha256:cdc3ca4ff97542a0c8531b3ad83b4592a41d3a8e9ab8654eb92fcf1ea45ae808",
         "federation-invite-peer": "sha256:f75a07661700e2c926b972336df93b67f6d4d4180ff9f1d05e3ee26bedf5a4e1",
         "flowpilot-heartbeat": "sha256:21acbb3522ba6b2d9a117ac63fbfb548bd21ea282715bc5d032047d9f9b310cd",
         "flowpilot-lifecycle": "sha256:c89547f6c804aa18bb0a809f34d88cc816d2bd71e87b8845cdd0b68b200f1782",
@@ -1613,7 +1613,7 @@
         "integrations-account": "sha256:97349b1f66e6a4e628de49bd36473af4f5c19726174c30e3b47ff4c594d68e29",
         "invite-colleague": "sha256:cad6246a2988ca3c780cb3497707a4d818e311f3b1bf704957b3754b9d86b5b3",
         "invite-employee": "sha256:354d9ecbcc20ff402597a0e4c10875807c1a140ace0c5c06505ff8fc9fe13eb5",
-        "knowledge-indexer": "sha256:c6f628a21822a011e37b3719ef639f93b0dedab23c5becc0255e0c16e9c31289",
+        "knowledge-indexer": "sha256:51f19b1f01bb746d7dc51e4ffa7eee51053c9c99a9f27812090d2f6b4f100070",
         "llms-txt": "sha256:0a8a132d383590b810617ff9cdcd4893980208233d0c26b65d6c17a80af4f452",
         "mcp-server": "sha256:3cb3f630ad868ee15eb2c559e50af08449af876d3856ba0557f9c2ab9300d2b4",
         "media-optimize": "sha256:ddaa5868b1f154561a900e133ab64c6ffd0ebef9751098b2a42c03684c34d496",


### PR DESCRIPTION
Magnus laddade upp en PDF på optic den 10 augusti. Två dygn senare stod den kvar som `extraction_status='pending'`, 0 tecken text, 0 chunkar. Plattformens eget svar på "är den indexerad än?" var *pending*, för alltid.

Fem fel i samma söm, alla dolda bakom varandra.

## 1. Ingen sopade pending

`extract-pdf-text` anropades bara av de tre ytor som laddar upp åt en användare (cowork-bilagor, jobbansökan, skill-handlern). Admins uppladdning skrev en rad med kolumndefaulten `pending` och ingen kom någonsin. Ingen cron, ingen trigger, ingen kö.

Nu sveper `knowledge-indexer` pending var femte minut, i samma runda som den redan drar kunskapskön. **En sweeper i stället för en fjärde anropare** — raden plockas upp oavsett hur den blev pending, vilket är den egenskap en ny uppladdningsväg inte kan råka förstöra.

Arbetet klavas till `processing` före anrop (annars betalar cronen för samma PDF var femte minut), och tas tillbaka efter 15 minuter om extraktorn dog. `failed` retryas aldrig — en loop mot en trasig fil är en obegränsad AI-räkning.

## 2. Extraktorn skrev bara tillbaka till cowork

`updateDocumentExtraction` filtrerade på `source='cowork-upload'`, från när cowork var enda anroparen. För alla andra läste den PDF:en, betalade anropet, svarade `success` — och uppdaterade noll rader. Vems uppladdning det var är ingen egenskap hos om texten får sparas.

## 3. `file_url` bär två format

Cowork skriver bucket-kvalificerat (`cowork-uploads/x/y.pdf`), admin skriver relativt `documents`-bucketen och sätter tillbaka bucketen vid läsning. Båda är internt konsekventa — därför märkte ingen sida det. Extraktorn splittar på första `/` för att hitta bucketen, så admins värde fick den att leta efter en bucket döpt efter ett UUID.

## 4. Indexeraren struntade i vem som fick se filen

`case 'documents'` stämplade allt `internal` utan att ens selecta `visibility`.

Det här är designfrågan Magnus tog upp mitt i bygget: AnythingLLM låter användaren välja vilka filer som är RAG via en file manager — praktiskt, men fel fråga. En uppladdad fil är den enda kunskapskällan utan eget syfte (samma tabell rymmer produktblad, anställningsavtal, kvitto och CV), men svaret är inte en andra spak.

**Uppladdningsdialogen frågar redan den enda fråga den som laddar upp kan svara ärligt på — *vem får se den här*.** Räckvidden i indexet är nu en konsekvens av det svaret:

| Dokumentets svar | I indexet |
|---|---|
| `shared` | `internal` — staff-nivån, samma som handboken |
| `role` | utanför indexet (chunk-nivån kan inte bära en roll; `internal` hade visat HR-filer för lager och support) |
| `private` | utanför indexet |

Ingenting blir `public`. `knowledge_chunks` har en RLS-policy som ger anon läsning av publika chunkar, så en uppladdad fil hade hamnat framför besökarchatten med en nyckel som ligger i JS-bundlen — exakt docs_pages-incidentens form. Punkt 4 hade aldrig smällt bara därför att punkt 1–3 höll allt tomt.

## 5. CHECK-constraintet kände inte till `processing`

Hittat genom att köra sweepern skarpt: varje klav avvisades, sweepern rapporterade `failed: 1` mot ett dokument som stod kvar som pending — och mitt eget felsvälj gjorde att ingen fick veta varför. Migration lägger till värdet; felen följer nu med i sweepsvaret.

## Kvitto, live mot optic

```
sweep → 18 066 tecken extraherade → 12 chunkar → 12 vektorer
dokument 'shared' → chunkar 'internal'
SET ROLE anon → 0 synliga    service → 12
```

Första extraktionen dog på `WORKER_RESOURCE_LIMIT` (övergående — samma fil gick igenom på andra försöket). Workern dödas då utan att catch-blocket hinner köra, så statusen aldrig blir `failed`. Det är precis fallet stale-reclaimen finns för, och den behövdes inom en timme av att den skrevs.

## Grindar

14 nya tester, alla negativtestade genom att återinföra buggarna (`reads the column it branches on` och `does not scope the write to a single upload path` blir röda). Hela sviten: 2307 gröna, tsc rent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)