### PR TITLE
docs(concepts): Nordbrygg AB — sandboxföretaget, och varför dess data körs fram i stället för att infogas

### DIFF
--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -18,5 +18,6 @@ Architecture, vision, and the laws that govern FlowWink. **Read these before bui
 | [`a2a-communication-model.md`](./a2a-communication-model.md) | Implementing agent-to-agent federation |
 | [`integrations-strategy.md`](./integrations-strategy.md) | Planning third-party integrations |
 | [`ai-dependencies.md`](./ai-dependencies.md) | Checking which features need OpenAI / Gemini / local AI |
+| [`sandbox-company.md`](./sandbox-company.md) | Working with sandbox.flowwink.com — who Nordbrygg AB is, and why its data is run rather than inserted |
 
 > Looking for FlowPilot details? See [`../modules/flowpilot.md`](../modules/flowpilot.md) (configuration, heartbeat, trust gating, federation).

--- a/docs/concepts/sandbox-company.md
+++ b/docs/concepts/sandbox-company.md
@@ -1,0 +1,202 @@
+---
+title: "Nordbrygg AB — the sandbox company"
+category: concepts
+description: The fictional company that lives on sandbox.flowwink.com. Its state is not inserted — it is the residue of the fifteen processes having actually run, which makes the sandbox a standing regression test and a stage an external agent can play on.
+---
+
+# Nordbrygg AB — the sandbox company
+
+> **What is this?** `sandbox.flowwink.com` runs one fictional company. This page
+> is who that company is, what state it is in, and — the load-bearing part —
+> **why its data is produced by running the processes rather than by inserting
+> rows.**
+>
+> Think Contoso, but alive: not a catalogue of sample records, a business with a
+> Tuesday.
+
+---
+
+## Why this document exists
+
+The demo data we had was **scenery**. It was authored so that a person logging
+in would see something in the views, which was the right goal at the time and is
+a different goal from the one we have now.
+
+Measured on the sandbox instance, 2026-08-21:
+
+| what the data said | what it means |
+|---|---|
+| 6 stock moves, **all** `out`, **all** without a location | six deliveries out of a warehouse nothing ever came into |
+| 0 goods receipts, 0 purchase orders | the inbound chain had never run once |
+| 5 invoices, **0** with `order_id` | every invoice hangs in the air, unlinked to its order |
+| 6 orders, **0** with `quote_id` | no order was ever converted from a quote |
+| 0 stock locations | the nightly reset truncates them and nothing re-seeds |
+| catalogue: *Starter Plan, Pro Subscription, Onboarding Pack* | **nothing physical to buy, receive, pick or return** |
+
+Read the first row as a story: **six shipments out of an empty warehouse.** That
+is a state the system cannot itself produce — run the real process and you
+cannot get an outbound move without a location, and since the order-to-cash fix
+you cannot get an invoice without `order_id`.
+
+Scenery is worse than emptiness. An empty table is honest: nothing has happened
+here. Populated scenery **lies in the other direction** — the view looks right,
+the dashboard shows figures, and everyone concludes the chain works. The goods
+receipt bug lived for months partly because the stock view had rows in it. And
+for QA it is actively harmful: an agent asked to test "create an invoice from an
+order" finds five invoices that already exist without orders, concludes the step
+works, and never tests it.
+
+**So: the sandbox company's state is earned.** Every row exists because a process
+put it there.
+
+---
+
+## Who Nordbrygg AB is
+
+A Swedish company, in business since 2019, that **sells and services
+professional coffee equipment**.
+
+It was chosen for one reason: it exercises every lever an ERP has, without
+contrivance.
+
+| Nordbrygg sells | which forces |
+|---|---|
+| **Machines** — high value, serialised, imported | purchasing, goods receipt, landed cost, serial/lot tracking, warranty returns |
+| **Consumables** — beans, filters, descaler | reorder points, replenishment, subscriptions, the eshop's bread and butter |
+| **Spare parts** | stock at multiple locations, picking, backorder |
+| **Installation** — on site | services on a quote, scheduling, timesheets |
+| **Service agreements** — annual, per machine | contracts → subscriptions → recurring invoicing, the whole sign-to-serve chain |
+
+Its customers are both kinds, which the platform needs:
+
+- **B2C** through the webshop — a person buying a bag of beans or a home machine
+- **B2B** — cafés, offices and a hotel group, who ask for quotes, sign service
+  agreements, and are invoiced on 30 days
+
+Its suppliers are three, deliberately:
+
+- an **Italian machine manufacturer** (EUR, long lead time, the reason FX and
+  landed cost matter)
+- a **Swedish roastery** (SEK, weekly deliveries, the reason replenishment runs
+  often)
+- a **parts distributor** (small orders, the reason 3-way match has anything to
+  match)
+
+Nothing here is decoration. Each choice exists so that a process has a real
+reason to run.
+
+---
+
+## The company has been trading a while
+
+A business that started this morning has no interesting state. Nordbrygg has
+**history and things in flight** — because the bugs we keep finding do not live
+on the happy path, they live in the middle.
+
+The seed therefore leaves the company mid-stride, with at least one entity
+parked in a non-terminal state per process:
+
+| Process | What is in flight when the reset finishes |
+|---|---|
+| [Procure-to-Pay](../processes/procure-to-pay.md) | one PO **confirmed, awaiting delivery**; one **partially received**; one vendor invoice awaiting 3-way match |
+| [Order-to-Delivery](../processes/order-to-delivery.md) | orders spread across `paid`, `picked`, `shipped`, `delivered` — one of each |
+| [Quote-to-Cash](../processes/quote-to-cash.md) | a quote **sent** and unanswered; an invoice **overdue by 12 days** |
+| [Return-to-Refund](../processes/return-to-refund.md) | one RMA **received, under inspection**; one refunded and restocked |
+| [Sign-to-Serve](../processes/sign-to-serve.md) | a signed service agreement with an active subscription; one renewal due in 30 days |
+| [Support-to-Resolution](../processes/support-to-resolution.md) | an open ticket on a delivered machine, breaching SLA in 4 hours |
+| [Lead-to-Customer](../processes/lead-to-customer.md) | two leads mid-qualification, one deal at `proposal` |
+| [Record-to-Report](../processes/record-to-report.md) | last month **closed**, current month open with unreconciled bank lines |
+
+That table is the specification. If a process has nothing in flight, an agent
+arriving to work has nothing to pick up — and we have no evidence the middle of
+that process works.
+
+---
+
+## The rule: seeded by process, not by row
+
+The nightly reset (`sandbox_reset_wipe`) truncates and then **replays the
+business**, in dependency order:
+
+```
+1.  assert_platform_config()      locations, roles, chart of accounts, skills
+2.  master data                   products, vendors, customers, price lists
+3.  procure-to-pay                PO → goods receipt → vendor invoice → payment
+4.  the shop                      checkout → order → pick → ship → deliver
+5.  quote-to-cash                 quote → order → invoice → part payment
+6.  aftermarket                   RMA → inspection → refund → restock
+7.  services                      contract → subscription → recurring invoice
+8.  the month                     reconciliation, period close
+9.  leave the in-flight states above standing
+```
+
+Three things fall out of this, and they are the whole argument:
+
+**The data is possible by construction.** No state the process cannot reach, so
+no scenery hiding a broken step. Stock balances are *earned* — every unit in the
+warehouse arrived on a goods receipt that actually ran.
+
+**Every nightly reset becomes a full regression run.** If the seed does not
+complete, a chain is broken — and we learn it in the morning, not three weeks
+later when a QA agent trips over it. This is the signal the platform does not
+have today.
+
+**The platform-config problem disappears as a class.** The seed *cannot* run
+without stock locations, so the reset can never leave them empty. Compare the
+bug that prompted this page: `stock_locations` is platform config — the
+migration that created it is literally named
+`stock-locations-are-platform-config.sql` — but it is absent from the reset's
+KEEP list, so every night it was truncated and nothing sowed it again. Verified
+on sandbox: goods receipt refused with *"there is no active internal destination
+location"*, and after `seed_stock_locations()` the same chain ran clean —
+balance 0 → 100, one stock move, PO `received`, GRNI posted.
+
+---
+
+## What an external agent can do here
+
+This is the part that makes it a simulation rather than a fixture. The company
+has a state; agents move it forward, each playing a role:
+
+| Role | What it does | Surface |
+|---|---|---|
+| **Customer** | browses the shop, orders beans, asks support a question, returns a broken grinder | public site, `place_order`, chat, portal |
+| **Salesperson** | qualifies a lead, quotes the hotel group, converts to order | MCP gateway, CRM skills |
+| **Supplier** | confirms a PO, ships short, invoices at a different price than ordered | inbound A2A / MCP |
+| **Warehouse** | receives goods, picks, reports a discrepancy | inventory skills |
+| **Accountant** | matches invoices, reconciles the bank, closes the month | accounting skills |
+
+An adversarial supplier who **ships 8 of 10 and invoices for 10** is a better
+test of 3-way match than any assertion we can write. That is the point of
+letting agents drive: they produce the awkward middles we would not think to
+seed.
+
+**Run it until it breaks.** The instance resets nightly, so there is nothing to
+be careful about. The question a session should answer is not "did it error" but
+**"did the world change the way the process says it should"** — which is what
+the invariants below are for.
+
+---
+
+## Invariants — the check that survives the next bug
+
+Every serious finding so far broke one of these. They do not care *how* the code
+fails, which is why they catch silence:
+
+| Chain | Invariant |
+|---|---|
+| **Inbound** | Σ received quantity = Δ `stock_quantity` = Σ inbound `stock_moves`; GRNI amount = quantity × unit cost |
+| **Order-to-cash** | order total incl. VAT = accepted quote total · **exactly one** invoice per order · Σ invoice lines = order total |
+| **Aftermarket** | Σ refunded ≤ Σ(line qty × unit refund) − restocking fee |
+| **Replenishment** | reorder candidates ⊆ products where balance < reorder point |
+| **Ledger** | every stock move has a location · every invoice has its order · every order has its origin |
+
+The last row is the one that would have caught today's scenery in a single
+query, years before anyone opened the stock view and wondered.
+
+---
+
+## Related
+
+- [Business Processes — coverage map](../processes/README.md) — the fifteen processes this company runs
+- [Provisioning and updates](../operators/provisioning-and-updates.md) — how instances are built and kept current

--- a/docs/processes/README.md
+++ b/docs/processes/README.md
@@ -36,6 +36,58 @@ Fifteen processes, one platform. Each links to its own doc — one page per proc
 
 ---
 
+## Odoo as the reference model
+
+We follow **Odoo's standard processes**. Where Odoo has a name for a step, we use
+that name — a customer arriving from Odoo, an implementation partner, or an
+external agent trained on the standard should recognise the flow without a
+glossary.
+
+This table is the mapping. It is also an honest inventory: the right-hand column
+says where the concept actually lives, including where it does not live yet.
+
+| Odoo term | Meaning | In FlowWink |
+|---|---|---|
+| **RFQ** (Request for Quotation) | A purchase order before the vendor confirms | `purchase_orders` in status `draft` / `sent`. We do not call it an RFQ in the UI; the states are the same |
+| **Purchase Order** | Confirmed by the vendor | status `confirmed` |
+| **Receipt** (incoming picking) | Goods arriving against a PO | `goods_receipts` + `receive_purchase_order` |
+| **Backorder** | The remainder when a receipt or delivery is partial | status `partially_received`; the PO stays open for the rest |
+| **Vendor Bill** | The supplier's invoice | `vendor_invoices`, matched 3-way against PO + receipt |
+| **Credit Note** (vendor) | Correction after a mismatch | `vendor_credit_memos` |
+| **Reordering Rule** (min/max) | Replenish when stock falls below min, up to max | `reorder_rules` (`min_qty`, `reorder_qty`) — **see the divergence below** |
+| **Replenishment report** | What needs ordering right now | `list_reorder_candidates`, `purchase_reorder_check`, `procurement_run` |
+| **Quotation** | A sales offer before acceptance | `quotes` in `draft` / `sent` |
+| **Sales Order** | Accepted quotation | `orders`, carrying `quote_id` since the order-to-cash fix |
+| **Delivery Order** (outgoing picking) | Picking and shipping to the customer | `picking_orders` + `picking_lines`; `allocate_picking` / `confirm_pick` / `ship_picking` |
+| **Internal Transfer** | Stock moving between locations | `inventory_transfers` + `inventory_transfer_lines` |
+| **Lot / Serial** | Traceable units | `stock_lots`; serials are lots of size 1 |
+| **Landed Cost** | Freight and duty added to the inbound unit cost | `resolve_inbound_unit_cost` computes an inbound cost per receipt; freight/duty apportionment is **not** modelled yet |
+| **Scrap** | Writing stock off | `stock_moves` with an adjustment reason; no dedicated scrap document |
+| **Incoterms** | Delivery terms on the order | **not modelled** |
+
+### Known divergence: the reordering rule has three homes
+
+Verified on the sandbox instance, 2026-08-21. The replenishment loop reads its
+threshold from two different places depending on who asks:
+
+| Caller | Reads |
+|---|---|
+| UI (`useInventoryV2`) writes, `procurement_run` reads | `reorder_rules.min_qty` — the Odoo-standard rule |
+| `list_reorder_candidates`, `purchase_reorder_check` (the **agent-facing** skills) | `COALESCE(product_stock.reorder_point, products.low_stock_threshold, 5)` — and never `reorder_rules` |
+
+So an operator who sets a reordering rule the standard way gets no effect on the
+answer an agent gives, and a product with no threshold anywhere silently
+inherits a hardcoded **5**. `product_stock` is additionally the legacy table the
+stock-chain fix already found empty on fresh instances — which is how
+`purchase_reorder_check` once answered *"All stock levels are healthy"* forever.
+
+One rule, one home: `reorder_rules` is the one that matches the standard and the
+one the UI already writes. The skills should read it, falling back to the
+product threshold only for products with no rule — and a missing threshold
+should be *absent*, not 5.
+
+---
+
 ## How to read a process doc
 
 Every process doc follows the same anatomy, top to bottom:

--- a/docs/processes/procure-to-pay.md
+++ b/docs/processes/procure-to-pay.md
@@ -32,11 +32,11 @@ description: An employee pays for something out of pocket and photographs the re
 
 ```mermaid
 flowchart TD
-    A["Low stock / manual need"] --> B["Reorder check — auto or manual<br/>purchase_reorder_check · list_reorder_candidates · mrp_reorder_run"]
-    B --> C["Purchase order created<br/>create_purchase_order"]
-    C --> D["PO sent to vendor<br/>send_purchase_order"]
+    A["Low stock / manual need<br/>(Odoo: reordering rule min/max)"] --> B["Replenishment report — auto or manual<br/>purchase_reorder_check · list_reorder_candidates · procurement_run"]
+    B --> C["RFQ created — status draft<br/>create_purchase_order"]
+    C --> D["RFQ sent to vendor — status sent<br/>send_purchase_order"]
     D --> D2["PO change order (amendment + revision history)<br/>purchase_order_revisions"]
-    D2 --> E["Delivery → goods receipt<br/>receive_purchase_order"]
+    D2 --> E["Vendor confirms — status confirmed<br/>Delivery → goods receipt (partial ⇒ backorder)<br/>receive_purchase_order"]
     E --> F["Stock updated (Inventory) — receive→QC→putaway<br/>inventory_receipts"]
     F --> G["Vendor invoice in → 3-way match against PO + GR<br/>match_invoice_to_receipt"]
     G --> G2["Mismatch → dispute + supplier credit memo<br/>vendor_invoice_disputes · vendor_credit_memos"]
@@ -125,7 +125,20 @@ paid require admin trust.
 
 ---
 
-## Known gaps (missing for L5)
+
+## Known gaps
+
+> **The reordering rule has three homes.** Verified on sandbox 2026-08-21: the
+> UI writes `reorder_rules` (the Odoo-standard min/max rule) and `procurement_run`
+> reads it, while the agent-facing skills `list_reorder_candidates` and
+> `purchase_reorder_check` read
+> `COALESCE(product_stock.reorder_point, products.low_stock_threshold, 5)` and
+> never look at `reorder_rules` at all. So a rule set the standard way does not
+> change what an agent answers, and a product with no threshold anywhere
+> silently inherits a hardcoded 5. See the mapping table in
+> [README](./README.md#known-divergence-the-reordering-rule-has-three-homes).
+
+### Other gaps (missing for L5)
 
 - ✅ **3-way match auto-approve** — `match_invoice_to_receipt` + `auto_approve_vendor_invoice` live; tolerance config still manual
 - ❌ Multi-step approval based on amount thresholds


### PR DESCRIPTION
Vårt Contoso — fast levande. Inte en katalog med exempelposter, utan ett företag med en tisdag.

## Varför doket finns

Demodatan var **kulisser**: skriven så att den som loggar in ser något i vyerna. Rätt mål då, ett annat mål nu — och formen avslöjar det. Mätt på sandbox i dag:

| datan sa | vad det betyder |
|---|---|
| 6 lagerrörelser, **alla** `out`, **alla** utan lokation | sex utleveranser ur ett lager som aldrig fyllts på |
| 0 varumottagningar, 0 inköpsordrar | den inkommande kedjan har aldrig körts |
| 5 fakturor, **0** med `order_id` | varje faktura hänger i luften |
| 6 ordrar, **0** med `quote_id` | ingenting konverterat från offert |
| 0 lagerlokationer | nattliga resetten tömmer, ingen sår om |
| katalog: *Starter Plan, Pro Subscription* | **inget fysiskt att köpa, ta emot, plocka eller returnera** |

Det är tillstånd systemet **inte kan producera själv**. Kör man kedjan på riktigt kan en utleverans inte sakna lokation, och sedan O2C-fixen kan en faktura inte sakna sin order.

**Kulisser är värre än tomhet.** En tom tabell är ärlig — här har inget hänt. Befolkade kulisser säger motsatsen till sanningen: vyn ser rätt ut, dashboarden visar siffror. Varumottagningsbuggen överlevde månader delvis därför att lagervyn hade rader.

## Nordbrygg AB

Svenskt företag sedan 2019 som **säljer och servar professionell kaffeutrustning**. Valt för att det aktiverar varenda ERP-spak utan konstlade konstruktioner:

| säljer | tvingar fram |
|---|---|
| **maskiner** — dyra, serienummer, importerade i EUR | inköp, mottagning, landad kostnad, garantiretur |
| **förbrukning** — bönor, filter | beställningspunkter, påfyllning, prenumerationer, eshoppens vardag |
| **reservdelar** | flera lagerlokationer, plockning, restnotering |
| **installation** | tjänsterader på offert, schemaläggning, tidrapport |
| **serviceavtal** — årliga, per maskin | avtal → prenumeration → återkommande fakturering |

B2C via shoppen, B2B mot caféer, kontor och en hotellkedja. **Tre** leverantörer med flit: italiensk tillverkare (EUR, lång ledtid), svenskt rosteri (veckoleveranser), delsdistributör (småorder) — så att valuta, påfyllningstakt och 3-vägsmatchning var för sig har ett skäl att existera.

## Regeln: sått genom process, inte genom rad

Resetten **spelar upp verksamheten** i beroendeordning i stället för att INSERT:a: plattformspåstående → masterdata → P2P → shoppen → Q2C → eftermarknad → tjänster → månadsbokslut → och lämnar sedan de pågående tillstånden stående.

Tre saker faller ut, och de är hela argumentet:

- **Datan är möjlig per konstruktion.** Lagersaldot är *intjänat* — varje enhet kom in på en mottagning som faktiskt kördes.
- **Varje nattlig reset blir en full regressionskörning.** Går sådden inte igenom är en kedja trasig, och det syns på morgonen.
- **Plattformskonfigurationsklassen försvinner**, eftersom sådden inte kan köra utan sin mark.

## Synkat mot `/docs/processes`

Tabellen "vad som är i flykt" namnger **ett icke-terminalt tillstånd per process** och länkar till respektive processdok — PO som väntar leverans, offert som är skickad och obesvarad, RMA under inspektion, faktura 12 dagar försenad, ticket som spräcker SLA om fyra timmar.

Det är specifikationen: har en process inget i flykt har en agent som kommer till jobbet inget att ta i, och vi har inga bevis för att mitten fungerar. **Buggarna bor i mitten.**

## Verifierat live medan doket skrevs

```
mottagning  VÄGRAD — "there is no active internal destination location"
            ↓ seed_stock_locations()
saldo       0 → 100   (delta 100, väntat 100)   OK
stock_moves 2 → 3                               OK
po_status   received · varumottagning 1 · GRNI-post 1
```

ERP-paketets fix är alltså **korrekt** — det var marken under den som var tom. `stock_locations` är plattformskonfiguration (migrationen heter bokstavligen `stock-locations-are-platform-config.sql`) men saknas i resettens KEEP-lista.

Svit **2568 passed**.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_