### PR TITLE
fix(migrations): gut the Lovable re-dump of the finalizer's storage block to a no-op

### DIFF
--- a/supabase/migrations/20260814145236_d988df05-7399-4ee5-aaac-81d50ca8f0e0.sql
+++ b/supabase/migrations/20260814145236_d988df05-7399-4ee5-aaac-81d50ca8f0e0.sql
@@ -1,69 +1,14 @@
--- === 20260812130000_fresh-install-finalizer.sql (policies + cron) ===
-DO $fin$
-DECLARE
-  attempt int := 0;
-BEGIN
-  LOOP
-    attempt := attempt + 1;
-    BEGIN
-      DROP POLICY IF EXISTS "Authenticated users can view documents" ON storage.objects;
-      DROP POLICY IF EXISTS "Authenticated users can update documents" ON storage.objects;
-
-      DROP POLICY IF EXISTS "Admins can delete documents" ON storage.objects;
-      CREATE POLICY "Admins can delete documents" ON storage.objects FOR DELETE TO authenticated USING (((bucket_id = 'documents'::text) AND has_role(auth.uid(), 'admin'::app_role)));
-      DROP POLICY IF EXISTS "Anyone can view cms images" ON storage.objects;
-      CREATE POLICY "Anyone can view cms images" ON storage.objects FOR SELECT TO public USING ((bucket_id = 'cms-images'::text));
-      DROP POLICY IF EXISTS "Authenticated users can delete images" ON storage.objects;
-      CREATE POLICY "Authenticated users can delete images" ON storage.objects FOR DELETE TO authenticated USING ((bucket_id = 'cms-images'::text));
-      DROP POLICY IF EXISTS "Authenticated users can update images" ON storage.objects;
-      CREATE POLICY "Authenticated users can update images" ON storage.objects FOR UPDATE TO authenticated USING ((bucket_id = 'cms-images'::text));
-      DROP POLICY IF EXISTS "Authenticated users can upload documents" ON storage.objects;
-      CREATE POLICY "Authenticated users can upload documents" ON storage.objects FOR INSERT TO authenticated WITH CHECK ((bucket_id = 'documents'::text));
-      DROP POLICY IF EXISTS "Authenticated users can upload images" ON storage.objects;
-      CREATE POLICY "Authenticated users can upload images" ON storage.objects FOR INSERT TO authenticated WITH CHECK ((bucket_id = 'cms-images'::text));
-      DROP POLICY IF EXISTS "Document files follow their document's visibility" ON storage.objects;
-      CREATE POLICY "Document files follow their document's visibility" ON storage.objects FOR SELECT TO authenticated USING (((bucket_id = 'documents'::text) AND (has_role(auth.uid(), 'admin'::app_role) OR ((storage.foldername(name))[1] = (auth.uid())::text) OR (EXISTS ( SELECT 1
-         FROM documents d
-        WHERE (d.file_url = objects.name))))));
-      DROP POLICY IF EXISTS "Uploaders and admins can overwrite document files" ON storage.objects;
-      CREATE POLICY "Uploaders and admins can overwrite document files" ON storage.objects FOR UPDATE TO authenticated USING (((bucket_id = 'documents'::text) AND (has_role(auth.uid(), 'admin'::app_role) OR ((storage.foldername(name))[1] = (auth.uid())::text) OR (EXISTS ( SELECT 1
-         FROM documents d
-        WHERE ((d.file_url = objects.name) AND (d.uploaded_by = auth.uid())))))));
-      DROP POLICY IF EXISTS "cowork own delete" ON storage.objects;
-      CREATE POLICY "cowork own delete" ON storage.objects FOR DELETE TO authenticated USING (((bucket_id = 'cowork-uploads'::text) AND ((storage.foldername(name))[1] = (auth.uid())::text)));
-      DROP POLICY IF EXISTS "cowork own read" ON storage.objects;
-      CREATE POLICY "cowork own read" ON storage.objects FOR SELECT TO authenticated USING (((bucket_id = 'cowork-uploads'::text) AND ((storage.foldername(name))[1] = (auth.uid())::text)));
-      DROP POLICY IF EXISTS "cowork own upload" ON storage.objects;
-      CREATE POLICY "cowork own upload" ON storage.objects FOR INSERT TO authenticated WITH CHECK (((bucket_id = 'cowork-uploads'::text) AND ((storage.foldername(name))[1] = (auth.uid())::text)));
-      DROP POLICY IF EXISTS "form-uploads admin delete" ON storage.objects;
-      CREATE POLICY "form-uploads admin delete" ON storage.objects FOR DELETE TO authenticated USING (((bucket_id = 'form-uploads'::text) AND has_role(auth.uid(), 'admin'::app_role)));
-      DROP POLICY IF EXISTS "form-uploads admin read" ON storage.objects;
-      CREATE POLICY "form-uploads admin read" ON storage.objects FOR SELECT TO authenticated USING (((bucket_id = 'form-uploads'::text) AND has_role(auth.uid(), 'admin'::app_role)));
-      DROP POLICY IF EXISTS "form-uploads insert" ON storage.objects;
-      CREATE POLICY "form-uploads insert" ON storage.objects FOR INSERT TO anon, authenticated WITH CHECK ((bucket_id = 'form-uploads'::text));
-      DROP POLICY IF EXISTS "river-media authed upload" ON storage.objects;
-      CREATE POLICY "river-media authed upload" ON storage.objects FOR INSERT TO authenticated WITH CHECK ((bucket_id = 'river-media'::text));
-      DROP POLICY IF EXISTS "river-media owner delete" ON storage.objects;
-      CREATE POLICY "river-media owner delete" ON storage.objects FOR DELETE TO authenticated USING (((bucket_id = 'river-media'::text) AND (owner = auth.uid())));
-      DROP POLICY IF EXISTS "river-media public read" ON storage.objects;
-      CREATE POLICY "river-media public read" ON storage.objects FOR SELECT TO public USING ((bucket_id = 'river-media'::text));
-      EXIT;
-    EXCEPTION WHEN deadlock_detected THEN
-      IF attempt >= 5 THEN RAISE; END IF;
-      RAISE NOTICE 'Storage bootstrap hit a deadlock (attempt %); retrying…', attempt;
-      PERFORM pg_sleep(attempt * 2);
-    END;
-  END LOOP;
-
-  IF to_regclass('cron.job') IS NOT NULL THEN
-    DECLARE r record; BEGIN
-      FOR r IN SELECT jobid FROM cron.job LOOP
-        PERFORM cron.alter_job(r.jobid, active => true);
-      END LOOP;
-    END;
-    RAISE NOTICE 'Fresh-install finalizer: % cron job(s) activated.', (SELECT count(*) FROM cron.job);
-  END IF;
-  RAISE NOTICE 'Fresh-install finalizer complete: % bucket(s), % storage policies.',
-    (SELECT count(*) FROM storage.buckets),
-    (SELECT count(*) FROM pg_policies WHERE schemaname='storage' AND tablename='objects');
-END $fin$;
+-- HISTORY: this file arrived in a Lovable schema dump (commit 0cb7429, "Work
+-- in progress", 2026-08-14) and was a verbatim re-emission of the fresh-install
+-- finalizer's own storage-policy + cron-activation block — its original first
+-- line even said so: "=== 20260812130000_fresh-install-finalizer.sql ===".
+-- Every DROP/CREATE POLICY on storage.objects it carried is byte-identical to
+-- the block already in 20260812130000_fresh-install-finalizer.sql, where ALL
+-- storage.* DDL must live: a mid-stream migration touching storage.* deadlocks
+-- against the storage service's own migrator on fresh projects (SQLSTATE
+-- 40P01, observed live 2026-08-10). The fresh-install-replay guardrail test
+-- enforces this. The file stays as a no-op because managed ledgers (Lovable
+-- dev) already recorded this version.
+--
+-- Intentionally a no-op.
+SELECT 1;


### PR DESCRIPTION
## What

`fresh-install-replay.guardrails.test.ts` was failing on `main`: migration `20260814145236_d988df05-….sql` (from Lovable WIP commit 0cb7429) contained `storage.objects` policy DDL outside the finalizer. The rule it broke: ALL `storage.*` DDL must live in `20260812130000_fresh-install-finalizer.sql`, because mid-stream storage DDL deadlocks (SQLSTATE 40P01) against the storage service's own migrator on fresh installs.

## Why nothing was moved

The offending file turned out to be a **verbatim re-emission of the finalizer's own storage-policy + cron-activation block** — its original first line literally read `-- === 20260812130000_fresh-install-finalizer.sql (policies + cron) ===`. A normalized diff (comments/whitespace stripped) confirmed every `DROP`/`CREATE POLICY` statement was byte-identical to what the finalizer already contains, and the cron-activation block was likewise a copy. Lovable's schema dump had re-emitted the finalizer's content as an ordinary mid-stream migration.

So instead of moving statements, the file is **gutted to a comment + `SELECT 1` no-op**, following the repo's established pattern (see `20260810140000_river-and-cowork-buckets-in-repo.sql`). The file is kept rather than deleted because Lovable's dev ledger already recorded this version.

## Checks

- The other 11 migrations from the same WIP commit contain no `storage.*` DDL (grep-verified) and pass all guardrail rules.
- `npx vitest run src/lib/__tests__/fresh-install-replay.guardrails.test.ts` → **6/6 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdHJUC6qF1v3zXDeyxtFGK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdHJUC6qF1v3zXDeyxtFGK)_