### PR TITLE
fix(agent-execute): QA-agenten testar den här instansen, inte det raderade demoprojektet

### DIFF
--- a/src/lib/__tests__/site-url-not-hardcoded.guardrails.test.ts
+++ b/src/lib/__tests__/site-url-not-hardcoded.guardrails.test.ts
@@ -29,38 +29,26 @@ function walk(dir: string, out: string[] = []): string[] {
 }
 
 describe('no edge function hardcodes an instance address', () => {
-  /**
-   * Grandfathered, and tracked — not accepted.
-   *
-   * agent-execute:3148 hands the autonomous-testing skill
-   * `site.url = 'https://demo.flowwink.com'` with the description "test this
-   * URL, not any template/example domains", so the QA agent on every instance
-   * is pointed at the deleted project. It is a one-line fix (resolveSiteUrl,
-   * same as here) but agent-execute belongs to the local session; reported
-   * rather than edited. Remove this entry when it lands — the test then guards
-   * the whole surface.
-   */
-  const GRANDFATHERED = ['supabase/functions/agent-execute/index.ts'];
-
   it('the decommissioned demo domain appears in no code path', () => {
+    // No grandfathering left: agent-execute:3148 was the last holdout and now
+    // resolves the address like everything else.
+    //
     // A quoted occurrence is a value the code carries; an unquoted one is prose
     // in a comment (survey_send documents it as an example override). Stripping
     // trailing `//` comments is not an option here — every https:// URL would
     // be mangled by it.
     const offenders = walk(FUNCTIONS)
       .filter((f) => /['"`][^'"`\n]*demo\.flowwink\.com/.test(strip(read(f))))
-      .map((f) => f.replace(FUNCTIONS + '/', 'supabase/functions/'))
-      .filter((f) => !GRANDFATHERED.includes(f));
+      .map((f) => f.replace(FUNCTIONS + '/', 'supabase/functions/'));
     expect(offenders, 'hardcoded demo domain in a code path').toEqual([]);
   });
 
-  it('the grandfathered file is still the only one — and still there', () => {
-    // If this fails because the file no longer matches, the fix landed: delete
-    // the entry above. A guard that silently stops guarding is the failure mode
-    // this repo keeps meeting.
+  it('the QA agent is pointed at the running instance, or at nothing', () => {
     const src = strip(read(join(FUNCTIONS, 'agent-execute/index.ts')));
-    expect(/['"`][^'"`\n]*demo\.flowwink\.com/.test(src),
-      'agent-execute no longer hardcodes the domain — remove it from GRANDFATHERED').toBe(true);
+    expect(src).toMatch(/const siteUrl = await resolveSiteUrl\(supabase\)/);
+    expect(src).toMatch(/\.\.\.\(siteUrl \? \{ url: siteUrl \} : \{\}\)/);
+    // Without an address the instruction must stop telling it to test one.
+    expect(src).toMatch(/no public site URL is configured/);
   });
 });
 
@@ -74,11 +62,30 @@ describe('the address has one reader', () => {
     expect(helper).toMatch(/siteUrl/);
   });
 
+  it('keeps the house convention rather than a tidier one', () => {
+    // agent-execute resolved this at two call sites before the helper existed:
+    // PUBLIC_SITE_URL first, then four accepted spellings. A helper that read
+    // only `siteUrl` would have narrowed those paths on adoption.
+    expect(helper).toMatch(/Deno\.env\.get\('PUBLIC_SITE_URL'\)/);
+    for (const key of ['siteUrl', 'site_url', 'public_url', 'publicUrl']) {
+      expect(helper, `spelling ${key} dropped`).toContain(`'${key}'`);
+    }
+    // Env before setting, not after — measured on stripped source. The comment
+    // above the env read mentions PUBLIC_SITE_URL, so an unstripped indexOf
+    // compares against prose and passes even when the order is inverted.
+    // (Caught by negative-testing this very assertion; third time comments have
+    // sprung this trap in the repo.)
+    const code = strip(helper);
+    expect(code.indexOf('PUBLIC_SITE_URL')).toBeLessThan(code.indexOf("eq('key', 'general')"));
+  });
+
   it('answers null rather than a guess when unset or unreadable', () => {
-    expect(helper).toMatch(/return url\.length > 0 \? url : null/);
-    // The catch must not invent a fallback host.
+    // The property, not one phrasing of it: no host literal anywhere in the
+    // module, and the catch returns null instead of inventing a fallback.
+    expect(strip(helper), 'a host literal in the resolver is a guess')
+      .not.toMatch(/['"`]https?:\/\//);
     const body = helper.slice(helper.indexOf('} catch'));
-    expect(body).not.toMatch(/https?:\/\//);
+    expect(body).toMatch(/return null;/);
   });
 
   it('a2a omits the argument entirely when the address is unknown', () => {

--- a/supabase/functions/_shared/site-url.ts
+++ b/supabase/functions/_shared/site-url.ts
@@ -23,7 +23,20 @@ export interface SettingsReader {
   from(table: string): unknown;
 }
 
+/**
+ * The spellings this setting has been written under. agent-execute already
+ * accepted all four at two call sites before this helper existed; narrowing to
+ * `siteUrl` here would have quietly regressed those paths, so the helper takes
+ * the house convention rather than imposing a tidier one.
+ */
+const KEYS = ['siteUrl', 'site_url', 'public_url', 'publicUrl'] as const;
+
 export async function resolveSiteUrl(supabase: SettingsReader): Promise<string | null> {
+  // Env wins, same order the invoice and portal paths already use: a
+  // self-hosted deploy sets PUBLIC_SITE_URL and never touches the setting.
+  const fromEnv = String(Deno.env.get('PUBLIC_SITE_URL') ?? '').trim().replace(/\/+$/, '');
+  if (fromEnv) return fromEnv;
+
   try {
     const chain = supabase.from('site_settings') as {
       select(cols: string): {
@@ -31,9 +44,12 @@ export async function resolveSiteUrl(supabase: SettingsReader): Promise<string |
       };
     };
     const { data } = await chain.select('value').eq('key', 'general').maybeSingle();
-    const raw = (data as { value?: { siteUrl?: unknown } } | null)?.value?.siteUrl;
-    const url = String(raw ?? '').trim().replace(/\/+$/, '');
-    return url.length > 0 ? url : null;
+    const value = (data as { value?: Record<string, unknown> } | null)?.value ?? {};
+    for (const key of KEYS) {
+      const url = String(value[key] ?? '').trim().replace(/\/+$/, '');
+      if (url) return url;
+    }
+    return null;
   } catch {
     // An unreadable setting is "unknown", not "demo.flowwink.com". The caller
     // omits rather than guesses.

--- a/supabase/functions/agent-execute/index.ts
+++ b/supabase/functions/agent-execute/index.ts
@@ -5,6 +5,7 @@ import { normalizeBlockData, normalizeBlocks, validateBlockData } from '../_shar
 import { normalizeSkillArgs } from '../_shared/skill-aliases.ts';
 import { applyIdentityPolicy } from '../_shared/site-identity.ts';
 import { filterRecipients, blockedResponse } from '../_shared/email-allowlist.ts';
+import { resolveSiteUrl } from '../_shared/site-url.ts';
 import { readSieFile } from '../_shared/sie-reader.ts';
 import {
   buildIncomeStatement,
@@ -3149,11 +3150,23 @@ async function executeOpenClawAction(
         supabase.from('agent_memory').select('value').eq('key', 'identity').single(),
       ]);
 
+      // The QA agent tests THIS instance. This was the literal
+      // 'https://demo.flowwink.com' — one instance named for the whole fleet,
+      // and since that project was deleted (d5b867f) a host that does not
+      // resolve, handed over with an instruction to trust it. Resolved the way
+      // the invoice and portal paths in this file already resolve it: env
+      // first, then site_settings.general. Omitted when unknown — an agent
+      // without an address can say so; an agent with the wrong one reports the
+      // site is down.
+      const siteUrl = await resolveSiteUrl(supabase);
+
       return {
         site: {
-          url: 'https://demo.flowwink.com',
+          ...(siteUrl ? { url: siteUrl } : {}),
           name: 'FlowWink',
-          description: 'Autonomous Agentic CMS — test this URL, not any template/example domains',
+          description: siteUrl
+            ? 'Autonomous Agentic CMS — test this URL, not any template/example domains'
+            : 'Autonomous Agentic CMS — no public site URL is configured on this instance; do not guess one, and say so if a test needs it',
         },
         sessions: sessionsRes.data || [],
         findings: findingsRes.data || [],

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -1731,11 +1731,11 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:f04a8b4a04d9957ba0a03df94964e17ed12906369ed738ae5d17460e37e41eb4",
+      "shared_hash": "sha256:c2d89fa988e4dc5f48a84b9d22380ad6ff75d7f282f89cf785aecb4f9dd07555",
       "functions": {
         "a2a": "sha256:fe31e0b157534cc856e40c84efef6ff7f2ecc34ffd2cca250d8aed8ffe345397",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
-        "agent-execute": "sha256:0294a68cb6967da45789fc9f8a62d83bf54d493b002208e7d7739433199c63d5",
+        "agent-execute": "sha256:7707f7fcb05319cf9371186b71fd56d50f25ee9df5a3529bafc4b8a862dc3d81",
         "agent-operate": "sha256:72cdafe207ae2a5630e3263e6c993a55aade47c679f2cc200465cb3a17f30689",
         "ai-task": "sha256:c887b00caa01760c3c6a9fcfddee3bc0d0dba6973ffd2c780ff0251ac37c3a0b",
         "automation-dispatcher": "sha256:3cb8681d7acce65624bd7957a432b143a2d959d769845dc71696b95c2ea2012b",


### PR DESCRIPTION
Stänger **#226**. Sista kvarvarande förekomsten efter #225 — vaktens grandfathrade post är borttagen, så den täcker nu hela ytan.

## Felet

`agent-execute:3148` gav den autonoma testskillen:

```ts
site: {
  url: 'https://demo.flowwink.com',
  description: 'Autonomous Agentic CMS — test this URL, not any template/example domains',
}
```

Varje instans QA-agent pekades mot **en** namngiven instans — och sedan projektet raderades (`d5b867f`, NXDOMAIN) mot en värd som inte finns, med en instruktion som uttryckligen sa åt den att lita på adressen. En QA-agent med fel adress rapporterar att sajten är nere.

## Husets konvention vann över den snyggare

Det här är den intressanta delen, och den kom ur att Magnus sa *"kolla vad som finns först"*.

Filen löste **redan** adressen på två andra ställen:

```ts
let origin = Deno.env.get('PUBLIC_SITE_URL') || '';
if (!origin) { ...general → v.siteUrl || v.site_url || v.public_url || v.publicUrl }
```

`resolveSiteUrl` som jag lade till i #225 läste **bara** `siteUrl` ur inställningen och tittade inte på env alls. Att adoptera den som den var hade alltså **smalnat av två fungerande vägar** i den här filen — en tystare regression än den jag skulle laga.

Helpern breddas därför till konventionen i stället: env först, sedan fyra accepterade stavningar. Det gör a2a-vägen från #225 rättare på köpet.

## Okänt förblir okänt

Utan adress utelämnas `url` **och beskrivningen slutar be agenten testa en**:

> *"no public site URL is configured on this instance; do not guess one, and say so if a test needs it"*

## En vakt som var svag

7 guardrails, negativtestade — och en av dem höll inte. Ordningskontrollen *"env före inställningen"* jämförde **ostrippad källa**, så kommentaren ovanför env-läsningen (som nämner `PUBLIC_SITE_URL`) uppfyllde den även med ordningen omkastad. Sabotaget gick igenom tills påståendet flyttades till strippad källa.

Tredje gången kommentarer springer den fällan i det här repot — och första gången negativtestet fångade det i en vakt jag själv precis skrivit. Utan det steget hade jag levererat en grön bock som inte kontrollerade något, vilket är exakt det #190 handlade om.

## Verifierat

`tsc` rent, svit **2372 passed / 5 skipped**.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_