### PR TITLE
fix(ecommerce): lagerbevakningen sparade aldrig — publik RPC ersätter anon-upserten

### DIFF
--- a/src/components/public/StockStatus.tsx
+++ b/src/components/public/StockStatus.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Bell, CheckCircle2, AlertTriangle, XCircle } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
+import { logger } from '@/lib/logger';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import type { Product, StockStatus as StockStatusType } from '@/hooks/useProducts';
@@ -73,12 +74,37 @@ export function BackInStockForm({ productId, productName, className }: BackInSto
     if (!email) return;
 
     setLoading(true);
-    const { error } = await supabase
-      .from('back_in_stock_requests' as any)
-      .upsert(
-        { product_id: productId, email } as any,
-        { onConflict: 'product_id,email' }
-      );
+    // The RPC is the working path. The direct upsert below fails for every
+    // anonymous visitor on a correctly locked-down instance: ON CONFLICT DO
+    // UPDATE needs to read the conflict row, and anon (correctly) has no
+    // SELECT or UPDATE path on back_in_stock_requests. request_back_in_stock
+    // is SECURITY DEFINER and returns nothing, so an outsider cannot probe
+    // which addresses are waiting. The legacy upsert stays as fallback for
+    // instances that have not run the migration yet (the fleet runs several
+    // schema versions at once by design).
+    const rpcCall = supabase.rpc as unknown as (
+      fn: string,
+      args: Record<string, unknown>,
+    ) => Promise<{ error: { message: string } | null }>;
+    let error: { message: string } | null = null;
+    try {
+      ({ error } = await rpcCall('request_back_in_stock', {
+        p_product_id: productId,
+        p_email: email,
+      }));
+    } catch (e) {
+      error = { message: e instanceof Error ? e.message : String(e) };
+    }
+
+    if (error) {
+      logger.warn('request_back_in_stock unavailable, falling back to direct upsert', error.message);
+      ({ error } = await supabase
+        .from('back_in_stock_requests' as any)
+        .upsert(
+          { product_id: productId, email } as any,
+          { onConflict: 'product_id,email' }
+        ));
+    }
 
     setLoading(false);
 

--- a/supabase/migrations/20260821200000_back-in-stock-requests-actually-save.sql
+++ b/supabase/migrations/20260821200000_back-in-stock-requests-actually-save.sql
@@ -1,0 +1,77 @@
+-- "Meddela mig när den är tillbaka" gick sönder för anonyma besökare — tyst.
+--
+-- BackInStockForm (src/components/public/StockStatus.tsx) gör en anon UPSERT
+-- mot back_in_stock_requests med onConflict 'product_id,email'. Tesen var att
+-- INSERT-policyn "Anyone can request back in stock notifications" (WITH CHECK
+-- true) bar första anmälan och att bara den ANDRA föll på att anon saknar
+-- UPDATE-policy för konfliktvägen. Empirin på dev (anon-JWT-mönstret nedan)
+-- visade värre: Postgres kräver för INSERT ... ON CONFLICT DO UPDATE att
+-- målraden går att LÄSA — SELECT-policyn prövas redan på den rena insertvägen,
+-- innan någon konflikt ens finns. anon har (korrekt) ingen läsväg på tabellen,
+-- så VARJE anmälan via upserten nekas med 42501 på en instans utan
+-- anon-SELECT. Besökaren ser "Could not save your request" — deterministiskt,
+-- men utklätt till nätverksfel.
+--
+-- Vägar som övervägdes och förkastades:
+--   * UPDATE-policy (USING true) för anon + no-op-vaktande trigger — räcker
+--     inte: SELECT-kravet står kvar och upserten failar ändå.
+--   * anon-SELECT-policy — gör hela prenumerantlistan (e-postadresser) läsbar
+--     via PostgREST för vem som helst. Aldrig.
+--
+-- Därför samma mönster som ingest_form_lead (20260805190000): en SECURITY
+-- DEFINER-RPC som är hela den publika skrivytan. Den validerar hårt, failar
+-- tyst och returnerar ingenting — en utomstående ska inte kunna sondera vilka
+-- adresser som väntar på en produkt. Förnyad anmälan re-arm:ar notified_at:
+-- den som anmäler sig IGEN (produkten kom in, notifierades, tog slut på nytt)
+-- vill uppenbart ha nästa utskick också — utan re-arm satt raden kvar som
+-- "redan notifierad" och personen fick aldrig mer något mejl. Ingen ny
+-- missbruksyta: att anmäla någon annans adress är redan möjligt via
+-- INSERT-policyn; re-arm kräver samma kunskap (adress + produkt).
+--
+-- Tabellens RLS lämnas orörd: INSERT-policyn står kvar (skrivbar-men-oläsbar
+-- är rätt för en publik kö), och anon får varken SELECT eller UPDATE.
+--
+-- LACKMUS (anon-JWT-claims-mönstret):
+--   SET LOCAL ROLE anon;
+--   SELECT set_config('request.jwt.claims','{"role":"anon"}', true);
+--   POSITIVT: SELECT public.request_back_in_stock('<produkt-uuid>', 'a@b.se')
+--             två gånger i rad → båda lyckas, EN rad finns efteråt.
+--   POSITIVT: sätt notified_at på raden (som postgres), kör anmälan igen som
+--             anon → notified_at är NULL igen (re-arm).
+--   NEKANDE:  SELECT på back_in_stock_requests som anon → 0 rader.
+--   NEKANDE:  UPDATE ... SET notified_at = now() som anon → 0 rader träffade.
+--   NEKANDE:  ogiltig e-post ('inte-en-adress') / okänd produkt → RETURN utan
+--             rad och utan fel (publik yta: validera hårt, faila tyst).
+
+CREATE OR REPLACE FUNCTION public.request_back_in_stock(
+  p_product_id uuid,
+  p_email text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_email text := lower(trim(p_email));
+BEGIN
+  -- Publik, oautentiserad yta: validera hårt, faila tyst (ingest_form_lead-
+  -- mönstret). Inget returvärde — inte ens "fanns redan" läcker.
+  IF v_email IS NULL OR v_email !~ '^[^@\s]+@[^@\s]+\.[^@\s]+$' THEN
+    RETURN;
+  END IF;
+  IF p_product_id IS NULL
+     OR NOT EXISTS (SELECT 1 FROM public.products WHERE id = p_product_id) THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO public.back_in_stock_requests (product_id, email)
+  VALUES (p_product_id, v_email)
+  ON CONFLICT (product_id, email) DO UPDATE
+    SET notified_at = NULL;  -- förnyad anmälan re-arm:ar nästa utskick
+END;
+$$;
+
+-- Poängen med funktionen är att besökare får kalla den.
+GRANT EXECUTE ON FUNCTION public.request_back_in_stock(uuid, text)
+  TO anon, authenticated, service_role;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -4,7 +4,7 @@
   "layers": {
     "schema": {
       "migration_head": "20260822140000",
-      "migrations_count": 480,
+      "migrations_count": 481,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1873,6 +1873,10 @@
         {
           "version": "20260821090000",
           "name": "f2a3b4c5-email-gets-a-matrix-dial"
+        },
+        {
+          "version": "20260821200000",
+          "name": "back-in-stock-requests-actually-save"
         },
         {
           "version": "20260822010000",


### PR DESCRIPTION
## Vad

`BackInStockForm` (publika StockStatus-blocket) kunde inte spara "meddela mig när den är tillbaka"-anmälningar för anonyma besökare. Fixen är en SECURITY DEFINER-RPC (`request_back_in_stock`) i stil med `ingest_form_lead`, plus att frontenden anropar den med den gamla upserten som fallback.

## Rotorsaken var värre än diagnosen

Utgångstesen: INSERT-policyn (`WITH CHECK true`) bär första anmälan och bara den **andra** från samma e-post faller, eftersom upsertens konfliktväg kräver en UPDATE-policy som anon saknar.

Empirin på dev (anon-JWT-claims-mönstret i SQL) visade mer: Postgres kräver för `INSERT ... ON CONFLICT DO UPDATE` att målraden går att **läsa** — SELECT-policyn prövas redan på den rena insertvägen, innan någon konflikt finns. anon har (korrekt) ingen läsväg på `back_in_stock_requests`, så **varje** anmälan via upserten nekas med 42501 på en instans utan anon-SELECT — inte bara den andra. En ren INSERT utan `ON CONFLICT` passerar; det är upsertformen som faller.

## Vägval

* **UPDATE-policy (USING true) + no-op-vaktande trigger** — prövades först, räcker inte: SELECT-kravet står kvar och upserten failar ändå. (Applicerades tillfälligt på dev under bisekteringen och är bortstädad.)
* **anon-SELECT-policy** — hade fått upserten att fungera men exponerar hela prenumerantlistan (e-postadresser) via PostgREST. Aldrig.
* **SECURITY DEFINER-RPC** ✅ — validerar hårt (e-postregex, produktexistens), failar tyst, returnerar ingenting (en utomstående kan inte sondera vilka adresser som väntar), och re-arm:ar `notified_at` vid förnyad anmälan så att den som anmäler sig igen efter ett utskick faktiskt får nästa också. Ingen ny missbruksyta: att anmäla någon annans adress är redan möjligt via INSERT-policyn.

Tabellens RLS lämnas orörd — anon får varken SELECT eller UPDATE.

## Verifierat på dev (`rzhjotxffjfsdlhrdkpj`)

Med `SET LOCAL ROLE anon` + `request.jwt.claims`:

* ✅ Första + andra anmälan från samma e-post lyckas → **1** rad (case-normaliserad: `RLS-Verify@…` och `rls-verify@…` dedupas)
* ✅ Re-arm: notifierad rad får `notified_at = NULL` vid förnyad anmälan
* ✅ Nekande: anon-SELECT ger 0 rader; anon-UPDATE träffar 0 rader
* ✅ Nekande: ogiltig e-post / okänd produkt → tyst no-op
* Migrationen är idempotent och forward-datad; manifestet omgenererat (`npm run manifest:json`)

## Efter merge från main (2026-08-22)

main fick rollsvep 4 + anon-ythärdningen (ledger-HEAD `20260822050000`), så migrationen är omdöpt `20260821200000` → **`20260822060000`** för att inte skippas tyst av instanser som redan passerat den gamla stämpeln — den körs nu också EFTER anon-svepens REVOKEs, så RPC:ns explicita `GRANT EXECUTE … TO anon` står sig. Anon-svepet (`20260822010000`) undantar uttryckligen `back_in_stock_requests` med hänvisning till den här fixen; dess TODO att köra grant-svepet på tabellen kvarstår efter att denna landat. Forward-dating-guarden, tsc, vitest (2569 ✓) och bygget är gröna efter mergen.

## Fleet

RPC:n är **applicerad och verifierad på dev**. Övriga tre instanser nås inte från den här miljön (pooler-URL:er/lösenord finns bara i lokala `.env.local`/`fleet.local.json`) — applicera per instans via Supavisor-poolern, se runbook. `--no-verify-jwt`-deploy behövs inte (ingen edge-funktion ändrad).