### PR TITLE
Add portal "New request" flow via submit_support_request RPC

### DIFF
--- a/src/hooks/useMyTickets.ts
+++ b/src/hooks/useMyTickets.ts
@@ -1,7 +1,17 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
-import type { Ticket, TicketComment } from '@/hooks/useTickets';
+import type { Ticket, TicketCategory, TicketComment } from '@/hooks/useTickets';
+
+/** Priorities a customer may pick — `urgent` is staff-side triage only. */
+export type MySupportRequestPriority = 'low' | 'medium' | 'high';
+
+export interface CreateMySupportRequestInput {
+  subject: string;
+  description?: string;
+  priority?: MySupportRequestPriority;
+  category?: TicketCategory;
+}
 
 /**
  * Tickets the signed-in customer is allowed to see. Visibility is enforced by
@@ -37,6 +47,34 @@ export function useMyTicketComments(ticketId: string | null) {
       if (error) throw error;
       return (data ?? []) as unknown as TicketComment[];
     },
+  });
+}
+
+/**
+ * Creates a ticket via the submit_support_request RPC — the portal's only
+ * create path. Ownership (created_by, contact_email, company_id) is stamped
+ * from the session server-side; the arguments carry content only.
+ */
+export function useCreateMySupportRequest() {
+  const qc = useQueryClient();
+  const { toast } = useToast();
+  return useMutation({
+    mutationFn: async (input: CreateMySupportRequestInput) => {
+      const { data, error } = await supabase.rpc('submit_support_request', {
+        p_subject: input.subject,
+        p_description: input.description || undefined,
+        p_priority: input.priority || 'medium',
+        p_category: input.category || 'other',
+      });
+      if (error) throw error;
+      return data as string;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['my-tickets'] });
+      toast({ title: 'Request submitted', description: 'Our team will get back to you.' });
+    },
+    onError: (err: Error) =>
+      toast({ title: 'Could not submit request', description: err.message, variant: 'destructive' }),
   });
 }
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -23834,6 +23834,15 @@ export type Database = {
         Returns: Json
       }
       submit_expense_report: { Args: { p_report_id: string }; Returns: Json }
+      submit_support_request: {
+        Args: {
+          p_category?: string
+          p_description?: string
+          p_priority?: string
+          p_subject: string
+        }
+        Returns: string
+      }
       submit_survey_response: {
         Args: {
           _answers?: Json

--- a/src/pages/account/MyTicketsPage.tsx
+++ b/src/pages/account/MyTicketsPage.tsx
@@ -3,16 +3,154 @@ import { Helmet } from 'react-helmet-async';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Skeleton } from '@/components/ui/skeleton';
-import { LifeBuoy, MessageSquare } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { LifeBuoy, MessageSquare, Plus } from 'lucide-react';
 import { usePlatformFormat } from '@/hooks/usePlatformFormat';
 import {
   TICKET_STATUS_LABELS,
   TICKET_STATUS_COLORS,
   TICKET_PRIORITY_LABELS,
+  TICKET_CATEGORY_LABELS,
+  type TicketCategory,
 } from '@/hooks/useTickets';
-import { useMyTickets, useMyTicketComments, useAddMyTicketReply } from '@/hooks/useMyTickets';
+import {
+  useMyTickets,
+  useMyTicketComments,
+  useAddMyTicketReply,
+  useCreateMySupportRequest,
+  type MySupportRequestPriority,
+} from '@/hooks/useMyTickets';
+
+// The portal create rail (submit_support_request) only accepts these — urgent
+// is a staff-side triage call, not a customer field.
+const PORTAL_PRIORITIES: MySupportRequestPriority[] = ['low', 'medium', 'high'];
+
+function NewRequestDialog() {
+  const create = useCreateMySupportRequest();
+  const [open, setOpen] = useState(false);
+  const [subject, setSubject] = useState('');
+  const [description, setDescription] = useState('');
+  const [priority, setPriority] = useState<MySupportRequestPriority>('medium');
+  const [category, setCategory] = useState<TicketCategory>('other');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (subject.trim().length < 3) return;
+
+    await create.mutateAsync({
+      subject: subject.trim(),
+      description: description.trim() || undefined,
+      priority,
+      category,
+    });
+
+    setSubject('');
+    setDescription('');
+    setPriority('medium');
+    setCategory('other');
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" className="gap-1.5">
+          <Plus className="h-4 w-4" />
+          New request
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>New support request</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="request-subject">Subject</Label>
+            <Input
+              id="request-subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder="Brief summary of your request"
+              maxLength={200}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="request-description">Description</Label>
+            <Textarea
+              id="request-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Tell us more — what happened, and what did you expect?"
+              rows={4}
+              maxLength={10000}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>Priority</Label>
+              <Select value={priority} onValueChange={(v) => setPriority(v as MySupportRequestPriority)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PORTAL_PRIORITIES.map((value) => (
+                    <SelectItem key={value} value={value}>
+                      {TICKET_PRIORITY_LABELS[value]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Category</Label>
+              <Select value={category} onValueChange={(v) => setCategory(v as TicketCategory)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Object.entries(TICKET_CATEGORY_LABELS) as [TicketCategory, string][]).map(
+                    ([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    )
+                  )}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="flex justify-end">
+            <Button type="submit" disabled={create.isPending || subject.trim().length < 3}>
+              {create.isPending ? 'Submitting…' : 'Submit request'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 export default function MyTicketsPage() {
   const { formatDateTime } = usePlatformFormat();
@@ -32,11 +170,14 @@ export default function MyTicketsPage() {
     <>
       <Helmet><title>My support requests</title></Helmet>
       <div className="space-y-4">
-        <div>
-          <h2 className="text-2xl font-semibold">Support requests</h2>
-          <p className="text-sm text-muted-foreground">
-            Follow your open requests and reply to our team
-          </p>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-2xl font-semibold">Support requests</h2>
+            <p className="text-sm text-muted-foreground">
+              Follow your open requests and reply to our team
+            </p>
+          </div>
+          <NewRequestDialog />
         </div>
 
         {isLoading && (


### PR DESCRIPTION
## Summary

The customer portal's `MyTicketsPage` listed tickets and allowed replies, but had no way to open a new support request. This wires the portal to the sanctioned create rail added in `20260821060000_c9d0e1f2-tickets-system-insert-tightened.sql` — the `submit_support_request` SECURITY DEFINER RPC.

## Changes

- **`src/hooks/useMyTickets.ts`** — new `useCreateMySupportRequest` mutation calling `supabase.rpc('submit_support_request', {...})`. On success it invalidates the `['my-tickets']` query and shows a confirmation toast; RPC errors surface in a destructive toast, matching the file's existing conventions. Exports `MySupportRequestPriority` (`low | medium | high` — `urgent` is deliberately staff-side triage only, per the migration) and a `CreateMySupportRequestInput` type.
- **`src/pages/account/MyTicketsPage.tsx`** — a "New request" dialog (shadcn Dialog/Input/Textarea/Select) in the page header with subject, description, priority (low/medium/high) and category fields. Client-side guards mirror the RPC validation (subject ≥ 3 chars, `maxLength` 200/10000); the form sends content only — ownership (`created_by`, `contact_email`, `contact_name`, `company_id`) is stamped server-side from the session.
- **`src/integrations/supabase/types.ts`** — added the `submit_support_request` signature to the generated `Functions` map (hand-extended in alphabetical order; the migration is not yet applied anywhere, so regeneration from a live DB wasn't possible).

## Verification

- `npx tsc --noEmit` passes clean.
- Not tested against a live database — the migration has not been applied to any instance yet, so live testing needs to be coordinated with the migration rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFX5DXdJ8shVahTGRJfZn7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFX5DXdJ8shVahTGRJfZn7)_