### PR TITLE
fix(inventory): returnerade varor kom tillbaka värderade till noll — RMA-kedjan sås genom att KÖRAS

### DIFF
--- a/supabase/migrations/20260822105000_goods-come-back-at-a-cost.sql
+++ b/supabase/migrations/20260822105000_goods-come-back-at-a-cost.sql
@@ -1,0 +1,178 @@
+-- Returned goods re-entered the warehouse valued at nothing.
+--
+-- Found by running the RMA chain. sandbox_seed_rma() sends 5 kg of coffee back
+-- from a customer; the quantity came back correctly (90 → 95, both mirrors),
+-- and the valuation layer it created reads:
+--
+--   quantity 5.000 · unit_cost_cents 0 · value_cents 0
+--
+-- against the receipt layer beside it, which reads 120 @ 18 500. So the shelf
+-- holds 95 kg and the books say it is worth 90 kg — and when those 5 kg are
+-- sold, COGS for them is zero and the gross margin on that sale is overstated
+-- by the whole cost.
+--
+-- Two absences, both filled here with a number the system already had.
+--
+-- ── 1. A receipt never taught the product what it cost ─────────────────────
+-- resolve_inbound_unit_cost reads the PO line directly for a goods_receipt, so
+-- receipts are valued correctly. Every OTHER inbound movement — a customer
+-- return, a manual adjustment, an event-driven restock — falls through to
+-- products.cost_cents, which no code path has ever written. On this sandbox:
+-- 7 products, 7 without a cost, including two that had been received against
+-- priced purchase orders minutes earlier.
+--
+-- Purchasing knew the price. Valuation knew the price. The product did not.
+--
+-- Filling it only when NULL is deliberate: this learns a cost, it does not
+-- impose a costing policy. An operator's standard cost is never overwritten.
+--
+-- ── 2. Zero is not a cost, it is the absence of one ───────────────────────
+-- When nothing supplies a unit cost, the inbound branch booked 0 and moved on.
+-- For goods coming back that the warehouse already carries, the answer is
+-- sitting in the layers: the weighted average of what is still on hand. That
+-- is the standard treatment of a customer return under average costing, and
+-- the same figure the outbound branch computes for COGS twenty lines below.
+--
+-- Idempotent, and forward-dated so managed instances actually apply it.
+
+CREATE OR REPLACE FUNCTION public.process_stock_move_valuation()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_qty numeric := abs(COALESCE(NEW.quantity,0));
+  v_is_in boolean;
+  v_method text;
+  v_unit_cost bigint;
+  v_total_cost bigint := 0;
+  v_layer RECORD;
+  v_take numeric;
+  v_remaining numeric;
+  v_avg numeric;
+  v_je uuid;
+  v_is_purchase boolean;
+BEGIN
+  IF v_qty = 0 THEN RETURN NEW; END IF;
+  IF NEW.move_type NOT IN ('in','out','mo_production','mo_consumption') THEN RETURN NEW; END IF;
+  v_is_in := (NEW.move_type IN ('in','mo_production')) AND COALESCE(NEW.quantity,0) > 0;
+  v_is_purchase := NEW.reference_type IN ('purchase_order','po','goods_receipt');
+
+  IF v_is_in THEN
+    v_unit_cost := COALESCE(NEW.unit_cost_cents,
+                            resolve_inbound_unit_cost(NEW.product_id, NEW.reference_type, NEW.reference_id));
+
+    -- Goods coming back that the warehouse already carries re-enter at what it
+    -- carries them at. Only when nothing else supplied a cost — a receipt's PO
+    -- price and an explicit unit_cost_cents both still win.
+    IF COALESCE(v_unit_cost, 0) = 0 THEN
+      SELECT CASE WHEN sum(remaining_qty) > 0
+                  THEN round(sum(remaining_qty * unit_cost_cents) / sum(remaining_qty)) END
+        INTO v_unit_cost
+        FROM stock_valuation_layers
+       WHERE product_id = NEW.product_id AND remaining_qty > 0;
+      -- Still nothing on hand to average against: the product's standing cost.
+      IF COALESCE(v_unit_cost, 0) = 0 THEN
+        SELECT cost_cents INTO v_unit_cost FROM products WHERE id = NEW.product_id;
+      END IF;
+      v_unit_cost := COALESCE(v_unit_cost, 0);
+    END IF;
+
+    INSERT INTO stock_valuation_layers (product_id, variant_id, move_id, quantity, unit_cost_cents, value_cents, remaining_qty)
+    VALUES (NEW.product_id, NEW.variant_id, NEW.id, v_qty, v_unit_cost, round(v_qty * v_unit_cost), v_qty);
+    UPDATE stock_moves SET unit_cost_cents = v_unit_cost, value_cents = round(v_qty * v_unit_cost)
+      WHERE id = NEW.id;
+
+    -- What was paid for it is what it costs. Learned once, from the receipt
+    -- that knew; never overwritten, so a standard cost an operator set stands.
+    IF v_is_purchase AND v_unit_cost > 0 THEN
+      UPDATE products
+         SET cost_cents = v_unit_cost, updated_at = now()
+       WHERE id = NEW.product_id AND cost_cents IS NULL;
+    END IF;
+
+    IF v_is_purchase AND v_unit_cost > 0 THEN
+      BEGIN
+        INSERT INTO journal_entries (entry_date, description, source, status)
+        VALUES (CURRENT_DATE, 'Inventory receipt '||COALESCE(NEW.reference_id,''), 'inventory_receipt', 'posted')
+        RETURNING id INTO v_je;
+        INSERT INTO journal_entry_lines (journal_entry_id, account_code, debit_cents, credit_cents, description)
+        VALUES (v_je, '1460', round(v_qty*v_unit_cost), 0, 'Lager av handelsvaror'),
+               (v_je, '2441', 0, round(v_qty*v_unit_cost), 'GRNI — ej fakturerade leveranser');
+      EXCEPTION WHEN others THEN
+        RAISE NOTICE 'inventory_receipt JE skipped: %', SQLERRM;
+      END;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  SELECT COALESCE(pc.costing_method,'average') INTO v_method
+  FROM products p LEFT JOIN product_categories pc ON pc.id = p.category_id
+  WHERE p.id = NEW.product_id;
+  v_method := COALESCE(v_method,'average');
+
+  IF v_method = 'average' THEN
+    SELECT CASE WHEN sum(remaining_qty) > 0
+                THEN sum(remaining_qty * unit_cost_cents) / sum(remaining_qty) END
+    INTO v_avg FROM stock_valuation_layers
+    WHERE product_id = NEW.product_id AND remaining_qty > 0;
+  END IF;
+
+  v_remaining := v_qty;
+  FOR v_layer IN
+    SELECT id, remaining_qty, unit_cost_cents FROM stock_valuation_layers
+    WHERE product_id = NEW.product_id AND remaining_qty > 0
+    ORDER BY created_at, id
+    FOR UPDATE
+  LOOP
+    EXIT WHEN v_remaining <= 0;
+    v_take := LEAST(v_layer.remaining_qty, v_remaining);
+    v_total_cost := v_total_cost + round(v_take * CASE WHEN v_method='average' THEN v_avg ELSE v_layer.unit_cost_cents END);
+    UPDATE stock_valuation_layers SET remaining_qty = remaining_qty - v_take WHERE id = v_layer.id;
+    v_remaining := v_remaining - v_take;
+  END LOOP;
+  IF v_remaining > 0 THEN
+    SELECT COALESCE(v_avg, cost_cents, 0) INTO v_unit_cost FROM products WHERE id = NEW.product_id;
+    v_total_cost := v_total_cost + round(v_remaining * COALESCE(v_unit_cost,0));
+  END IF;
+
+  UPDATE stock_moves SET
+    unit_cost_cents = CASE WHEN v_qty > 0 THEN round(v_total_cost / v_qty) ELSE NULL END,
+    value_cents = v_total_cost
+  WHERE id = NEW.id;
+
+  IF NEW.reference_type IN ('order','pos_sale') AND v_total_cost > 0 THEN
+    BEGIN
+      INSERT INTO journal_entries (entry_date, description, source, status)
+      VALUES (CURRENT_DATE, 'COGS '||NEW.reference_type||' '||COALESCE(NEW.reference_id,''), 'inventory_cogs', 'posted')
+      RETURNING id INTO v_je;
+      INSERT INTO journal_entry_lines (journal_entry_id, account_code, debit_cents, credit_cents, description)
+      VALUES (v_je, '4990', v_total_cost, 0, 'Kostnad sålda varor'),
+             (v_je, '1460', 0, v_total_cost, 'Lager av handelsvaror');
+    EXCEPTION WHEN others THEN
+      RAISE NOTICE 'inventory_cogs JE skipped: %', SQLERRM;
+    END;
+  END IF;
+  RETURN NEW;
+END $function$;
+
+-- Backfill: products that have been received against a priced purchase order
+-- but never learned the price. Fills blanks only — an operator's standard cost
+-- is left alone, and re-running changes nothing.
+--
+-- Historical zero-valued layers are deliberately NOT rewritten. Restating an
+-- inventory valuation that has already been posted to the journal is an
+-- accounting act, not a migration; see the issue this ships with.
+UPDATE public.products p
+   SET cost_cents = src.unit_price_cents, updated_at = now()
+  FROM (
+    SELECT DISTINCT ON (pol.product_id)
+           pol.product_id, pol.unit_price_cents
+      FROM public.purchase_order_lines pol
+      JOIN public.purchase_orders po ON po.id = pol.purchase_order_id
+     WHERE pol.unit_price_cents > 0
+       AND COALESCE(pol.received_quantity, 0) > 0
+     ORDER BY pol.product_id, po.created_at DESC
+  ) src
+ WHERE p.id = src.product_id AND p.cost_cents IS NULL;

--- a/supabase/migrations/20260822110000_sandbox-seed-rma.sql
+++ b/supabase/migrations/20260822110000_sandbox-seed-rma.sql
@@ -1,0 +1,253 @@
+-- Nordbrygg AB's returns, seeded by RUNNING them — and putting goods back on
+-- the shelf they were actually taken from.
+--
+-- The third chain. P2P earned the stock, O2C sold it, this brings some of it
+-- back. Returns are where the two directions meet, so it is the first chain
+-- that can contradict itself: a refund is money leaving against goods arriving,
+-- and either half can silently fail to happen.
+--
+-- Called through the real surface — approve_return, receive_return,
+-- inspect_return, refund_return are all RPCs and all get called. return_items
+-- are written directly (manage_return_item is an edge skill and cannot be
+-- reached from SQL), with the fields the skill would set.
+--
+-- Sandbox/demo only. Idempotent. See docs/concepts/sandbox-company.md.
+
+CREATE OR REPLACE FUNCTION public.sandbox_seed_rma()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_is_sandbox boolean;
+  v_beans uuid;
+  v_beans_name text;
+  v_loc uuid;
+  v_order uuid;
+  v_order_item uuid;
+  v_rma uuid;
+  v_line uuid;
+  v_refund1 jsonb;
+  v_refund2 jsonb;
+  v_mirror_before numeric;
+  v_mirror_after numeric;
+  v_quant_before numeric;
+  v_quant_after numeric;
+  v_qty int := 5;
+  v_unit bigint := 34900;
+  v_fee bigint := 2000;
+  v_expected bigint;
+  v_first bigint := 100000;
+  v_valued_qty numeric;
+  v_valued_cents numeric;
+  v_layer_cost bigint;
+  v_report jsonb := '{}'::jsonb;
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR public.has_role(auth.uid(), 'admin')) THEN
+    RAISE EXCEPTION 'Only admins can seed the sandbox';
+  END IF;
+
+  SELECT COALESCE(
+           (SELECT (value #>> '{}')::boolean FROM public.site_settings WHERE key = 'sandbox_mode'),
+           (SELECT (value ->> 'enabled')::boolean FROM public.site_settings WHERE key = 'demo_mode'),
+           false)
+    INTO v_is_sandbox;
+  IF NOT COALESCE(v_is_sandbox, false) THEN
+    RAISE EXCEPTION 'sandbox_seed_rma refused: this instance is neither a sandbox nor a demo';
+  END IF;
+
+  -- A return needs something that was sold. Refusing beats inventing an RMA
+  -- against an order that never existed — that is the scenery this replaces.
+  SELECT o.id INTO v_order
+    FROM public.orders o
+   WHERE o.quote_id IS NOT NULL AND o.metadata ->> 'seed' = 'o2c:order'
+   LIMIT 1;
+  IF v_order IS NULL THEN
+    RAISE EXCEPTION 'sandbox_seed_rma: run sandbox_seed_o2c() first — there is no order to return against';
+  END IF;
+
+  SELECT oi.id, oi.product_id INTO v_order_item, v_beans
+    FROM public.order_items oi WHERE oi.order_id = v_order LIMIT 1;
+  SELECT name INTO v_beans_name FROM public.products WHERE id = v_beans;
+
+  SELECT id INTO v_loc FROM public.stock_locations
+   WHERE code = 'WH/MAIN' AND COALESCE(is_active, true) LIMIT 1;
+  IF v_loc IS NULL THEN
+    SELECT id INTO v_loc FROM public.stock_locations
+     WHERE location_type = 'internal' AND COALESCE(is_active, true) LIMIT 1;
+  END IF;
+
+  -- ── 1. The RMA that went all the way: goods back, money out ──────────────
+  IF NOT EXISTS (SELECT 1 FROM public.returns WHERE internal_notes LIKE 'seed:rma:full%') THEN
+    SELECT COALESCE(stock_quantity, 0) INTO v_mirror_before FROM public.products WHERE id = v_beans;
+    SELECT COALESCE(quantity, 0) INTO v_quant_before
+      FROM public.stock_quants WHERE product_id = v_beans AND location_id = v_loc AND lot_id IS NULL;
+
+    INSERT INTO public.returns (order_id, status, reason, reason_code, customer_notes, internal_notes)
+    VALUES (v_order, 'requested', 'Beställde för mycket till konferensveckan',
+            'changed_mind', 'Oöppnade påsar, ligger kvar i originalkartongen.',
+            'seed:rma:full')
+    RETURNING id INTO v_rma;
+
+    -- condition drives suggested_action via trg_return_item_action:
+    -- 'unopened' → 'restock'. `restock` is the field receive_return actually
+    -- reads, so it is set here, where the line is created.
+    INSERT INTO public.return_items (
+      return_id, order_item_id, product_id, quantity, unit_refund_cents, condition, restock, notes)
+    VALUES (v_rma, v_order_item, v_beans, v_qty, v_unit, 'unopened', true,
+            'Obruten försegling, bäst före 2027-03.')
+    RETURNING id INTO v_line;
+
+    PERFORM public.approve_return(v_rma, 'Inom 14 dagar, oöppnat — godkänt.');
+
+    -- Receiving is what books the goods back in: it emits a stock.movement
+    -- event whose trigger mirrors products.stock_quantity AND the quant.
+    PERFORM public.receive_return(v_rma);
+
+    SELECT COALESCE(stock_quantity, 0) INTO v_mirror_after FROM public.products WHERE id = v_beans;
+    SELECT COALESCE(quantity, 0) INTO v_quant_after
+      FROM public.stock_quants WHERE product_id = v_beans AND location_id = v_loc AND lot_id IS NULL;
+
+    -- Goods came back. An RMA that refunds without restocking is a warehouse
+    -- that pays for coffee it never got — the mirror image of the picking
+    -- chain that shipped without deducting.
+    IF (COALESCE(v_mirror_after, 0) - v_mirror_before) <> v_qty THEN
+      RAISE EXCEPTION 'sandbox_seed_rma: products.stock_quantity moved by % on a % unit return (% → %)',
+        COALESCE(v_mirror_after, 0) - v_mirror_before, v_qty, v_mirror_before, v_mirror_after;
+    END IF;
+    IF (COALESCE(v_quant_after, 0) - v_quant_before) <> v_qty THEN
+      RAISE EXCEPTION 'sandbox_seed_rma: the quant moved by % on a % unit return (% → %)',
+        COALESCE(v_quant_after, 0) - v_quant_before, v_qty, v_quant_before, v_quant_after;
+    END IF;
+    -- And the two still agree, as they must after any physical movement.
+    IF COALESCE(v_quant_after, 0) <> COALESCE(v_mirror_after, 0) THEN
+      RAISE EXCEPTION 'sandbox_seed_rma: stock_quants says % and products.stock_quantity says %',
+        v_quant_after, v_mirror_after;
+    END IF;
+
+    -- Goods that came back must come back at a COST, not just as a count.
+    -- Before 20260822105000 this layer was booked at zero: the shelf held 95 kg
+    -- and the books valued 90. Selling those 5 kg would then have posted a COGS
+    -- of nothing and overstated the margin by the whole cost.
+    SELECT l.unit_cost_cents INTO v_layer_cost
+      FROM public.stock_valuation_layers l
+      JOIN public.stock_moves m ON m.id = l.move_id
+     WHERE l.product_id = v_beans AND m.notes = 'rma_restock'
+     ORDER BY l.created_at DESC LIMIT 1;
+    IF COALESCE(v_layer_cost, 0) <= 0 THEN
+      RAISE EXCEPTION 'sandbox_seed_rma: % kg came back valued at % — zero is not a cost',
+        v_qty, COALESCE(v_layer_cost, 0);
+    END IF;
+
+    -- The whole point, stated once: every unit on the shelf is a unit in the
+    -- books. A quantity the valuation does not know about is stock that shows
+    -- up in the warehouse and vanishes from the balance sheet.
+    SELECT COALESCE(SUM(remaining_qty), 0), COALESCE(SUM(remaining_qty * unit_cost_cents), 0)
+      INTO v_valued_qty, v_valued_cents
+      FROM public.stock_valuation_layers WHERE product_id = v_beans;
+    IF v_valued_qty <> COALESCE(v_mirror_after, 0) THEN
+      RAISE EXCEPTION 'sandbox_seed_rma: % units on hand but % valued', v_mirror_after, v_valued_qty;
+    END IF;
+
+    -- QC sets the restocking fee. Only valid in status 'received'.
+    PERFORM public.inspect_return(v_rma, 'Fem påsar, obrutna. 2 % hanteringsavgift.', v_fee);
+
+    -- The payout, in two calls, because the platform supports partial refunds
+    -- and a seed that only ever pays in one go never exercises the running
+    -- total or its ceiling.
+    v_expected := v_qty * v_unit - v_fee;
+    v_refund1 := public.refund_return(v_rma, v_first::int, 'bank_transfer', false);
+    IF (v_refund1 ->> 'status') = 'refunded' THEN
+      RAISE EXCEPTION 'sandbox_seed_rma: a partial refund of % closed an RMA expecting %', v_first, v_expected;
+    END IF;
+    v_refund2 := public.refund_return(v_rma, (v_expected - v_first)::int, 'bank_transfer', true);
+
+    IF (SELECT refund_amount_cents FROM public.returns WHERE id = v_rma) <> v_expected THEN
+      RAISE EXCEPTION 'sandbox_seed_rma: refunded % but expected % (% lines − % fee)',
+        (SELECT refund_amount_cents FROM public.returns WHERE id = v_rma),
+        v_expected, v_qty * v_unit, v_fee;
+    END IF;
+    IF (SELECT status FROM public.returns WHERE id = v_rma) <> 'refunded' THEN
+      RAISE EXCEPTION 'sandbox_seed_rma: RMA paid in full but status is %',
+        (SELECT status FROM public.returns WHERE id = v_rma);
+    END IF;
+
+    v_report := v_report || jsonb_build_object('full', jsonb_build_object(
+      'rma', (SELECT rma_number FROM public.returns WHERE id = v_rma),
+      'qty', v_qty,
+      'stock_before', v_mirror_before, 'stock_after', v_mirror_after,
+      'quant_before', v_quant_before, 'quant_after', v_quant_after,
+      'gross_cents', v_qty * v_unit, 'fee_cents', v_fee,
+      'refunded_cents', v_expected,
+      'restocked_at_cost_cents', v_layer_cost,
+      'inventory_valued_qty', v_valued_qty,
+      'inventory_value_cents', v_valued_cents,
+      'refunds', jsonb_build_array(v_refund1, v_refund2)));
+  END IF;
+
+  -- ── 2. Damaged in transit: received, and deliberately NOT restocked ──────
+  IF NOT EXISTS (SELECT 1 FROM public.returns WHERE internal_notes LIKE 'seed:rma:damaged%') THEN
+    SELECT COALESCE(stock_quantity, 0) INTO v_mirror_before FROM public.products WHERE id = v_beans;
+
+    INSERT INTO public.returns (order_id, status, reason, reason_code, customer_notes, internal_notes)
+    VALUES (v_order, 'requested', 'Två påsar spruckna vid leverans',
+            'damaged_in_transit', 'Kartongen var blöt när den kom.',
+            'seed:rma:damaged')
+    RETURNING id INTO v_rma;
+
+    -- 'damaged' → suggested_action 'rtv'. restock stays false: goods that came
+    -- back broken must not reappear as sellable stock. This is the half of the
+    -- flow an assertion is worth on — a restock that fires when it should not
+    -- is as wrong as one that does not fire when it should.
+    INSERT INTO public.return_items (
+      return_id, order_item_id, product_id, quantity, unit_refund_cents, condition, restock, notes)
+    VALUES (v_rma, v_order_item, v_beans, 2, v_unit, 'damaged', false,
+            'Fuktskadade, reklameras mot transportör.');
+
+    PERFORM public.approve_return(v_rma, 'Transportskada — ersätts, varan skrotas.');
+    PERFORM public.receive_return(v_rma);
+
+    SELECT COALESCE(stock_quantity, 0) INTO v_mirror_after FROM public.products WHERE id = v_beans;
+    IF COALESCE(v_mirror_after, 0) <> v_mirror_before THEN
+      RAISE EXCEPTION 'sandbox_seed_rma: damaged goods were booked back in (% → %)',
+        v_mirror_before, v_mirror_after;
+    END IF;
+
+    -- Parked at 'received', un-inspected on purpose: this is the RMA that has
+    -- work waiting for a human, and the state an empty demo never shows.
+    v_report := v_report || jsonb_build_object('damaged', jsonb_build_object(
+      'rma', (SELECT rma_number FROM public.returns WHERE id = v_rma),
+      'qty', 2, 'restocked', false, 'awaiting', 'inspection',
+      'stock_unchanged_at', v_mirror_after));
+  END IF;
+
+  -- ── 3. In flight: requested, waiting for someone to approve it ───────────
+  IF NOT EXISTS (SELECT 1 FROM public.returns WHERE internal_notes LIKE 'seed:rma:open%') THEN
+    INSERT INTO public.returns (order_id, status, reason, reason_code, customer_notes, internal_notes)
+    VALUES (v_order, 'requested', 'Fel malningsgrad — ville ha bryggmalet',
+            'wrong_item', 'Kan jag byta mot bryggmalet i stället?', 'seed:rma:open')
+    RETURNING id INTO v_rma;
+
+    INSERT INTO public.return_items (
+      return_id, order_item_id, product_id, quantity, unit_refund_cents, condition, restock)
+    VALUES (v_rma, v_order_item, v_beans, 1, v_unit, 'unopened', true);
+
+    v_report := v_report || jsonb_build_object('open', jsonb_build_object(
+      'rma', (SELECT rma_number FROM public.returns WHERE id = v_rma),
+      'qty', 1, 'awaiting', 'approval'));
+  END IF;
+
+  RETURN jsonb_build_object(
+    'seeded', true,
+    'chain', 'return-to-refund',
+    'detail', v_report,
+    'note', 'Goods that came back are on the shelf again, the money that went out matches the lines minus the fee, and the broken ones stayed off it.');
+END; $fn$;
+
+REVOKE EXECUTE ON FUNCTION public.sandbox_seed_rma() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.sandbox_seed_rma() FROM anon;
+GRANT EXECUTE ON FUNCTION public.sandbox_seed_rma() TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.sandbox_seed_rma() IS
+  'Seeds Nordbrygg AB''s returns on top of the order sandbox_seed_o2c() shipped. Refuses if O2C has not run. Asserts that restocked goods come back, damaged goods do not, and the refund equals lines minus the restocking fee. Sandbox/demo only.';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260822100000",
-      "migrations_count": 475,
+      "migration_head": "20260822110000",
+      "migrations_count": 477,
       "migrations": [
         {
           "version": "00000000000000",
@@ -1905,6 +1905,14 @@
         {
           "version": "20260822100000",
           "name": "sandbox-seed-o2c"
+        },
+        {
+          "version": "20260822105000",
+          "name": "goods-come-back-at-a-cost"
+        },
+        {
+          "version": "20260822110000",
+          "name": "sandbox-seed-rma"
         }
       ]
     },


### PR DESCRIPTION
Tredje kedjan ur [`sandbox-company.md`](../blob/main/docs/concepts/sandbox-company.md). P2P tjänade in lagret (#248), O2C sålde det (#248), den här tar tillbaka en del.

Returer är där de två riktningarna möts, så det är **den första kedjan som kan motsäga sig själv**: en återbetalning är pengar ut mot varor in, och endera halvan kan tyst utebli.

Den här gången uteblev inte kvantiteten. **Värdet uteblev.**

---

# Varorna kom tillbaka värderade till noll

Kvantiteten var perfekt: 90 → 95 i båda speglarna, en `rma_restock`-rörelse från `WH/CUSTOMERS` till `WH/MAIN`. Värderingslagret den skapade läste:

```
quantity 5.000 · unit_cost_cents 0 · value_cents 0
```

mot kvittolagret bredvid:

```
quantity 120.000 · unit_cost_cents 18500 · value_cents 2220000
```

**Hyllan höll 95 kg. Böckerna sa 90.** Och när de 5 kilona säljs blir COGS noll och bruttomarginalen på den affären överskattas med hela kostnaden.

Två frånvaron, båda ifyllda med ett tal systemet redan hade.

### 1. Ett kvitto lärde aldrig produkten vad den kostade

`resolve_inbound_unit_cost` läser PO-raden **direkt** för en `goods_receipt`, så kvitton värderas rätt. Varje *annan* inkommande rörelse — en kundretur, en manuell justering, en händelsedriven restock — faller igenom till `products.cost_cents`:

```sql
SELECT cost_cents INTO v_cost FROM products WHERE id = p_product_id;
RETURN COALESCE(v_cost, 0);
```

…som **ingen kodväg någonsin skrivit**. Mätt på sandbox:

```
utan_kostnad | totalt
           7 |      7
```

Sju av sju, varav två mottagna mot prissatta inköpsordrar minuter tidigare. Inköp visste priset. Värderingen visste priset. Produkten visste det inte.

Fylls **bara när NULL**: det här lär in en kostnad, det inför ingen kostnadspolicy. En operatörs standardkostnad skrivs aldrig över.

### 2. Noll är ingen kostnad, det är frånvaron av en

När inget levererade en styckkostnad bokade den inkommande grenen `0` och gick vidare. För varor som kommer tillbaka och som lagret **redan bär** ligger svaret i lagren: det vägda snittet av det som finns kvar.

Det är standardbehandlingen av en kundretur under genomsnittskostnad — och exakt samma tal som den utgående grenen räknar fram för COGS tjugo rader längre ner i samma funktion.

### Bevisat genom att städa bort spåren och köra om

| | före | efter |
|---|---|---|
| returens styckkostnad | `0` | `18 500` (samma som varorna lämnade på) |
| på hyllan | 95 | 95 |
| **värderade** | **90** | **95** |
| lagervärde | 16 650 kr | 17 575 kr |

Backfill ingår: produkter som mottagits mot en prissatt PO men aldrig lärt sig priset får det. Idempotent, fyller bara tomma fält.

> **Historiska nollvärderade lager skrivs medvetet INTE om.** Att räkna om en lagervärdering som redan bokförts i huvudboken är en redovisningshandling, inte en migration — `process_stock_move_valuation` postar journalrader (1460/2441 vid mottagning, 4990/1460 vid COGS) som då inte längre skulle stämma. Mätfrågor per instans i **#252**.

---

# Sådden

Genom den riktiga ytan: `approve_return`, `receive_return`, `inspect_return` och `refund_return` anropas alla. `return_items` skrivs direkt (`manage_return_item` är en edge-skill och kan inte nås från SQL), med de fält skillen hade satt.

| RMA | tillstånd | vad den prövar |
|---|---|---|
| `RMA-00001` | `refunded` | 5 kg oöppnat tillbaka, 2 % hanteringsavgift, återbetalning i **två steg** |
| `RMA-00002` | `received` | transportskada — mottagen och medvetet **inte** inlagd |
| `RMA-00003` | `requested` | väntar på godkännande |

Två steg för återbetalningen är avsiktligt: en sådd som alltid betalar i ett svep prövar aldrig den löpande summan eller dess tak. Första anropet lämnar RMA:n öppen på `remaining_cents: 72500`, andra stänger den.

### Invarianter den påstår

| | |
|---|---|
| varorna kom tillbaka | båda speglarna +5, och de stämmer med varandra |
| varorna kom tillbaka **till en kostnad** | `unit_cost_cents > 0` — buggen ovan |
| varje enhet på hyllan är en enhet i böckerna | saldo = värderad kvantitet |
| trasiga varor kom **inte** tillbaka | en restock som utlöses när den inte ska är lika fel |
| återbetalningen = rader − avgift | 172 500 = 174 500 − 2 000 |
| en delbetalning stänger inte RMA:n | första anropet ska lämna den öppen |

En restock som utlöses när den *inte* ska är lika fel som en som inte utlöses — därför assertas båda riktningarna.

## Bevisat live på sandbox

```
120 in  · WH/VENDORS   → WH/MAIN       (goods_receipt)
 30 ut  · WH/MAIN      → WH/CUSTOMERS  (order)
  5 in  · WH/CUSTOMERS → WH/MAIN       (rma_restock, 18 500/st)
 95 på hyllan · 95 värderade · 17 575 kr · 0 reserverat
```

Andra körningen ändrar ingenting.

---

## Fynd rapporterade i stället för ändrade

**#251 — inspektörens restock-beslut gör ingenting.** `return_items` bär tre fält för samma sak. `set_return_item_action` (inspektörens RPC) skriver `chosen_action`, som har **noll läsare i databasen** — enda användningen är en toast och en dropdown. `receive_return` läser `restock`, som sätts vid radskapandet, innan någon tittat på varan.

Sekvensen gör det värre: mottagningen är det enda tillfället något händer, och inspektionen kräver status `received` — beslutet fattas **efter** det ögonblick som agerar på det. Fixen bär ett val (Odoo validerar returplockningen efter inspektion), så den hör hemma i en egen ändring.

**#252 — historiska nollvärderade lagerposter.** Mätfrågor per instans; tre vägar framåt beskrivna.

---

Rebasad på `7381648`. `tsc` rent.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5


---
_Generated by [Claude Code](https://claude.ai/code/session_01EumPY2oP7T3tJ49PHyDvS5)_