### PR TITLE
fix(inventory): plockkedjan har aldrig flyttat en enda enhet — P2P + O2C sås genom att KÖRAS

### DIFF
--- a/supabase/migrations/20260822080000_the-outbound-chain-never-ran.sql
+++ b/supabase/migrations/20260822080000_the-outbound-chain-never-ran.sql
@@ -1,0 +1,372 @@
+-- The picking chain has never once moved a unit of stock.
+--
+-- Found by trying to run it. `sandbox_seed_o2c()` sells 30 kg of coffee out of
+-- the 120 kg that `sandbox_seed_p2p()` received, and asserted that the balance
+-- fell. It did not — and the three reasons are all the same shape: a call that
+-- cannot resolve, wrapped in a handler that reports success.
+--
+--   1. allocate_picking → reserve_stock(..., 'picking_order', v_picking_id)
+--      p_reference_id is text; v_picking_id is uuid. There is no implicit
+--      uuid→text cast, so Postgres raises 42883 "function ... does not exist".
+--      `EXCEPTION WHEN OTHERS` counted it as short stock. Every picking line
+--      ever allocated, on every instance, came out `status='short'` with
+--      reservation_id NULL — and the envelope said {"success": true}.
+--
+--   2. ship_picking → consume_reservation(v_line.reservation_id, v_line.qty_picked)
+--      The second parameter is `p_to_location_code text`, a LOCATION CODE, not a
+--      quantity. numeric→text does not cast implicitly either, so this is 42883
+--      as well, swallowed into an audit row nobody reads. `consumed_lines` came
+--      back 0 and the order flipped to 'shipped' regardless.
+--
+--   3. Even repaired, the two calls would have double-counted: the AFTER INSERT
+--      trigger on order_items (trg_order_item_stock_decrement, 20260820210005)
+--      already writes the outbound move and the quant delta at order-entry time.
+--      A second delta at shipment would take 30 units off the books twice while
+--      30 sat on the shelf.
+--
+-- 1 and 2 are unambiguous: the functions could not work as written. 3 is a
+-- decision, so it is made explicitly here rather than absorbed — see the
+-- ownership rule on consume_reservation below.
+--
+-- The class this belongs to: a guard that reports success while the world did
+-- not change. `EXCEPTION WHEN OTHERS` cannot tell "there is not enough stock"
+-- (a business outcome, and a real one) from "that function does not exist" (a
+-- defect). Conflating them is what let this survive from the baseline until a
+-- process was run against it for real. Both handlers below now re-raise the
+-- undefined-object class and keep the business outcome.
+--
+-- Idempotent, and forward-dated so managed instances actually apply it.
+
+-- ---------------------------------------------------------------------------
+-- consume_reservation: who owns the balance
+-- ---------------------------------------------------------------------------
+-- p_move_stock says whether this call is the one that takes the goods off the
+-- shelf. It is true by default, which is the standalone case (an MO consuming
+-- components, an agent shipping a reservation it made itself) and preserves
+-- every existing caller and the `consume_reservation` skill unchanged.
+--
+-- ship_picking passes false for an order-linked picking, because order entry
+-- already moved those goods. One writer per balance: order_items owns the
+-- quantity, the picking chain owns the reservation lifecycle and the shipment
+-- record. That is a divergence from Odoo, where the delivery order's validation
+-- is what moves stock and the sales order only reserves — noted so the next
+-- person meets the decision instead of re-deriving it from a discrepancy.
+-- The two-argument form must go, or the new one is an overload and every
+-- existing two-argument call becomes ambiguous (42725). Dropping first is the
+-- only way to widen a signature that carries a default.
+DROP FUNCTION IF EXISTS public.consume_reservation(uuid, text);
+
+CREATE OR REPLACE FUNCTION public.consume_reservation(
+  p_reservation_id uuid,
+  p_to_location_code text DEFAULT 'WH/CUSTOMERS'::text,
+  p_move_stock boolean DEFAULT true
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE r stock_reservations%ROWTYPE; v_to uuid; v_move uuid;
+BEGIN
+  IF NOT (auth.role() = 'service_role'
+          OR has_role(auth.uid(), 'writer'::app_role)
+          OR has_role(auth.uid(), 'admin'::app_role)) THEN
+    RAISE EXCEPTION 'Insufficient privileges';
+  END IF;
+
+  SELECT * INTO r FROM stock_reservations WHERE id = p_reservation_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Reservation not found'; END IF;
+  IF r.state <> 'reserved' THEN RAISE EXCEPTION 'Reservation not in reserved state'; END IF;
+
+  SELECT id INTO v_to FROM stock_locations WHERE code = p_to_location_code;
+  IF v_to IS NULL THEN RAISE EXCEPTION 'Destination location % not found', p_to_location_code; END IF;
+
+  -- Releasing the hold happens either way: the reservation is over, so the
+  -- quantity must stop counting as spoken-for or it strands available stock.
+  UPDATE stock_quants
+     SET reserved_quantity = GREATEST(0, COALESCE(reserved_quantity,0) - r.quantity),
+         updated_at = now()
+   WHERE product_id = r.product_id AND location_id = r.location_id
+     AND (lot_id IS NOT DISTINCT FROM r.lot_id);
+
+  IF p_move_stock THEN
+    PERFORM _upsert_quant(r.product_id, r.location_id, r.lot_id, -r.quantity);
+    PERFORM _upsert_quant(r.product_id, v_to, r.lot_id, r.quantity);
+
+    INSERT INTO stock_moves (product_id, quantity, move_type, from_location_id, to_location_id,
+                             lot_id, reference_type, reference_id, created_by, state)
+    VALUES (r.product_id, r.quantity::int, 'reservation_consumed', r.location_id, v_to,
+            r.lot_id, r.reference_type, r.reference_id, auth.uid(), 'done')
+    RETURNING id INTO v_move;
+  END IF;
+
+  UPDATE stock_reservations SET state = 'consumed', consumed_at = now() WHERE id = p_reservation_id;
+  RETURN v_move;
+END; $function$;
+
+-- ---------------------------------------------------------------------------
+-- allocate_picking: reserve for real, and tell the truth when it fails
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.allocate_picking(
+  p_order_id uuid,
+  p_source_location_id uuid DEFAULT NULL::uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_picking_id UUID;
+  v_order RECORD;
+  v_item RECORD;
+  v_line_id UUID;
+  v_reservation_id UUID;
+  v_source_location UUID;
+  v_short_count INT := 0;
+  v_total_count INT := 0;
+  v_short_reason TEXT;
+  v_lines JSONB := '[]'::JSONB;
+BEGIN
+  IF NOT ((auth.role() = 'service_role' OR can_access_module(auth.uid(),'inventory')) OR auth.uid() IS NULL) THEN
+    RAISE EXCEPTION 'Insufficient permissions';
+  END IF;
+
+  SELECT * INTO v_order FROM public.orders WHERE id = p_order_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Order % not found', p_order_id;
+  END IF;
+
+  v_source_location := COALESCE(
+    p_source_location_id,
+    (SELECT id FROM public.stock_locations
+      WHERE location_type = 'internal' AND is_active = true ORDER BY created_at LIMIT 1)
+  );
+
+  -- Idempotency: reuse an open picking_order for this order if one exists.
+  SELECT id INTO v_picking_id
+    FROM public.picking_orders
+   WHERE order_id = p_order_id AND status IN ('draft','ready','in_progress')
+   LIMIT 1;
+
+  IF v_picking_id IS NULL THEN
+    INSERT INTO public.picking_orders (order_id, source_location_id, status, ship_to_name,
+                                       ship_to_address, created_by, allocated_at)
+    VALUES (p_order_id, v_source_location, 'ready', v_order.customer_name, NULL, auth.uid(), now())
+    RETURNING id INTO v_picking_id;
+  END IF;
+
+  -- products has no `sku` column — `barcode` carries the SKU value.
+  FOR v_item IN
+    SELECT oi.*, p.name AS p_name, p.barcode AS p_sku
+      FROM public.order_items oi
+      LEFT JOIN public.products p ON p.id = oi.product_id
+     WHERE oi.order_id = p_order_id
+  LOOP
+    v_total_count := v_total_count + 1;
+    v_reservation_id := NULL;
+    v_short_reason := NULL;
+
+    BEGIN
+      -- ::text — p_reference_id is text. Without the cast this call does not
+      -- resolve and no line has ever been reserved.
+      v_reservation_id := public.reserve_stock(
+        v_item.product_id,
+        v_source_location,
+        v_item.quantity,
+        'picking_order',
+        v_picking_id::text
+      );
+    EXCEPTION
+      -- A missing function, column or table is a defect in this function, not a
+      -- statement about the warehouse. Let it out.
+      WHEN undefined_function OR undefined_column OR undefined_table THEN
+        RAISE;
+      WHEN OTHERS THEN
+        v_short_count := v_short_count + 1;
+        v_short_reason := left(SQLERRM, 200);
+    END;
+
+    INSERT INTO public.picking_lines (
+      picking_order_id, product_id, product_sku, product_name,
+      qty_requested, reservation_id, status, notes
+    )
+    VALUES (
+      v_picking_id, v_item.product_id, v_item.p_sku, COALESCE(v_item.p_name, 'Product'),
+      v_item.quantity, v_reservation_id,
+      CASE WHEN v_reservation_id IS NOT NULL THEN 'reserved' ELSE 'short' END,
+      v_short_reason
+    )
+    RETURNING id INTO v_line_id;
+
+    v_lines := v_lines || jsonb_build_object(
+      'line_id', v_line_id,
+      'product_id', v_item.product_id,
+      'qty', v_item.quantity,
+      'reserved', v_reservation_id IS NOT NULL,
+      'short_reason', v_short_reason
+    );
+  END LOOP;
+
+  INSERT INTO public.audit_logs (action, entity_type, entity_id, user_id, metadata)
+  VALUES ('picking.allocated', 'picking_order', v_picking_id, auth.uid(),
+    jsonb_build_object('order_id', p_order_id, 'lines', v_total_count, 'short', v_short_count));
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'picking_order_id', v_picking_id,
+    'lines_total', v_total_count,
+    'lines_short', v_short_count,
+    'lines', v_lines
+  );
+END; $function$;
+
+-- ---------------------------------------------------------------------------
+-- ship_picking: consume with the right arity, and do not claim a shipment that
+-- consumed nothing
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.ship_picking(
+  p_picking_order_id uuid,
+  p_tracking_number text DEFAULT NULL::text,
+  p_carrier text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_po RECORD; v_line RECORD;
+  v_consumed INT := 0; v_reserved_lines INT := 0; v_failed jsonb := '[]'::jsonb;
+  v_carrier_id uuid; v_carrier_code text; v_active_count int;
+  v_move_stock boolean;
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR can_access_module(auth.uid(),'inventory')) THEN
+    RAISE EXCEPTION 'Insufficient permissions';
+  END IF;
+
+  SELECT * INTO v_po FROM public.picking_orders WHERE id = p_picking_order_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Picking order % not found', p_picking_order_id; END IF;
+  IF v_po.status = 'shipped' THEN RETURN jsonb_build_object('success', true, 'already_shipped', true); END IF;
+  IF v_po.status = 'cancelled' THEN RAISE EXCEPTION 'Cannot ship cancelled picking_order'; END IF;
+
+  -- 4b85909f: resolve p_carrier against the carriers table (id, code or name,
+  -- case-insensitive). Unknown values are rejected while active carriers
+  -- exist; when none are configured yet, free text passes (fail forward).
+  IF p_carrier IS NOT NULL AND btrim(p_carrier) <> '' THEN
+    SELECT c.id, c.code INTO v_carrier_id, v_carrier_code
+      FROM public.carriers c
+     WHERE c.is_active
+       AND (c.id::text = btrim(p_carrier)
+            OR lower(c.code) = lower(btrim(p_carrier))
+            OR lower(c.name) = lower(btrim(p_carrier)))
+     LIMIT 1;
+    IF v_carrier_id IS NULL THEN
+      SELECT count(*) INTO v_active_count FROM public.carriers WHERE is_active;
+      IF v_active_count > 0 THEN
+        RAISE EXCEPTION 'Unknown carrier "%" — pass an active carrier id, code or name. Active carriers: %',
+          p_carrier, (SELECT string_agg(code, ', ' ORDER BY code) FROM public.carriers WHERE is_active);
+      END IF;
+    END IF;
+  END IF;
+
+  -- Order entry already took these goods off the shelf (trg_order_item_stock_decrement).
+  -- A picking with no order behind it — an agent's own reservation — has not.
+  v_move_stock := (v_po.order_id IS NULL);
+
+  FOR v_line IN
+    SELECT * FROM public.picking_lines
+     WHERE picking_order_id = p_picking_order_id AND status = 'picked'
+  LOOP
+    IF v_line.reservation_id IS NOT NULL THEN
+      v_reserved_lines := v_reserved_lines + 1;
+      BEGIN
+        -- Two arguments, not three: the second is a LOCATION CODE. Passing
+        -- qty_picked here is what made this call unresolvable.
+        PERFORM public.consume_reservation(v_line.reservation_id, 'WH/CUSTOMERS', v_move_stock);
+        v_consumed := v_consumed + 1;
+      EXCEPTION
+        WHEN undefined_function OR undefined_column OR undefined_table THEN
+          RAISE;
+        WHEN OTHERS THEN
+          v_failed := v_failed || jsonb_build_object('line_id', v_line.id, 'error', left(SQLERRM, 200));
+          INSERT INTO public.audit_logs (action, entity_type, entity_id, user_id, metadata)
+          VALUES ('picking.consume_failed', 'picking_line', v_line.id, auth.uid(),
+                  jsonb_build_object('error', SQLERRM));
+      END;
+    END IF;
+  END LOOP;
+
+  UPDATE public.picking_orders
+     SET status = 'shipped', shipped_at = now(),
+         tracking_number = COALESCE(p_tracking_number, tracking_number),
+         carrier = COALESCE(v_carrier_code, p_carrier, carrier),
+         carrier_id = COALESCE(v_carrier_id, carrier_id)
+   WHERE id = p_picking_order_id;
+
+  IF v_po.order_id IS NOT NULL THEN
+    UPDATE public.orders SET status = 'shipped', updated_at = now() WHERE id = v_po.order_id;
+  END IF;
+
+  BEGIN
+    PERFORM public.emit_platform_event('picking.shipped', jsonb_build_object(
+      'picking_order_id', p_picking_order_id, 'order_id', v_po.order_id,
+      'tracking_number', p_tracking_number, 'carrier_id', v_carrier_id,
+      'consumed_lines', v_consumed), 'pick_pack');
+  EXCEPTION WHEN OTHERS THEN NULL; END;
+
+  INSERT INTO public.audit_logs (action, entity_type, entity_id, user_id, metadata)
+  VALUES ('picking.shipped', 'picking_order', p_picking_order_id, auth.uid(),
+          jsonb_build_object('order_id', v_po.order_id, 'tracking_number', p_tracking_number,
+                             'carrier_id', v_carrier_id, 'consumed', v_consumed));
+
+  -- reserved_lines vs consumed is the whole point: a caller that reads only
+  -- `success` cannot tell a shipment from a status change. Now it can.
+  RETURN jsonb_build_object(
+    'success', true,
+    'picking_order_id', p_picking_order_id,
+    'reserved_lines', v_reserved_lines,
+    'consumed_lines', v_consumed,
+    'stock_moved', v_move_stock,
+    'failed_lines', v_failed,
+    'carrier_id', v_carrier_id,
+    'carrier_code', v_carrier_code
+  );
+END; $function$;
+
+GRANT EXECUTE ON FUNCTION public.consume_reservation(uuid, text, boolean) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.allocate_picking(uuid, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ship_picking(uuid, text, text) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.consume_reservation(uuid, text, boolean) IS
+  'Ends a reservation. Always releases the hold; moves the quants only when p_move_stock (default true). ship_picking passes false for order-linked pickings because trg_order_item_stock_decrement already moved those goods.';
+
+-- ---------------------------------------------------------------------------
+-- Grants: DROP + recreate re-arms the PUBLIC default
+-- ---------------------------------------------------------------------------
+-- Widening consume_reservation's signature meant dropping the old one, and a
+-- freshly created function is EXECUTE-able by PUBLIC unless something says
+-- otherwise. That silently re-opened an anon-reachable SECURITY DEFINER
+-- function that moves stock — the exact class fb7d9e5/dd322e6 had just closed.
+-- ALTER DEFAULT PRIVILEGES covers this going forward, but a migration must not
+-- depend on having been applied after that one.
+--
+-- allocate_picking and ship_picking were anon-reachable before this commit too
+-- (=X/postgres and an explicit anon grant, straight from the baseline). Same
+-- revoke, same reason: three functions that mutate the warehouse have no
+-- business being callable without a session.
+DO $revoke$
+DECLARE v_fn record;
+BEGIN
+  FOR v_fn IN
+    SELECT p.oid::regprocedure AS sig
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public'
+       AND p.proname IN ('consume_reservation', 'allocate_picking', 'ship_picking')
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC', v_fn.sig);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM anon', v_fn.sig);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated, service_role', v_fn.sig);
+  END LOOP;
+END $revoke$;

--- a/supabase/migrations/20260822090000_sandbox-seed-p2p.sql
+++ b/supabase/migrations/20260822090000_sandbox-seed-p2p.sql
@@ -1,0 +1,220 @@
+-- Nordbrygg AB's inbound chain, seeded by RUNNING it.
+--
+-- The demo data this replaces was scenery: six outbound stock moves, all
+-- without a location, from a warehouse nothing ever came into; five invoices
+-- with no order; a catalogue of "Starter Plan" and "Pro Subscription" with
+-- nothing physical to receive, pick or return. Those are states the system
+-- cannot itself produce, which is why they hid a broken chain instead of
+-- exercising it. See docs/concepts/sandbox-company.md.
+--
+-- So this seeds through the REAL surface — receive_purchase_order, not INSERT
+-- INTO stock_moves. Every unit in the warehouse arrives on a goods receipt that
+-- actually ran, which makes each nightly reset a regression run: if the seed
+-- cannot complete, the chain is broken and we learn it in the morning.
+--
+-- WHY P2P FIRST, AND WHY NOT FOR EVERYTHING. Inbound is the precondition — you
+-- cannot ship, return or restock what never arrived, so the shop and the
+-- aftermarket have nothing to stand on until this runs. But a company trading
+-- since 2019 does not have every unit traceable to a purchase order, and
+-- pretending otherwise would be a different kind of fiction. So history enters
+-- as an opening inventory adjustment (Odoo's own convention) and only the
+-- recent window is played through live POs.
+--
+-- Guarded to sandbox instances, same predicate as sandbox_reset_wipe: this
+-- writes business data and must never run on an instance someone relies on.
+-- Idempotent — re-running finds its own rows and does nothing.
+
+CREATE OR REPLACE FUNCTION public.sandbox_seed_p2p()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_is_sandbox boolean;
+  v_loc_in uuid;
+  v_vendor_machines uuid;
+  v_vendor_roastery uuid;
+  v_vendor_parts uuid;
+  v_machine uuid;
+  v_beans uuid;
+  v_filter uuid;
+  v_po_full uuid;
+  v_po_partial uuid;
+  v_po_awaiting uuid;
+  v_line uuid;
+  v_bill uuid;
+  v_before numeric;
+  v_after numeric;
+  v_moves_before int;
+  v_moves_after int;
+  v_report jsonb := '{}'::jsonb;
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR public.has_role(auth.uid(), 'admin')) THEN
+    RAISE EXCEPTION 'Only admins can seed the sandbox';
+  END IF;
+
+  -- Either flag, because the fleet uses both and a guard that binds to the
+  -- wrong one is a guard that never binds. sandbox.flowwink.com carries
+  -- demo_mode.enabled and NOT sandbox_mode — the nightly rebuild there runs
+  -- through demo-cycle, not sandbox_reset_wipe. Checking only the latter would
+  -- have made this function unrunnable on the one instance it exists for.
+  SELECT COALESCE(
+           (SELECT (value #>> '{}')::boolean FROM public.site_settings WHERE key = 'sandbox_mode'),
+           (SELECT (value ->> 'enabled')::boolean FROM public.site_settings WHERE key = 'demo_mode'),
+           false)
+    INTO v_is_sandbox;
+  IF NOT COALESCE(v_is_sandbox, false) THEN
+    RAISE EXCEPTION 'sandbox_seed_p2p refused: this instance is neither a sandbox nor a demo (site_settings.sandbox_mode / demo_mode.enabled)';
+  END IF;
+
+  -- ── 1. The ground ────────────────────────────────────────────────────────
+  -- The reset truncates every table outside its KEEP list, and stock_locations
+  -- is not on it — so the warehouse layout is gone every morning and goods
+  -- receipt refuses with "no active internal destination location". Asserting
+  -- it here means the seed cannot run on empty ground, which is exactly the
+  -- property that makes the platform-config class disappear.
+  PERFORM public.seed_stock_locations();
+  SELECT id INTO v_loc_in FROM public.stock_locations
+   WHERE location_type = 'internal' AND COALESCE(is_active, true) LIMIT 1;
+  IF v_loc_in IS NULL THEN
+    RAISE EXCEPTION 'sandbox_seed_p2p: no internal stock location after seeding — the ground is broken, not the seed';
+  END IF;
+
+  -- ── 2. Master data ───────────────────────────────────────────────────────
+  -- Three vendors, deliberately different, so currency, cadence and 3-way match
+  -- each have a reason to exist rather than being asserted about.
+  INSERT INTO public.vendors (name, email, currency, payment_terms, is_active)
+  SELECT 'Caffè Milano S.r.l.', 'ordini@caffemilano.example', 'EUR', 30, true
+   WHERE NOT EXISTS (SELECT 1 FROM public.vendors WHERE name = 'Caffè Milano S.r.l.');
+  INSERT INTO public.vendors (name, email, currency, payment_terms, is_active)
+  SELECT 'Söderberg Rosteri AB', 'order@soderbergrosteri.example', 'SEK', 20, true
+   WHERE NOT EXISTS (SELECT 1 FROM public.vendors WHERE name = 'Söderberg Rosteri AB');
+  INSERT INTO public.vendors (name, email, currency, payment_terms, is_active)
+  SELECT 'Nordic Parts Distribution AB', 'sales@nordicparts.example', 'SEK', 30, true
+   WHERE NOT EXISTS (SELECT 1 FROM public.vendors WHERE name = 'Nordic Parts Distribution AB');
+
+  SELECT id INTO v_vendor_machines FROM public.vendors WHERE name = 'Caffè Milano S.r.l.';
+  SELECT id INTO v_vendor_roastery FROM public.vendors WHERE name = 'Söderberg Rosteri AB';
+  SELECT id INTO v_vendor_parts    FROM public.vendors WHERE name = 'Nordic Parts Distribution AB';
+
+  -- Physical goods. The old catalogue had none, which is why inventory,
+  -- picking and returns had never run a single time.
+  INSERT INTO public.products (name, description, type, price_cents, currency, is_active, track_inventory, low_stock_threshold)
+  SELECT 'Milano Due — espressomaskin, 2 grupper',
+         'Halvautomatisk espressomaskin i två grupper. Serienummermärkt, två års garanti.',
+         'one_time', 4890000, 'SEK', true, true, 2
+   WHERE NOT EXISTS (SELECT 1 FROM public.products WHERE name LIKE 'Milano Due%');
+  INSERT INTO public.products (name, description, type, price_cents, currency, is_active, track_inventory, low_stock_threshold)
+  SELECT 'Söderberg Mörkrost — 1 kg',
+         'Mörkrostade bönor för espresso. Levereras veckovis.',
+         'one_time', 34900, 'SEK', true, true, 40
+   WHERE NOT EXISTS (SELECT 1 FROM public.products WHERE name LIKE 'Söderberg Mörkrost%');
+  INSERT INTO public.products (name, description, type, price_cents, currency, is_active, track_inventory, low_stock_threshold)
+  SELECT 'Vattenfilter FX-200', 'Utbytesfilter, rekommenderat byte var sjätte månad.',
+         'one_time', 89900, 'SEK', true, true, 15
+   WHERE NOT EXISTS (SELECT 1 FROM public.products WHERE name LIKE 'Vattenfilter FX-200%');
+
+  SELECT id INTO v_machine FROM public.products WHERE name LIKE 'Milano Due%';
+  SELECT id INTO v_beans   FROM public.products WHERE name LIKE 'Söderberg Mörkrost%';
+  SELECT id INTO v_filter  FROM public.products WHERE name LIKE 'Vattenfilter FX-200%';
+
+  -- ── 3. Live P2P: fully received ──────────────────────────────────────────
+  IF NOT EXISTS (SELECT 1 FROM public.purchase_orders WHERE notes = 'seed:p2p:full') THEN
+    SELECT COALESCE(stock_quantity, 0) INTO v_before FROM public.products WHERE id = v_beans;
+    SELECT count(*) INTO v_moves_before FROM public.stock_moves WHERE product_id = v_beans;
+
+    INSERT INTO public.purchase_orders (vendor_id, status, currency, order_date, expected_delivery, notes)
+    VALUES (v_vendor_roastery, 'confirmed', 'SEK', current_date - 9, current_date - 7, 'seed:p2p:full')
+    RETURNING id INTO v_po_full;
+    INSERT INTO public.purchase_order_lines (purchase_order_id, product_id, description, quantity, unit_price_cents, tax_rate, total_cents)
+    VALUES (v_po_full, v_beans, 'Söderberg Mörkrost 1 kg', 120, 18500, 0.25, 120 * 18500)
+    RETURNING id INTO v_line;
+
+    PERFORM public.receive_purchase_order(
+      v_po_full,
+      jsonb_build_array(jsonb_build_object('po_line_id', v_line, 'quantity_received', 120)),
+      v_loc_in);
+
+    SELECT COALESCE(stock_quantity, 0) INTO v_after FROM public.products WHERE id = v_beans;
+    SELECT count(*) INTO v_moves_after FROM public.stock_moves WHERE product_id = v_beans;
+
+    -- The invariant, asserted where it is cheapest to assert: the receipt said
+    -- 120, so the balance moved 120 and the journal grew. A receipt that
+    -- returns success while the world stands still is the failure this whole
+    -- exercise exists to catch.
+    IF (v_after - v_before) <> 120 THEN
+      RAISE EXCEPTION 'sandbox_seed_p2p: received 120 but balance moved % (from % to %)',
+        (v_after - v_before), v_before, v_after;
+    END IF;
+    IF v_moves_after <= v_moves_before THEN
+      RAISE EXCEPTION 'sandbox_seed_p2p: balance moved but no stock_move was written';
+    END IF;
+
+    v_report := v_report || jsonb_build_object('po_full', jsonb_build_object(
+      'received', 120, 'balance_before', v_before, 'balance_after', v_after));
+  END IF;
+
+  -- ── 4. Live P2P: partially received, backorder standing ──────────────────
+  -- Odoo calls the remainder a backorder. The middles are where the bugs live,
+  -- so the seed leaves one standing on purpose.
+  IF NOT EXISTS (SELECT 1 FROM public.purchase_orders WHERE notes = 'seed:p2p:partial') THEN
+    INSERT INTO public.purchase_orders (vendor_id, status, currency, order_date, expected_delivery, notes)
+    VALUES (v_vendor_parts, 'confirmed', 'SEK', current_date - 5, current_date - 2, 'seed:p2p:partial')
+    RETURNING id INTO v_po_partial;
+    INSERT INTO public.purchase_order_lines (purchase_order_id, product_id, description, quantity, unit_price_cents, tax_rate, total_cents)
+    VALUES (v_po_partial, v_filter, 'Vattenfilter FX-200', 40, 42000, 0.25, 40 * 42000)
+    RETURNING id INTO v_line;
+
+    PERFORM public.receive_purchase_order(
+      v_po_partial,
+      jsonb_build_array(jsonb_build_object('po_line_id', v_line, 'quantity_received', 25)),
+      v_loc_in);
+
+    IF (SELECT status FROM public.purchase_orders WHERE id = v_po_partial) <> 'partially_received' THEN
+      RAISE EXCEPTION 'sandbox_seed_p2p: 25 of 40 received but PO status is %, expected partially_received',
+        (SELECT status FROM public.purchase_orders WHERE id = v_po_partial);
+    END IF;
+
+    v_report := v_report || jsonb_build_object('po_partial',
+      jsonb_build_object('ordered', 40, 'received', 25, 'backorder', 15));
+  END IF;
+
+  -- ── 5. In flight: confirmed, awaiting delivery ───────────────────────────
+  -- The long-lead-time import. An agent arriving to work has something to
+  -- follow up.
+  IF NOT EXISTS (SELECT 1 FROM public.purchase_orders WHERE notes = 'seed:p2p:awaiting') THEN
+    INSERT INTO public.purchase_orders (vendor_id, status, currency, order_date, expected_delivery, notes)
+    VALUES (v_vendor_machines, 'confirmed', 'EUR', current_date - 12, current_date + 9, 'seed:p2p:awaiting')
+    RETURNING id INTO v_po_awaiting;
+    INSERT INTO public.purchase_order_lines (purchase_order_id, product_id, description, quantity, unit_price_cents, tax_rate, total_cents)
+    VALUES (v_po_awaiting, v_machine, 'Milano Due, 2 grupper', 2, 285000, 0.25, 2 * 285000);
+
+    v_report := v_report || jsonb_build_object('po_awaiting',
+      jsonb_build_object('vendor', 'Caffè Milano S.r.l.', 'currency', 'EUR', 'due_in_days', 9));
+  END IF;
+
+  -- ── 6. Vendor bill awaiting 3-way match ──────────────────────────────────
+  IF v_po_full IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM public.vendor_invoices WHERE notes = 'seed:p2p:bill') THEN
+    INSERT INTO public.vendor_invoices (
+      invoice_number, vendor_id, purchase_order_id, invoice_date, due_date,
+      subtotal_cents, tax_cents, total_cents, currency, status, notes)
+    VALUES ('SR-2026-0413', v_vendor_roastery, v_po_full, current_date - 6, current_date + 14,
+            120 * 18500, (120 * 18500 * 0.25)::bigint, (120 * 18500 * 1.25)::bigint,
+            'SEK', 'received', 'seed:p2p:bill')
+    RETURNING id INTO v_bill;
+    v_report := v_report || jsonb_build_object('vendor_bill', 'SR-2026-0413');
+  END IF;
+
+  RETURN jsonb_build_object(
+    'seeded', true,
+    'chain', 'procure-to-pay',
+    'detail', v_report,
+    'note', 'Stock in this instance is earned: every unit arrived on a goods receipt that ran.');
+END; $fn$;
+
+GRANT EXECUTE ON FUNCTION public.sandbox_seed_p2p() TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.sandbox_seed_p2p() IS
+  'Seeds Nordbrygg AB''s inbound chain by RUNNING it (receive_purchase_order, not INSERT). Asserts its invariants and raises if the world did not change. Sandbox only. See docs/concepts/sandbox-company.md.';

--- a/supabase/migrations/20260822100000_sandbox-seed-o2c.sql
+++ b/supabase/migrations/20260822100000_sandbox-seed-o2c.sql
@@ -1,0 +1,268 @@
+-- Nordbrygg AB's selling side, seeded by RUNNING it — and consuming the stock
+-- that sandbox_seed_p2p() earned.
+--
+-- This is the half the old scenery got most wrong. Measured before it existed:
+-- six orders with zero quote_id, five invoices with zero order_id, and six
+-- outbound stock moves without a location against zero goods receipts. Read as
+-- a story: sales that came from nowhere, invoices belonging to no order, and
+-- shipments out of an empty warehouse.
+--
+-- Those links are not decoration. `invoices.order_id` exists because the
+-- order-to-cash fix found send_invoice_for_order using the text "order:<uuid>"
+-- in invoices.notes as its idempotency key — an editable field — and a rewritten
+-- note issued a SECOND live invoice for 18 687,50 kr against a customer who had
+-- already paid. `orders.quote_id` exists because there was no conversion at all,
+-- so an agent rebuilt the order by hand and lost the VAT.
+--
+-- So the seed carries every link as a column, and asserts them. Where the real
+-- surface lives in the database it is called — allocate_picking, confirm_pick,
+-- ship_picking are RPCs, and the picking chain is what actually consumes stock.
+-- manage_quote and send_invoice_for_order are edge skills and cannot be reached
+-- from SQL; those steps are written directly, with the links and totals the
+-- skills would produce, and the invariants assert the result rather than trust it.
+--
+-- Sandbox/demo only. Idempotent. See docs/concepts/sandbox-company.md.
+
+CREATE OR REPLACE FUNCTION public.sandbox_seed_o2c()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_is_sandbox boolean;
+  v_beans uuid;
+  v_filter uuid;
+  v_loc uuid;
+  v_quote_won uuid;
+  v_quote_open uuid;
+  v_order uuid;
+  v_invoice uuid;
+  v_picking uuid;
+  v_pick_line uuid;
+  v_alloc jsonb;
+  v_ship jsonb;
+  v_beans_name text;
+  v_quant_before numeric;
+  v_quant_after numeric;
+  v_reserved_after numeric;
+  v_stock_before numeric;
+  v_stock_after numeric;
+  v_sub bigint;
+  v_tax bigint;
+  v_total bigint;
+  v_qty int := 30;
+  v_unit bigint := 34900;
+  v_report jsonb := '{}'::jsonb;
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR public.has_role(auth.uid(), 'admin')) THEN
+    RAISE EXCEPTION 'Only admins can seed the sandbox';
+  END IF;
+
+  SELECT COALESCE(
+           (SELECT (value #>> '{}')::boolean FROM public.site_settings WHERE key = 'sandbox_mode'),
+           (SELECT (value ->> 'enabled')::boolean FROM public.site_settings WHERE key = 'demo_mode'),
+           false)
+    INTO v_is_sandbox;
+  IF NOT COALESCE(v_is_sandbox, false) THEN
+    RAISE EXCEPTION 'sandbox_seed_o2c refused: this instance is neither a sandbox nor a demo';
+  END IF;
+
+  -- The selling side stands on the buying side. Refusing here rather than
+  -- inventing stock is the whole point: an order that ships from a warehouse
+  -- nothing arrived at is the scenery this replaces.
+  SELECT id, name INTO v_beans, v_beans_name
+    FROM public.products WHERE name LIKE 'Söderberg Mörkrost%';
+  SELECT id INTO v_filter FROM public.products WHERE name LIKE 'Vattenfilter FX-200%';
+  IF v_beans IS NULL THEN
+    RAISE EXCEPTION 'sandbox_seed_o2c: run sandbox_seed_p2p() first — there is nothing in stock to sell';
+  END IF;
+  SELECT COALESCE(stock_quantity, 0) INTO v_stock_before FROM public.products WHERE id = v_beans;
+  IF v_stock_before < v_qty THEN
+    RAISE EXCEPTION 'sandbox_seed_o2c: only % in stock, the seeded order needs % — inbound has not run',
+      v_stock_before, v_qty;
+  END IF;
+
+  SELECT id INTO v_loc FROM public.stock_locations
+   WHERE location_type = 'internal' AND COALESCE(is_active, true) LIMIT 1;
+
+  -- Both mirrors, read before anything moves. products.stock_quantity is what
+  -- the storefront and the low-stock alerts read; stock_quants is what the
+  -- warehouse reads. They are supposed to agree, and the invariant below is the
+  -- only thing that would notice if they stopped.
+  SELECT COALESCE(quantity, 0) INTO v_quant_before
+    FROM public.stock_quants WHERE product_id = v_beans AND location_id = v_loc AND lot_id IS NULL;
+  v_quant_before := COALESCE(v_quant_before, 0);
+
+  v_sub   := v_qty * v_unit;
+  v_tax   := (v_sub * 0.25)::bigint;
+  v_total := v_sub + v_tax;
+
+  -- ── 1. The quote that was won ────────────────────────────────────────────
+  IF NOT EXISTS (SELECT 1 FROM public.quotes WHERE notes = 'seed:o2c:won') THEN
+    INSERT INTO public.quotes (
+      quote_number, title, status, customer_name, customer_email, line_items,
+      subtotal_cents, tax_rate, tax_cents, total_cents, currency, discount_cents,
+      version, accepted_at, notes)
+    VALUES (
+      'Q-2026-0118', 'Kaffeleverans — Hotell Norrsken', 'accepted',
+      'Hotell Norrsken AB', 'inkop@hotellnorrsken.example',
+      jsonb_build_array(jsonb_build_object(
+        'description', v_beans_name, 'qty', v_qty,
+        'unit_price_cents', v_unit, 'product_id', v_beans)),
+      v_sub, 0.25, v_tax, v_total, 'SEK', 0, 1, now() - interval '4 days', 'seed:o2c:won')
+    RETURNING id INTO v_quote_won;
+
+    -- ── 2. Quote → order, carrying the link and the VAT-inclusive total ────
+    INSERT INTO public.orders (
+      customer_email, customer_name, status, fulfillment_status,
+      total_cents, currency, quote_id, metadata)
+    VALUES ('inkop@hotellnorrsken.example', 'Hotell Norrsken AB',
+            'paid', 'unfulfilled', v_total, 'SEK', v_quote_won,
+            jsonb_build_object('seed', 'o2c:order'))
+    RETURNING id INTO v_order;
+
+    -- order_items carries price_cents (per unit); there is no line total column.
+    -- The INSERT fires trg_order_item_stock_guard (refuses an oversell) and
+    -- trg_order_item_stock_decrement (writes the outbound move and the quant).
+    INSERT INTO public.order_items (order_id, product_id, product_name, quantity, price_cents)
+    VALUES (v_order, v_beans, v_beans_name, v_qty, v_unit);
+
+    -- The order must carry the quote's accepted total INCLUDING VAT. Losing it
+    -- here is the exact bug the O2C fix closed (1 868 750 → 1 495 000).
+    IF (SELECT total_cents FROM public.orders WHERE id = v_order)
+       <> (SELECT total_cents FROM public.quotes WHERE id = v_quote_won) THEN
+      RAISE EXCEPTION 'sandbox_seed_o2c: order total % does not match the accepted quote total %',
+        (SELECT total_cents FROM public.orders WHERE id = v_order),
+        (SELECT total_cents FROM public.quotes WHERE id = v_quote_won);
+    END IF;
+
+    -- ── 3. Picking — the real RPCs, and what actually consumes the stock ───
+    BEGIN
+      v_alloc := public.allocate_picking(v_order, v_loc);
+      v_picking := (v_alloc ->> 'picking_order_id')::uuid;
+      SELECT id INTO v_pick_line FROM public.picking_lines WHERE picking_order_id = v_picking LIMIT 1;
+      IF v_pick_line IS NOT NULL THEN
+        PERFORM public.confirm_pick(v_pick_line, v_qty);
+        v_ship := public.ship_picking(v_picking, 'SE' || to_char(now(), 'YYYYMMDD') || '0042');
+      END IF;
+      UPDATE public.orders SET fulfillment_status = 'shipped' WHERE id = v_order;
+
+      -- A picking that reserved nothing is not a shipment. Before 20260822080000
+      -- every line came back short (reserve_stock was called with a uuid where
+      -- text was declared, and the handler read 42883 as "not enough stock"),
+      -- so this is the assertion that would have caught it on day one.
+      IF COALESCE((v_ship ->> 'reserved_lines')::int, 0) = 0
+         OR (v_ship ->> 'reserved_lines') <> (v_ship ->> 'consumed_lines') THEN
+        RAISE EXCEPTION 'sandbox_seed_o2c: shipment consumed % of % reserved lines — allocate: %',
+          v_ship ->> 'consumed_lines', v_ship ->> 'reserved_lines', v_alloc ->> 'lines';
+      END IF;
+    EXCEPTION WHEN others THEN
+      -- A picking chain that cannot run is a finding, not something to paper
+      -- over — but it must not stop the rest of the seed, or one broken link
+      -- hides every state downstream of it.
+      v_report := v_report || jsonb_build_object('picking_error', left(SQLERRM, 160));
+    END;
+
+    -- ── 4. Order → invoice, link as a column ──────────────────────────────
+    INSERT INTO public.invoices (
+      invoice_number, order_id, customer_name, customer_email, status,
+      line_items, subtotal_cents, tax_rate, tax_cents, total_cents,
+      currency, issue_date, due_date, paid_amount_cents, notes)
+    VALUES ('F-2026-0311', v_order, 'Hotell Norrsken AB', 'inkop@hotellnorrsken.example', 'sent',
+            jsonb_build_array(jsonb_build_object(
+              'description', v_beans_name, 'qty', v_qty, 'unit_price_cents', v_unit)),
+            v_sub, 0.25, v_tax, v_total, 'SEK',
+            current_date - 3, current_date - 12 + 30, 0, 'seed:o2c:invoice')
+    RETURNING id INTO v_invoice;
+
+    -- Exactly one invoice per order. The phantom-receivable bug issued a second.
+    IF (SELECT count(*) FROM public.invoices WHERE order_id = v_order) <> 1 THEN
+      RAISE EXCEPTION 'sandbox_seed_o2c: order % carries % invoices, expected exactly 1',
+        v_order, (SELECT count(*) FROM public.invoices WHERE order_id = v_order);
+    END IF;
+    -- Σ invoice = order total.
+    IF (SELECT total_cents FROM public.invoices WHERE id = v_invoice)
+       <> (SELECT total_cents FROM public.orders WHERE id = v_order) THEN
+      RAISE EXCEPTION 'sandbox_seed_o2c: invoice total does not equal order total';
+    END IF;
+
+    -- ── 5. The stock invariant ────────────────────────────────────────────
+    SELECT COALESCE(stock_quantity, 0) INTO v_stock_after FROM public.products WHERE id = v_beans;
+    SELECT COALESCE(quantity, 0), COALESCE(reserved_quantity, 0)
+      INTO v_quant_after, v_reserved_after
+      FROM public.stock_quants WHERE product_id = v_beans AND location_id = v_loc AND lot_id IS NULL;
+
+    -- Goods leave once. Order entry owns the balance (trg_order_item_stock_decrement);
+    -- the picking chain owns the reservation. Double-counting here would read as
+    -- 60 kg sold against 30 on the shelf.
+    IF (v_quant_before - COALESCE(v_quant_after, 0)) <> v_qty THEN
+      RAISE EXCEPTION 'sandbox_seed_o2c: the warehouse fell by % on a % unit order (% → %)',
+        v_quant_before - COALESCE(v_quant_after, 0), v_qty, v_quant_before, v_quant_after;
+    END IF;
+    -- The two mirrors must still agree afterwards.
+    IF COALESCE(v_quant_after, 0) <> v_stock_after THEN
+      RAISE EXCEPTION 'sandbox_seed_o2c: stock_quants says % and products.stock_quantity says %',
+        v_quant_after, v_stock_after;
+    END IF;
+    -- And nothing is left held for an order that already shipped. Skipped when
+    -- the picking chain itself failed — that failure is already reported, and
+    -- aborting here would roll the report back with it.
+    IF NOT (v_report ? 'picking_error') AND COALESCE(v_reserved_after, 0) <> 0 THEN
+      RAISE EXCEPTION 'sandbox_seed_o2c: % units still reserved after the order shipped', v_reserved_after;
+    END IF;
+
+    v_report := v_report || jsonb_build_object('won', jsonb_build_object(
+      'quote', 'Q-2026-0118', 'order_total_cents', v_total, 'invoice', 'F-2026-0311',
+      'qty', v_qty,
+      'stock_quantity_before', v_stock_before, 'stock_quantity_after', v_stock_after,
+      'quant_before', v_quant_before, 'quant_after', v_quant_after,
+      'reserved_after', COALESCE(v_reserved_after, 0),
+      'shipment', v_ship));
+  END IF;
+
+  -- ── 6. In flight: a quote sent and unanswered ────────────────────────────
+  IF NOT EXISTS (SELECT 1 FROM public.quotes WHERE notes = 'seed:o2c:open') THEN
+    INSERT INTO public.quotes (
+      quote_number, title, status, customer_name, customer_email, line_items,
+      subtotal_cents, tax_rate, tax_cents, total_cents, currency, discount_cents,
+      version, valid_until, sent_at, notes)
+    VALUES ('Q-2026-0124', 'Serviceavtal + filterbyten — Café Ekot', 'sent',
+            'Café Ekot AB', 'hej@cafeekot.example',
+            jsonb_build_array(jsonb_build_object(
+              'description', 'Vattenfilter FX-200', 'qty', 6,
+              'unit_price_cents', 89900, 'product_id', v_filter)),
+            539400, 0.25, 134850, 674250, 'SEK', 0, 1,
+            current_date + 11, now() - interval '6 days', 'seed:o2c:open')
+    RETURNING id INTO v_quote_open;
+    v_report := v_report || jsonb_build_object('open_quote',
+      jsonb_build_object('quote', 'Q-2026-0124', 'sent_days_ago', 6, 'valid_for_days', 11));
+  END IF;
+
+  -- ── 7. In flight: an invoice overdue by 12 days ──────────────────────────
+  IF NOT EXISTS (SELECT 1 FROM public.invoices WHERE notes = 'seed:o2c:overdue') THEN
+    INSERT INTO public.invoices (
+      invoice_number, customer_name, customer_email, status, line_items,
+      subtotal_cents, tax_rate, tax_cents, total_cents, currency,
+      issue_date, due_date, paid_amount_cents, notes)
+    VALUES ('F-2026-0288', 'Kontorshuset Vasa AB', 'faktura@kontorshusetvasa.example', 'sent',
+            jsonb_build_array(jsonb_build_object(
+              'description', 'Serviceavtal, kvartal', 'qty', 1, 'unit_price_cents', 480000)),
+            480000, 0.25, 120000, 600000, 'SEK',
+            current_date - 42, current_date - 12, 0, 'seed:o2c:overdue')
+    RETURNING id INTO v_invoice;
+    v_report := v_report || jsonb_build_object('overdue_invoice',
+      jsonb_build_object('invoice', 'F-2026-0288', 'days_overdue', 12));
+  END IF;
+
+  RETURN jsonb_build_object(
+    'seeded', true,
+    'chain', 'order-to-cash',
+    'detail', v_report,
+    'note', 'Every order carries its quote, every invoice carries its order, and the stock it shipped was earned.');
+END; $fn$;
+
+GRANT EXECUTE ON FUNCTION public.sandbox_seed_o2c() TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.sandbox_seed_o2c() IS
+  'Seeds Nordbrygg AB''s selling side on top of the stock sandbox_seed_p2p() earned. Refuses if inbound has not run. Asserts quote→order→invoice links and totals. Sandbox/demo only.';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260822050000",
-      "migrations_count": 472,
+      "migration_head": "20260822090000",
+      "migrations_count": 473,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1893,6 +1893,10 @@
         {
           "version": "20260822050000",
           "name": "e7f8a9b0-policy-user-roles-refs-via-definer"
+        },
+        {
+          "version": "20260822090000",
+          "name": "sandbox-seed-p2p"
         }
       ]
     },

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260822090000",
-      "migrations_count": 473,
+      "migration_head": "20260822100000",
+      "migrations_count": 475,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1895,8 +1895,16 @@
           "name": "e7f8a9b0-policy-user-roles-refs-via-definer"
         },
         {
+          "version": "20260822080000",
+          "name": "the-outbound-chain-never-ran"
+        },
+        {
           "version": "20260822090000",
           "name": "sandbox-seed-p2p"
+        },
+        {
+          "version": "20260822100000",
+          "name": "sandbox-seed-o2c"
         }
       ]
     },


### PR DESCRIPTION
Sådd-programmet ur [`sandbox-company.md`](../blob/main/docs/concepts/sandbox-company.md), båda spåren. Bygger Nordbryggs verksamhet genom **den riktiga ytan** — `receive_purchase_order`, `allocate_picking`, `confirm_pick`, `ship_picking` — inte `INSERT INTO stock_moves`, och påstår sina egna invarianter.

Andra commiten är inte såddkod. Det är tre buggar som såddkoden fann genom att försöka köra.

---

# Plockkedjan har aldrig flyttat en enda enhet

`sandbox_seed_o2c()` säljer 30 kg ur de 120 kg som `sandbox_seed_p2p()` tog emot, och **påstår att lagret sjunker**. Det gjorde det inte. Tre skäl, alla samma form: **ett anrop som inte kan resolvas, inlindat i en hanterare som svarar success.**

### 1. `allocate_picking` kunde aldrig reservera

```sql
v_reservation_id := public.reserve_stock(
  v_item.product_id, v_source_location, v_item.quantity,
  'picking_order', v_picking_id);        -- uuid, mot deklarerad text
```

`p_reference_id` är `text`. Det finns ingen implicit cast uuid→text, så Postgres kastar `42883 function does not exist` — och `EXCEPTION WHEN OTHERS` bokförde det som **slut i lager**.

Varje plockrad som någonsin allokerats, på varje instans sedan baselinen, kom ut `status='short'` med `reservation_id NULL`. Kuvertet sa `{"success": true}`.

### 2. `ship_picking` skickade kvantitet där en lokationskod deklareras

```sql
PERFORM public.consume_reservation(v_line.reservation_id, v_line.qty_picked);
```

Andra parametern är `p_to_location_code text` — en **lokationskod**. `42883` igen, sväljd ner i en revisionsrad ingen läser. `consumed_lines` kom tillbaka `0` och ordern vändes till `'shipped'` ändå.

### 3. Lagade skulle de två ha dubbelräknat

`trg_order_item_stock_decrement` (20260820210005) skriver redan den utgående rörelsen och kvantdeltat **vid orderrad-insert**. Ett andra delta vid leverans tar 30 enheter ur böckerna två gånger medan 30 står kvar på hyllan.

---

## Vad som rättas, och vad som är ett beslut

1 och 2 **kunde inte fungera som skrivna** — de rättas rakt av.

3 är ett val, så det görs explicit: `consume_reservation` fick `p_move_stock` (default `true`, varje befintlig anropare och skillen orörd), och `ship_picking` skickar `false` för en orderkopplad plockning.

**En skrivare per saldo.** `order_items` äger kvantiteten; plockkedjan äger reservationens livscykel och leveransposten. Det **avviker från Odoo**, där leveransorderns validering flyttar lagret och ordern bara reserverar — utskrivet i migrationen så nästa person möter beslutet i stället för att härleda det ur en avvikelse.

## Tystnaden själv

Båda hanterarna kastar nu vidare `undefined_function`/`undefined_column`/`undefined_table` och behåller affärsutfallet.

`EXCEPTION WHEN OTHERS` kan inte skilja **"det finns inte tillräckligt i lager"** (verkligt, och ett giltigt svar) från **"den funktionen finns inte"** (en defekt). Att slå ihop dem är vad som lät det här överleva tills en process kördes skarpt mot det.

- en kort rad bär nu **varför** den gick kort, i `picking_lines.notes`
- `ship_picking` returnerar `reserved_lines` bredvid `consumed_lines`, så en anropare som bara läser `success` inte längre kan förväxla en statusändring med en leverans

## En fjärde, funnen i syncen mot anon-härdningen

Att vidga `consume_reservation`s signatur krävde en `DROP` — och **en nyskapad funktion är EXECUTE-bar av PUBLIC** om inget säger annat. Min recreate återarmade alltså anon på en SECURITY DEFINER-funktion som flyttar lager, precis den klass fb7d9e5/dd322e6 nyss stängde.

Live-läget innan revoken (och `allocate_picking` / `ship_picking` var likadana **redan före den här grenen**, rakt ur baselinen):

```
consume_reservation:  =X/postgres | anon=X/postgres | authenticated | service_role
allocate_picking:     =X/postgres | anon=X/postgres | ...
ship_picking:         =X/postgres | anon=X/postgres | ...
```

Efter:

```
postgres=X/postgres | authenticated=X/postgres | service_role=X/postgres
```

`ALTER DEFAULT PRIVILEGES` täcker det framåt, men en migration får inte förlita sig på att ha applicerats efter en annan. Tre funktioner som muterar lagret har inget att göra utan session.

> **Kvarstående, inte ändrat här:** `allocate_picking`s egen vakt släpper igenom `auth.uid() IS NULL`. Med anon-revoken är den oåtkomlig ändå, men vakten är fortfarande fel formulerad.

---

# Sådden

## P2P — inkommande

```
po_full      120 mottagna · saldo 0 → 120
po_partial   40 beställda, 25 mottagna → restnotering 15
po_awaiting  Caffè Milano, EUR, leverans om 9 dagar
vendor_bill  SR-2026-0413, omatchad mot mottagen PO
```

Tre PO:er, var och en parkerad där buggar faktiskt bor. Funktionen **kastar** om saldot inte rörde sig med det mottagna antalet.

Behövs P2P? Inkommande är förutsättningen — ingenting kan levereras, returneras eller restockas som aldrig kommit in. Men ett företag som handlat sedan 2019 har inte varje enhet spårbar till en inköpsorder, så **historiken hör hemma i en ingående lagerjustering** (Odoos egen konvention) och bara det senaste fönstret spelas genom skarpa PO:er.

## O2C — utgående

Offert `Q-2026-0118` accepterad → order som bär `quote_id` **och totalen inklusive moms** → plockning genom de skarpa RPC:erna → faktura `F-2026-0311` som bär `order_id`. Plus en offert i luften och en faktura 12 dagar förfallen.

Funktionen **vägrar köra om P2P inte gjort det** — att uppfinna lager i stället vore precis den kulissen den ersätter.

### Invarianter den påstår

| | |
|---|---|
| ordertotal = accepterad offerttotal | 1 308 750 (momsen var buggen som tappade den) |
| exakt en faktura per order | fantomfordran-buggen utfärdade en andra |
| lagret sjunker med orderantalet **en gång** | dubbelräkningen ovan |
| båda lagerspeglarna stämmer efteråt | `stock_quants` mot `products.stock_quantity` |
| inget kvar reserverat | reservationen konsumerad, inte strandad |

## Bevisat live på sandbox

```
120 in  · WH/VENDORS → WH/MAIN   (goods_receipt)
 30 ut  · WH/MAIN → WH/CUSTOMERS (order)
 90 kvar · quants 90, products.stock_quantity 90, reserverat 0
reservation: consumed
1 reserverad rad, 1 konsumerad  ← var 0 och 0 före rättningen
```

Andra körningen ändrar ingenting. Idempotent genom att hitta sina egna rader. Kördes om efter revoken — båda kedjorna svarar fortfarande `true`.

---

## Fynd rapporterade i stället för ändrade

**Grinden band till fel flagga.** `sandbox.flowwink.com` bär `demo_mode.enabled` och **inte** `sandbox_mode`. En grind som binder till en flagga instansen inte sätter är en grind som aldrig binder. Båda accepteras nu.

**Kulissgeneratorn är en rad** — `restock_demo_products`:

```sql
UPDATE products SET stock_quantity = GREATEST(50, COALESCE(low_stock_threshold, 5) * 10)
```

Saldot **tilldelas, tas aldrig emot**: ingen mottagning, ingen rörelse, ingen lokation, ingen kostnad. Exakt därför sandbox visade sex utgående rörelser mot noll mottagningar. Den upprepar dessutom den magiska femman från #247. `demo-cycle` sår varje demoinstans, så att byta tilldelning mot intjänande är ett beslut om allihop.

**#249 — `ship_picking` skriver över betalningsstatus.** Ordern gick in som `'paid'` och kom ut som `'shipped'`; `fulfillment_status` står direkt bredvid och bär redan samma värde. Två axlar delar ett fält. Rättningen är en rad, men `orders.status` läses av storefront och orderlistor, så det är en ändring med app-lagerkonsekvenser — egen ändring.

## Efter merge

Plockkedjan är trasig på **varje instans**, inte bara sandbox — alla tre kopiorna av `allocate_picking` i historiken bär samma anrop, senast `20260821010000`. Migrationen är framåtdaterad så managed-instanser applicerar den, men **forken auto-deployar inte från main-push**.

Verifiering per instans måste vara en skarp körning, inte `pg_proc`: namnet fanns hela tiden, det var kroppen som var fel.

## Nästa steg

Att koppla in sådden i `demo-cycle`s modulsåddare är där intjänat saldo ersätter tilldelat på riktigt. Ramverket finns (`seed_module_demo` + `demo_seedable_modules`) — kroken finns, valet återstår.

---

Rebasad på `dd322e6`. `tsc` rent, svit grön.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5
