### PR TITLE
fix(a2a): instansen bär sin egen adress, inte det raderade demoprojektets

### DIFF
--- a/src/lib/__tests__/site-url-not-hardcoded.guardrails.test.ts
+++ b/src/lib/__tests__/site-url-not-hardcoded.guardrails.test.ts
@@ -1,0 +1,92 @@
+/**
+ * An instance knows its own address — it does not carry someone else's.
+ *
+ * The A2A bridge shipped `_site_url: 'https://demo.flowwink.com'` as a literal
+ * into every inbound skill call, and put the same domain in the agent's system
+ * prompt. That named ONE instance for the whole fleet, and after the demo
+ * project was deleted (2026-08-15) it named a domain that NXDOMAINs.
+ *
+ * `site_settings.general.siteUrl` was already the platform's answer: the
+ * contract renderer reads it for {{terms_url}} and {{site_url}}, the email
+ * shell reads it for the header link. Now the edge functions read it through
+ * one helper instead of guessing.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const FUNCTIONS = resolve(__dirname, '../../../supabase/functions');
+const read = (p: string) => readFileSync(p, 'utf-8');
+const strip = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/[^\n]*$/gm, '');
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith('.ts')) out.push(p);
+  }
+  return out;
+}
+
+describe('no edge function hardcodes an instance address', () => {
+  /**
+   * Grandfathered, and tracked — not accepted.
+   *
+   * agent-execute:3148 hands the autonomous-testing skill
+   * `site.url = 'https://demo.flowwink.com'` with the description "test this
+   * URL, not any template/example domains", so the QA agent on every instance
+   * is pointed at the deleted project. It is a one-line fix (resolveSiteUrl,
+   * same as here) but agent-execute belongs to the local session; reported
+   * rather than edited. Remove this entry when it lands — the test then guards
+   * the whole surface.
+   */
+  const GRANDFATHERED = ['supabase/functions/agent-execute/index.ts'];
+
+  it('the decommissioned demo domain appears in no code path', () => {
+    // A quoted occurrence is a value the code carries; an unquoted one is prose
+    // in a comment (survey_send documents it as an example override). Stripping
+    // trailing `//` comments is not an option here — every https:// URL would
+    // be mangled by it.
+    const offenders = walk(FUNCTIONS)
+      .filter((f) => /['"`][^'"`\n]*demo\.flowwink\.com/.test(strip(read(f))))
+      .map((f) => f.replace(FUNCTIONS + '/', 'supabase/functions/'))
+      .filter((f) => !GRANDFATHERED.includes(f));
+    expect(offenders, 'hardcoded demo domain in a code path').toEqual([]);
+  });
+
+  it('the grandfathered file is still the only one — and still there', () => {
+    // If this fails because the file no longer matches, the fix landed: delete
+    // the entry above. A guard that silently stops guarding is the failure mode
+    // this repo keeps meeting.
+    const src = strip(read(join(FUNCTIONS, 'agent-execute/index.ts')));
+    expect(/['"`][^'"`\n]*demo\.flowwink\.com/.test(src),
+      'agent-execute no longer hardcodes the domain — remove it from GRANDFATHERED').toBe(true);
+  });
+});
+
+describe('the address has one reader', () => {
+  const helper = read(join(FUNCTIONS, '_shared/site-url.ts'));
+  const a2a = strip(read(join(FUNCTIONS, 'a2a/index.ts')));
+
+  it('reads the same setting the SQL side reads', () => {
+    // 20260808180000 / 20260808230000: value->>'siteUrl' under key 'general'.
+    expect(helper).toMatch(/\.eq\('key', 'general'\)/);
+    expect(helper).toMatch(/siteUrl/);
+  });
+
+  it('answers null rather than a guess when unset or unreadable', () => {
+    expect(helper).toMatch(/return url\.length > 0 \? url : null/);
+    // The catch must not invent a fallback host.
+    const body = helper.slice(helper.indexOf('} catch'));
+    expect(body).not.toMatch(/https?:\/\//);
+  });
+
+  it('a2a omits the argument entirely when the address is unknown', () => {
+    // A skill that builds a link is better off with no value than a wrong one.
+    expect(a2a).toMatch(/u \? \{ _site_url: u \} : \{\}/);
+  });
+
+  it('a2a names the running instance in the system prompt, or nothing', () => {
+    expect(a2a).toMatch(/autonomous CMS operator for FlowWink\$\{siteUrl \? ` \(\$\{siteUrl\}\)` : ''\}/);
+  });
+});

--- a/supabase/functions/_shared/site-url.ts
+++ b/supabase/functions/_shared/site-url.ts
@@ -1,0 +1,42 @@
+/**
+ * Where this instance lives — one reader for one setting.
+ *
+ * `site_settings.general.siteUrl` is already the platform's answer to "what is
+ * my public address": the contract renderer reads it for {{terms_url}} and
+ * {{site_url}} (20260808180000, 20260808230000), and the email shell reads it
+ * for the header link. The A2A bridge did not — it carried
+ * `https://demo.flowwink.com` as a hardcoded literal into every inbound skill
+ * call and into the agent's own system prompt, on every instance in the fleet.
+ * That was wrong before the demo project was deleted (it named ONE instance for
+ * all of them) and provably wrong after: the domain now NXDOMAINs.
+ *
+ * Returns null when unset. A caller must then omit the value rather than
+ * substitute a guess — a link to nowhere is worse than no link, and the same
+ * reasoning the terms renderer already applies ("a missing value must look like
+ * words, not like markup").
+ */
+
+/** The narrowest shape this needs: something with `.from()`. Kept loose so
+ *  every runtime that reads a setting can import it without dragging the
+ *  generated client's builder chain into its types. */
+export interface SettingsReader {
+  from(table: string): unknown;
+}
+
+export async function resolveSiteUrl(supabase: SettingsReader): Promise<string | null> {
+  try {
+    const chain = supabase.from('site_settings') as {
+      select(cols: string): {
+        eq(col: string, val: string): { maybeSingle(): PromiseLike<{ data: unknown; error: unknown }> };
+      };
+    };
+    const { data } = await chain.select('value').eq('key', 'general').maybeSingle();
+    const raw = (data as { value?: { siteUrl?: unknown } } | null)?.value?.siteUrl;
+    const url = String(raw ?? '').trim().replace(/\/+$/, '');
+    return url.length > 0 ? url : null;
+  } catch {
+    // An unreadable setting is "unknown", not "demo.flowwink.com". The caller
+    // omits rather than guesses.
+    return null;
+  }
+}

--- a/supabase/functions/a2a/index.ts
+++ b/supabase/functions/a2a/index.ts
@@ -1,5 +1,6 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { getServiceClient, getUserClient } from '../_shared/supabase-clients.ts';
+import { resolveSiteUrl } from '../_shared/site-url.ts';
 
 /**
  * a2a — Unified router for all A2A federation traffic.
@@ -132,6 +133,10 @@ async function handleChat(req: Request): Promise<Response> {
   const agentName = idObj?.name || 'FlowPilot';
 
   const siteIntel = await gatherSiteIntelligence(supabase);
+  // This instance's own address, not a literal naming one instance for all of
+  // them. Unknown stays unknown: the agent is told nothing rather than told a
+  // domain that does not resolve.
+  const siteUrl = await resolveSiteUrl(supabase);
 
   const schemaInstruction = responseSchema
     ? `\n\nIMPORTANT: The peer has requested a specific response format. You MUST respond with valid JSON matching this schema:\n${JSON.stringify(responseSchema, null, 2)}\nDo NOT wrap it in markdown code blocks. Return raw JSON only.`
@@ -140,7 +145,7 @@ async function handleChat(req: Request): Promise<Response> {
     ? `You are INITIATING a message to peer "${peerName}". The "user" message below is your internal prompt/intent — compose a natural, direct message to send to the peer.`
     : `You are RESPONDING to a message from federation peer "${peerName}" via the A2A protocol.`;
 
-  const systemPrompt = `You are ${agentName}, an autonomous CMS operator for FlowWink (demo.flowwink.com). ${conversationDirection}
+  const systemPrompt = `You are ${agentName}, an autonomous CMS operator for FlowWink${siteUrl ? ` (${siteUrl})` : ''}. ${conversationDirection}
 
 ${soulText ? `Your soul/personality:\n${soulText}\n` : ''}
 
@@ -633,7 +638,14 @@ async function handleIngest(req: Request): Promise<Response> {
     ...(args || {}),
     ...(!args?.peer_name ? { peer_name: peer.name } : {}),
     ...(!args?.peer_id ? { _a2a_peer_id: peer.id } : {}),
-    _site_url: 'https://demo.flowwink.com',
+    // The instance's own address, read from site_settings.general.siteUrl —
+    // the same setting the contract renderer and the email shell already use.
+    // This was the literal 'https://demo.flowwink.com' on every instance in the
+    // fleet, which named one instance for all of them and, since that project
+    // was deleted, points at a domain that does not resolve. Omitted entirely
+    // when unset: a skill that builds a link is better off with no value than
+    // with a wrong one.
+    ...(await resolveSiteUrl(supabase).then((u) => (u ? { _site_url: u } : {}))),
     ...(responseSchema ? { responseSchema } : {}),
   };
 

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1723,9 +1723,9 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:59f1427f5e3357c6e24b4f698f76ec979a0a71d2d8f81704483bbc90f3b518fc",
+      "shared_hash": "sha256:71a81163c1f478681c02f21a851e128ed27dbd9fc2d6f27b18f920f412f3f5b2",
       "functions": {
-        "a2a": "sha256:ce9a4fb6212cae08011c6418af9ad906786f4bbad6a8de6f962eda2eb4c54978",
+        "a2a": "sha256:fe31e0b157534cc856e40c84efef6ff7f2ecc34ffd2cca250d8aed8ffe345397",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
         "agent-execute": "sha256:509c08f3917e3dc31551fe5603017a3195799311e276b09c99e25a0b31d6ae2c",
         "agent-operate": "sha256:72cdafe207ae2a5630e3263e6c993a55aade47c679f2cc200465cb3a17f30689",


### PR DESCRIPTION
`a2a/index.ts` skickade `_site_url: 'https://demo.flowwink.com'` som en literal in i **varje inkommande skill-anrop**, och satte samma domän i agentens systemprompt:

```
You are ..., an autonomous CMS operator for FlowWink (demo.flowwink.com).
```

Det namngav **en** instans för hela flottan — fel redan innan avvecklingen — och sedan demoprojektet raderades (`d5b867f`, NXDOMAIN på både ref och domän) namnger det en värd som inte finns. Avvecklingen tog demo ur deploy-rälsen; de här runtime-literalerna blev kvar.

## Inställningen fanns redan — men inte på edge-sidan

`site_settings.general.siteUrl` är plattformens svar på "var bor jag": avtalsrenderaren läser den för `{{terms_url}}` och `{{site_url}}` (`20260808180000`, `20260808230000`), och e-postskalet för header-länken. Ingen läste den från edge-funktionerna, så `_shared/site-url.ts` ger den **en läsare**.

## Okänt förblir okänt

`resolveSiteUrl` returnerar `null` när inställningen saknas eller inte går att läsa, och a2a **utelämnar då `_site_url` helt** i stället för att gissa. En skill som bygger en länk klarar sig bättre utan värde än med fel värde — samma resonemang som avtalsrenderaren redan tillämpar på en saknad URL (*"a missing value must look like words, not like markup"*).

Kontrollerat först: **ingenting konsumerar argumentet i dag** (avtalsrenderaren läser inställningen direkt ur databasen), så utelämnandet bryter ingen anropare.

## Ett fynd till — grandfathrat, inte accepterat

Samma literal finns i **`agent-execute:3148`**, där den autonoma testskillen får:

```ts
site: { url: 'https://demo.flowwink.com',
        description: 'Autonomous Agentic CMS — test this URL, not any template/example domains' }
```

QA-agenten på varje instans pekas alltså mot det raderade projektet — och instruktionen säger uttryckligen åt den att testa just den adressen. Filen tillhör local-sessionen, så den är **grandfathrad i vakten** i stället för redigerad här, med ett andra test som **fäller när fixen landar**, så posten inte blir kvar och tyst slutar vakta.

## Verifierat

**6 guardrails, negativtestade** — att hårdkoda tillbaka i a2a, och att lägga en fallback-värd i helperns `catch`, ger var för sig två röda.

En detalj i testet värd att nämna: det matchar domänen **inom citattecken**. Att strippa efterföljande `//`-kommentarer var inget alternativ — varje `https://`-URL hade mörbultats av det. `comms-send/survey_send.ts` nämner domänen i en kommentar som exempel och är därför korrekt utanför.

`tsc` rent, svit **2356 passed / 5 skipped**.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_