### PR TITLE
feat(media): HEIC avkodas klientside — iPhone-foton konverteras till WebP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "dompurify": "^3.4.10",
         "embla-carousel-autoplay": "^8.6.0",
         "embla-carousel-react": "^8.6.0",
+        "heic2any": "^0.0.4",
         "input-otp": "^1.4.2",
         "jsdom": "^27.4.0",
         "json5": "^2.2.3",
@@ -573,6 +574,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -589,6 +591,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -605,6 +608,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -621,6 +625,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -637,6 +642,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -653,6 +659,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -669,6 +676,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -685,6 +693,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -701,6 +710,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -717,6 +727,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -733,6 +744,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -749,6 +761,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,6 +778,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -781,6 +795,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -797,6 +812,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -813,6 +829,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -829,6 +846,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -862,6 +880,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -895,6 +914,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -927,6 +947,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -943,6 +964,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -959,6 +981,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -975,6 +998,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6664,6 +6688,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "dompurify": "^3.4.10",
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
+    "heic2any": "^0.0.4",
     "input-otp": "^1.4.2",
     "jsdom": "^27.4.0",
     "json5": "^2.2.3",

--- a/src/components/admin/ImageUploader.tsx
+++ b/src/components/admin/ImageUploader.tsx
@@ -11,7 +11,7 @@ import { MediaLibraryPicker } from './MediaLibraryPicker';
 import { UnsplashPicker } from './UnsplashPicker';
 import { UnsplashConfigHint } from './UnsplashConfigHint';
 
-import { convertToWebP, getWebPFileName } from '@/lib/image-utils';
+import { convertToWebP, getWebPFileName, isHeicFile } from '@/lib/image-utils';
 
 interface ImageUploaderProps {
   value: string;
@@ -44,8 +44,9 @@ export function ImageUploader({
     const file = e.target.files?.[0];
     if (!file) return;
 
-    // Validate file type
-    if (!file.type.startsWith('image/')) {
+    // Validate file type. HEIC needs its own check: Chrome reports an empty
+    // mime type for .heic files, so they fail the image/* test.
+    if (!file.type.startsWith('image/') && !isHeicFile(file)) {
       toast({
         title: 'Invalid file type',
         description: 'Please select an image file (JPG, PNG, GIF, WebP)',
@@ -74,18 +75,18 @@ export function ImageUploader({
 
       if (file.type !== 'image/webp' && file.type !== 'image/gif') {
         try {
+          // convertToWebP decodes HEIC via heic2any before the canvas pass.
           uploadBlob = await convertToWebP(file, 0.85);
           fileName = getWebPFileName(file.name);
           contentType = 'image/webp';
           logger.log(`Converted to WebP: ${file.size} → ${uploadBlob.size} bytes`);
         } catch (conversionError) {
           logger.warn('WebP conversion failed, using original:', conversionError);
-          // Formats the browser cannot DECODE (HEIC from phones is the common
-          // one) cannot fall back: the original would upload fine and then
-          // never render anywhere. Fail with a message instead of succeeding
-          // into a broken image.
-          if (/hei[cf]/i.test(file.type) || /\.hei[cf]$/i.test(file.name)) {
-            throw new Error('HEIC photos cannot be converted in this browser — export the photo as JPG or PNG first.');
+          // HEIC cannot fall back: browsers don't render it, so the original
+          // would upload fine and then never display anywhere. Fail with a
+          // message instead of succeeding into a broken image.
+          if (isHeicFile(file)) {
+            throw new Error('Could not decode this HEIC photo — export it as JPG or PNG and try again.');
           }
           // Other conversion hiccups: fall back to the original format.
         }
@@ -207,7 +208,7 @@ export function ImageUploader({
           <input
             ref={fileInputRef}
             type="file"
-            accept="image/*"
+            accept="image/*,.heic,.heif"
             onChange={handleFileSelect}
             className="hidden"
           />

--- a/src/lib/image-utils.test.ts
+++ b/src/lib/image-utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { isHeicFile, getWebPFileName } from './image-utils';
+
+const makeFile = (name: string, type: string) => new File([''], name, { type });
+
+describe('isHeicFile', () => {
+  it('detects HEIC by mime type', () => {
+    expect(isHeicFile(makeFile('photo.heic', 'image/heic'))).toBe(true);
+    expect(isHeicFile(makeFile('photo.heif', 'image/heif'))).toBe(true);
+  });
+
+  it('detects HEIC by extension when mime type is empty (Chrome)', () => {
+    expect(isHeicFile(makeFile('IMG_1234.HEIC', ''))).toBe(true);
+    expect(isHeicFile(makeFile('photo.heif', ''))).toBe(true);
+  });
+
+  it('does not flag other image formats', () => {
+    expect(isHeicFile(makeFile('photo.jpg', 'image/jpeg'))).toBe(false);
+    expect(isHeicFile(makeFile('photo.png', 'image/png'))).toBe(false);
+    expect(isHeicFile(makeFile('photo.webp', 'image/webp'))).toBe(false);
+    // "heic" in the basename but not as extension
+    expect(isHeicFile(makeFile('heic-guide.png', 'image/png'))).toBe(false);
+  });
+});
+
+describe('getWebPFileName', () => {
+  it('replaces the extension with .webp', () => {
+    expect(getWebPFileName('photo.jpg')).toBe('photo.webp');
+    expect(getWebPFileName('IMG_1234.HEIC')).toBe('IMG_1234.webp');
+  });
+
+  it('appends .webp when there is no extension', () => {
+    expect(getWebPFileName('photo')).toBe('photo.webp');
+  });
+});

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -14,13 +14,36 @@ export const loadImage = (source: File | Blob): Promise<HTMLImageElement> => {
 };
 
 /**
- * Convert an image file to WebP format using Canvas API
+ * Detect HEIC/HEIF files (iPhone photos). Chrome reports an empty mime type
+ * for .heic files, so the extension check is load-bearing, not a fallback.
+ */
+export const isHeicFile = (file: File): boolean =>
+  /image\/hei[cf]/i.test(file.type) || /\.hei[cf]$/i.test(file.name);
+
+/**
+ * Decode a HEIC/HEIF file into a blob the browser can render.
+ * heic2any (libheif compiled to wasm/asm.js) is imported lazily so the
+ * decoder chunk only loads when a HEIC file is actually selected.
+ */
+export const decodeHeic = async (file: File): Promise<Blob> => {
+  const { default: heic2any } = await import('heic2any');
+  const result = await heic2any({ blob: file, toType: 'image/png' });
+  // Multi-image HEIC containers decode to an array; the first entry is the
+  // primary image.
+  return Array.isArray(result) ? result[0] : result;
+};
+
+/**
+ * Convert an image file to WebP format using Canvas API.
+ * HEIC/HEIF input is decoded via heic2any first, since browsers cannot
+ * decode it natively.
  * @param file - The image file to convert
  * @param quality - WebP quality (0-1), default 0.85
  * @returns A Blob in WebP format
  */
 export const convertToWebP = async (file: File, quality = 0.85): Promise<Blob> => {
-  const img = await loadImage(file);
+  const source: Blob = isHeicFile(file) ? await decodeHeic(file) : file;
+  const img = await loadImage(source);
   
   const canvas = document.createElement('canvas');
   canvas.width = img.naturalWidth;

--- a/src/pages/admin/MediaLibraryPage.tsx
+++ b/src/pages/admin/MediaLibraryPage.tsx
@@ -8,7 +8,7 @@ import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
-import { convertToWebP } from '@/lib/image-utils';
+import { convertToWebP, isHeicFile } from '@/lib/image-utils';
 import { cn } from '@/lib/utils';
 import { UnsplashPicker } from '@/components/admin/UnsplashPicker';
 import { MediaDetailsSheet } from '@/components/admin/MediaDetailsSheet';
@@ -158,7 +158,9 @@ export default function MediaLibraryPage() {
 
   const handleUpload = useCallback(async (filesToUpload: FileList | File[]) => {
     const mediaFiles = Array.from(filesToUpload).filter(
-      f => f.type.startsWith('image/') || f.type.startsWith('video/')
+      // HEIC needs its own check: Chrome reports an empty mime type for
+      // .heic files, so they fail the image/* test.
+      f => f.type.startsWith('image/') || f.type.startsWith('video/') || isHeicFile(f)
     );
 
     if (mediaFiles.length === 0) {
@@ -397,7 +399,7 @@ export default function MediaLibraryPage() {
           <input
             ref={fileInputRef}
             type="file"
-            accept="image/*,video/mp4,video/webm,video/quicktime"
+            accept="image/*,.heic,.heif,video/mp4,video/webm,video/quicktime"
             multiple
             onChange={handleFileInput}
             className="hidden"


### PR DESCRIPTION
## Vad

iPhone-foton (HEIC) kan nu laddas upp direkt i bilduppladdaren och mediebiblioteket. De avkodas klientside med **heic2any** (libheif-wasm) och går sedan genom den befintliga canvas→WebP-pipelinen — uppladdning till `cms-images` som `.webp` precis som övriga format.

## Hur

- **`src/lib/image-utils.ts`** — nya `isHeicFile()` och `decodeHeic()`; `convertToWebP()` avkodar HEIC→PNG före canvas-passet. heic2any importeras med dynamisk `import()` så dekodern blir en egen lazy-chunk (**~341 kB gzip**, verifierat i `vite build`: `dist/assets/heic2any-*.js`) som bara laddas när en HEIC-fil faktiskt väljs.
- **`ImageUploader.tsx`** — throw-guarden för HEIC borttagen (riktig konvertering finns nu). Äkta avkodningsfel failar fortfarande ärligt i conversion-catchen — inget original laddas upp som sedan aldrig renderar. `image/*`-valideringen och `accept` släpper nu igenom HEIC.
- **`MediaLibraryPage.tsx`** — samma lucka fanns i filfiltret: Chrome rapporterar **tom mime-typ** för `.heic`, så filerna tappades tyst före konverteringen. Filtret och `accept` fixade; `isHeicFile` kollar därför både mime och filändelse (ändelsekollen är bärande, inte fallback).
- **`src/lib/image-utils.test.ts`** — nya enhetstester för `isHeicFile` (inkl. tom mime-typ) och `getWebPFileName`.

## Verifiering

- `npx tsc --noEmit -p tsconfig.app.json` — rent
- `npx vitest run` — 2445 passerade, 0 fallerade
- `npx eslint` på ändrade filer — inga nya fynd
- Browser-test i Chromium (som inte kan HEIC nativt) mot vite dev med **riktig HEIC-fil** (Nokia-samplet, 1440×960, tom mime-typ som Chrome ger): `convertToWebP` gav giltig WebP (RIFF/WEBP-magik, rätt dimensioner, renderbar i `<img>`) på ~2,4 s inkl. lazy-laddning av dekodern
- `vite build` — grönt, heic2any i egen chunk

## Notering

`scripts/sync-forks.sh` propagerar `main` och kräver fork-tokens i `.env.local` — körs efter merge, inte härifrån.

---
_Generated by [Claude Code](https://claude.ai/code/session_018hop11LNKLJzCgyKnXSBFB)_