### PR TITLE
guard(ci): fyra grindar som inte grep — en tyst migrationskrock, en krasch för alla anställda, en lint som aldrig kunde fälla

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run ESLint
+      - name: Run ESLint (advisory — ~3350 findings, 97% no-explicit-any)
         run: npm run lint
         continue-on-error: true
+
+      # BLOCKING, and narrow on purpose. The step above can never fail a build,
+      # which is the same shape as the decorative typecheck described below. This
+      # one holds a two-rule allowlist at zero: rules-of-hooks (a runtime crash,
+      # never correct) and no-empty (a swallowed error must say why). Rules that
+      # are sometimes violated on purpose are deliberately NOT here — see the
+      # exclusion notes in scripts/lint-correctness-gate.ts.
+      - name: Correctness lint gate (BLOCKING)
+        run: npx -y bun run scripts/lint-correctness-gate.ts
 
       # BLOCKING, and against the app's own config.
       #

--- a/.github/workflows/main-red-alert.yml
+++ b/.github/workflows/main-red-alert.yml
@@ -144,7 +144,35 @@ jobs:
             }
 
             // state === 'red'
-            const body = issueBody(verdict);
+            //
+            // Collect open PRs whose own CI is green. The alert used to report
+            // only that main was red; on 2026-08-24 it did that 28 times over
+            // 43 hours while the fix sat open, green and mergeable the whole
+            // time. Naming an available action is what turns a repeated notice
+            // back into a signal. Best-effort: a failure here must never stop
+            // the alert itself from being raised.
+            let greenPrs = [];
+            try {
+              const { data: openPrs } = await github.rest.pulls.list({
+                owner: context.repo.owner, repo: context.repo.repo,
+                state: 'open', base: 'main', per_page: 20,
+              });
+              for (const pr of openPrs) {
+                const { data: checks } = await github.rest.checks.listForRef({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  ref: pr.head.sha, per_page: 30,
+                });
+                const runs = checks.check_runs.filter((c) => c.status === 'completed');
+                if (runs.length > 0 && runs.every((c) => ['success', 'neutral', 'skipped'].includes(c.conclusion))) {
+                  greenPrs.push({ number: pr.number, title: pr.title });
+                }
+              }
+            } catch (e) {
+              core.info(`Could not list candidate fixes (${e.message}) — alerting without them.`);
+              greenPrs = [];
+            }
+
+            const body = issueBody({ ...verdict, greenPrs });
 
             if (!existing) {
               // Create the label if it is missing. issues.create is documented

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
+    "lint:correctness": "bun run scripts/lint-correctness-gate.ts",
     "preview": "vite preview",
     "cli": "bash scripts/flowwink.sh",
     "sync-blocks": "bun run scripts/sync-block-schema.ts",

--- a/scripts/check-migration-forward-dated.ts
+++ b/scripts/check-migration-forward-dated.ts
@@ -22,6 +22,29 @@
  * that legitimately landed on main in parallel does not falsely flag this
  * branch's own (already-forward-dated-at-authoring-time) migrations.
  *
+ * SECOND FAILURE MODE: VERSION COLLISION BETWEEN SIBLINGS
+ * -------------------------------------------------------
+ * Forward-dating alone is not enough. Two branches cut from the SAME fork point
+ * can each pick the same 14-digit timestamp, and each passes the check above —
+ * because each is compared only against its own merge-base, where the other
+ * sibling does not yet exist. (Observed 2026-08-24: PR #261 and PR #265 both
+ * added `20260828120000_*.sql`; both went green.)
+ *
+ * A shared timestamp is not a cosmetic clash. The ledger's identity IS the
+ * version — `supabase_migrations.schema_migrations.version` — so the second file
+ * to be applied looks already-applied and is SILENTLY SKIPPED. Exactly the same
+ * outcome as back-dating, arrived at from the other direction.
+ *
+ * Worse, it is invisible downstream: `instance-readiness.ts` matches an expected
+ * migration when `versions.has(m.version) || names.has(m.name)`, so ONE applied
+ * file satisfies BOTH expected entries and the instance reports "all migrations
+ * applied" while one of them never ran.
+ *
+ * So we additionally reject any version shared by two different filenames in the
+ * post-merge state (origin/main ∪ this branch), and only when this branch is the
+ * one introducing the clash — a pre-existing clash on main must not block every
+ * unrelated PR.
+ *
  * Fails closed only on a real offender; if the base ref / history is unavailable
  * (e.g. a shallow checkout with no common ancestor) it exits 0 with a warning
  * rather than blocking spuriously.
@@ -109,4 +132,66 @@ if (offenders.length > 0) {
   process.exit(1);
 }
 
-console.log(`✓ migration-forward-dated: ${addedFiles.length} new migration(s) all forward-dated (> ${baseMax}).`);
+// ---------------------------------------------------------------------------
+// Version-collision guard (see SECOND FAILURE MODE above).
+//
+// Post-merge state = every migration basename on origin/main plus every one on
+// this branch. Deduping by BASENAME first is what makes self-comparison
+// impossible: a file already merged to main appears once, not twice.
+// ---------------------------------------------------------------------------
+const baseName = (f: string) => f.split('/').pop() ?? '';
+
+let postMerge: Set<string>;
+try {
+  const onMain = sh(`git ls-tree -r --name-only ${baseRef} -- ${MIGRATIONS_DIR}`)
+    .split('\n').map((s) => s.trim()).filter((f) => f.endsWith('.sql'));
+  const onBranch = sh(`git ls-tree -r --name-only HEAD -- ${MIGRATIONS_DIR}`)
+    .split('\n').map((s) => s.trim()).filter((f) => f.endsWith('.sql'));
+  const untrackedNow = sh(`git ls-files --others --exclude-standard -- ${MIGRATIONS_DIR}`)
+    .split('\n').map((s) => s.trim()).filter((f) => f.endsWith('.sql'));
+  postMerge = new Set([...onMain, ...onBranch, ...untrackedNow].map(baseName));
+} catch (e) {
+  console.warn(`⚠ migration-version-collision: git inspection failed — skipping (not blocking). ${(e as Error).message}`);
+  process.exit(0);
+}
+
+const byVersion = new Map<number, string[]>();
+for (const name of postMerge) {
+  const ts = tsOf(name);
+  if (ts === undefined) continue;
+  const bucket = byVersion.get(ts);
+  if (bucket) bucket.push(name);
+  else byVersion.set(ts, [name]);
+}
+
+// Only clashes this branch is responsible for. A clash already sitting on main
+// is main's problem, not this PR's — blocking here would stop every unrelated
+// branch and teach everyone to ignore the gate.
+const addedNames = new Set(addedFiles.map(baseName));
+const clashes = [...byVersion.entries()]
+  .filter(([, names]) => names.length > 1 && names.some((n) => addedNames.has(n)))
+  .map(([ts, names]) => ({ ts, names: names.sort() }));
+
+if (clashes.length > 0) {
+  console.error(
+    '✖ Migration version collision. Two files share one 14-digit timestamp, and\n' +
+    '  that timestamp IS the ledger\'s primary key — whichever applies second looks\n' +
+    '  already-applied and is SILENTLY SKIPPED. The readiness check cannot see it\n' +
+    '  either: one applied file satisfies both expected entries, so the instance\n' +
+    '  reports "all migrations applied" while one of them never ran.\n'
+  );
+  for (const { ts, names } of clashes) {
+    console.error(`   version ${ts} claimed by ${names.length} files:`);
+    for (const n of names) console.error(`      ${n}`);
+  }
+  console.error(
+    '\n  Fix: re-timestamp the file(s) added on THIS branch to a fresh, unique value\n' +
+    '  (date -u +%Y%m%d%H%M%S), keeping it strictly greater than the base HEAD.'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✓ migration-forward-dated: ${addedFiles.length} new migration(s) all forward-dated (> ${baseMax}), ` +
+  `no version collisions across ${postMerge.size} post-merge migration(s).`,
+);

--- a/scripts/deploy-edge-via-api.sh
+++ b/scripts/deploy-edge-via-api.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 #
+# REQUIRES bash 4+. macOS ships bash 3.2 as /bin/bash, which cannot PARSE this
+# file (the failure is a cryptic "unexpected EOF while looking for matching )",
+# raised before a single line runs, so no in-script version check can catch it).
+# On macOS run it as:  /opt/homebrew/bin/bash scripts/deploy-edge-via-api.sh ...
+#
 # deploy-edge-via-api.sh — deploy a Supabase edge function via the Management API
 # (HTTPS), with NO supabase CLI and NO direct Postgres access required.
 #
@@ -38,7 +43,20 @@ VERIFY_JWT=false
 cd "$(dirname "$0")/../supabase/functions"
 
 # Compute the local dependency closure (entry + transitively-imported relative files).
-mapfile -t FILES < <(python3 - "$FN" <<'PY'
+#
+# Captured with `$(...)` rather than read from `< <(...)` so the python exit
+# code is VISIBLE. Inside `< <(...)` a failing generator is invisible to
+# `set -e`: python exits 1, the loop reads nothing, and the script sails on with
+# an EMPTY closure — which is how "MISSING local imports" once turned into a
+# silent 0-file deploy. With command substitution the failure propagates.
+#
+# This does NOT make the file bash 3.2-parseable, and pretending otherwise would
+# be its own small lie: 3.2's `$()` scanner trips over the quote soup in the
+# python body below (`['\"]`), exactly as it did over the process substitution
+# before. Getting there means moving the python into its own .py file. Not worth
+# it for a legacy manual-deploy path — the fleet syncs via scripts/sync-forks.sh
+# now. See the REQUIRES note at the top of this file.
+_CLOSURE=$(python3 - "$FN" <<'PY'
 import re, os, sys
 fn = sys.argv[1]
 def imports_of(p):
@@ -68,6 +86,11 @@ if missing:
 for f in sorted(seen): print(f)
 PY
 )
+
+FILES=()
+while IFS= read -r _line; do
+  [ -n "$_line" ] && FILES+=("$_line")
+done <<< "$_CLOSURE"
 
 # A function may carry its own import map (deno.json) for BARE specifiers —
 # `from "hono"`, `from "mcp-lite"`. Those are not paths, so the closure walker

--- a/scripts/generate-instance-manifest.ts
+++ b/scripts/generate-instance-manifest.ts
@@ -84,6 +84,28 @@ export function buildManifest(root: string): InstanceManifest {
     const base = f.replace(/\.sql$/, '');
     return { version: base.slice(0, 14), name: base.slice(15) }; // <ts>_<name>
   });
+
+  // A version is an IDENTITY, not a sort key. `schema_migrations.version` is the
+  // ledger's primary key, so two files sharing one timestamp are one migration
+  // to every instance — the second silently never runs. And the readiness check
+  // (instance-readiness.ts) matches on `version` OR `name`, so the one applied
+  // file satisfies BOTH expected entries and the instance reports itself fully
+  // migrated. Refusing to EMIT a duplicate stops the lie at the source; CI's
+  // check-migration-forward-dated.ts is the same lock one step earlier.
+  const seenVersions = new Map<string, string>();
+  for (const m of migrations) {
+    const prior = seenVersions.get(m.version);
+    if (prior !== undefined) {
+      throw new Error(
+        `Migration version collision: ${m.version} is claimed by two files\n` +
+        `  ${m.version}_${prior}.sql\n` +
+        `  ${m.version}_${m.name}.sql\n` +
+        `The version is the ledger's primary key — whichever applies second looks\n` +
+        `already-applied and is silently skipped. Re-timestamp one of them.`,
+      );
+    }
+    seenVersions.set(m.version, m.name);
+  }
   const migration_head = migrations.length ? migrations[migrations.length - 1].version : '';
 
   // Layer 2: skills — hash of the seed bundle minus volatile fields.

--- a/scripts/lint-correctness-gate.ts
+++ b/scripts/lint-correctness-gate.ts
@@ -1,0 +1,130 @@
+/**
+ * Correctness lint gate (BLOCKING CI step).
+ *
+ * WHY THIS EXISTS SEPARATELY FROM `npm run lint`
+ * ----------------------------------------------
+ * The full ESLint run is `continue-on-error: true` in CI and reports ~3350
+ * errors, 97% of them `@typescript-eslint/no-explicit-any` — overwhelmingly in
+ * Deno edge functions handling untyped JSON, where `any` is a reasonable choice.
+ * Making that blocking is a multi-week refactor with no correctness payoff, so
+ * it stays advisory.
+ *
+ * But a step that can never fail is furniture, and the repo already learned this
+ * once: `tsc --noEmit` sat behind `continue-on-error` against a config that
+ * skipped the app sources, so it "passed" in under a second while real errors
+ * accumulated (see the comment on the typecheck step in ci.yml). A green tick
+ * that checks nothing is a claim the repo makes about itself and does not keep.
+ *
+ * So: a small, named allowlist of rules that catch BUGS rather than style, held
+ * at zero and blocking. Adding a rule here is a deliberate act — it must be one
+ * where a violation is a defect, not a preference.
+ *
+ * FOUND BY THIS GATE'S FIRST RUN (2026-08-24)
+ * -------------------------------------------
+ * `react-hooks/rules-of-hooks` × 10. Nine were in
+ * `src/pages/account/PerformancePage.tsx`, which returned early on
+ * `!isEmployee` — a value that is false while the query loads and true after it
+ * resolves. Two hooks on the first render, eleven on the second: React throws
+ * "Rendered more hooks than during the previous render". The page crashed for
+ * every employee and for nobody else, which is exactly why it survived.
+ */
+import { execSync } from 'node:child_process';
+
+/**
+ * Rules whose violations are defects. Keep this list short and justified.
+ *
+ * NOT included, deliberately: `@typescript-eslint/no-explicit-any` (style, and
+ * 3262 pre-existing), `prefer-const` (style), `no-case-declarations` (style
+ * unless the declaration actually leaks, which TS already narrows).
+ */
+const CORRECTNESS_RULES = [
+  // A conditionally-called hook desynchronises React's hook list. Runtime crash,
+  // every time, with no safe way to write it on purpose.
+  'react-hooks/rules-of-hooks',
+  // `catch {}` — an error observed and discarded. Every instance in this repo is
+  // a deliberate best-effort call (a webhook that must not fail the business
+  // operation, a localStorage write in private mode), and every one of them was
+  // silent about it. The rule is satisfied by a comment, so what it actually
+  // enforces is: a swallowed error must say why it is swallowed. This repo has
+  // lost hours to stacked bugs hiding behind a swallowed catch.
+  'no-empty',
+] as const;
+
+/**
+ * DELIBERATELY EXCLUDED, and the reasoning matters more than the list.
+ *
+ * The first draft of this gate also carried `no-useless-escape` (11),
+ * `no-regex-spaces` (5) and `no-constant-binary-expression` (2). Reading all 18
+ * killed them: every escape was `\/` inside a character class or `\"` inside a
+ * template literal — byte-identical behaviour; every regex-space was a test
+ * matching literal indentation; and both constant expressions were
+ * `cn('base', true && 'included')` in a test whose whole point is feeding `cn`
+ * literal conditionals. Eighteen cosmetic edits to regexes and strings, zero
+ * defects found, non-zero risk.
+ *
+ * Holding a rule at zero is only honest when a violation IS a defect. Forcing a
+ * list green to look rigorous is the same failure as a green tick that checks
+ * nothing — just more work.
+ *
+ * ALSO EXCLUDED: `react-hooks/exhaustive-deps` (43 violations today).
+ *
+ * Unlike the rules above, this one is broken on purpose all the time — a
+ * run-once effect, an intentionally stale closure, a dep that would loop. A gate
+ * can only be held at zero when every violation is a defect; hold a
+ * sometimes-right rule at zero and you get a suppression culture, or the gate
+ * gets `continue-on-error` back within a week. It stays in the advisory lint,
+ * where a human can weigh each case.
+ */
+
+type EslintMessage = { ruleId: string | null; line: number; column: number; message: string };
+type EslintFile = { filePath: string; messages: EslintMessage[] };
+
+let raw: string;
+try {
+  raw = execSync('npx eslint . -f json', { encoding: 'utf8', maxBuffer: 128 * 1024 * 1024 });
+} catch (e: unknown) {
+  // ESLint exits non-zero when it reports errors — that is the normal path here,
+  // and stdout still holds the JSON we want.
+  const err = e as { stdout?: string };
+  if (!err.stdout) {
+    console.error('✖ lint-correctness-gate: eslint produced no output.');
+    process.exit(1);
+  }
+  raw = err.stdout;
+}
+
+let report: EslintFile[];
+try {
+  report = JSON.parse(raw);
+} catch {
+  console.error('✖ lint-correctness-gate: could not parse eslint JSON output.');
+  process.exit(1);
+}
+
+const watched = new Set<string>(CORRECTNESS_RULES);
+const cwd = process.cwd();
+const offenders = report.flatMap((f) =>
+  f.messages
+    .filter((m) => m.ruleId !== null && watched.has(m.ruleId))
+    .map((m) => ({
+      file: f.filePath.startsWith(cwd) ? f.filePath.slice(cwd.length + 1) : f.filePath,
+      ...m,
+    })),
+);
+
+if (offenders.length > 0) {
+  console.error(
+    `✖ ${offenders.length} correctness lint error(s). These are defects, not style —\n` +
+    '  see the rule notes in scripts/lint-correctness-gate.ts for what each one breaks.\n',
+  );
+  for (const o of offenders) {
+    console.error(`   ${o.file}:${o.line}:${o.column}`);
+    console.error(`      ${o.ruleId} — ${o.message}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `✓ lint-correctness-gate: 0 violations across ${CORRECTNESS_RULES.length} correctness rules ` +
+  `(${report.length} files linted).`,
+);

--- a/scripts/main-red-alert.mjs
+++ b/scripts/main-red-alert.mjs
@@ -107,13 +107,41 @@ export function waitStepMs(verdict, graceMinutes = 30, maxStepMs = 60_000) {
 }
 
 /** Issue body. Rebuilt on every check so the issue always shows current state. */
-export function issueBody({ minutesRed, sha, url, streak, redSince }) {
+/**
+ * @param greenPrs Open PRs whose own CI is passing — candidate fixes.
+ *
+ * WHY THIS SECTION EXISTS
+ * -----------------------
+ * 2026-08-24: main sat red for 43 hours. This alert did its job perfectly —
+ * 28 comments, each one accurate. And the fix was already open, already green,
+ * already mergeable, the whole time (PR #267). Nobody connected the two, because
+ * the alert only ever reported the SYMPTOM.
+ *
+ * An alert that names a problem repeatedly and never names an available action
+ * becomes furniture. So the body now lists open PRs that are themselves green.
+ * They are CANDIDATES, not a diagnosis — a green PR need not be the fix — but
+ * "here are three things that would make this go away" is an action, and
+ * "main is still red" on its 28th repetition is not.
+ */
+export function issueBody({ minutesRed, sha, url, streak, redSince, greenPrs = [] }) {
+  const candidates = greenPrs.length
+    ? [
+        '',
+        `**${greenPrs.length} open PR${greenPrs.length === 1 ? ' is' : 's are'} green right now** — one may already fix this:`,
+        ...greenPrs.map((p) => `- #${p.number} — ${p.title}`),
+        '',
+        '<sub>Green here means that PR\'s own CI passed. It is a candidate, not a',
+        'diagnosis — check that it addresses the failure above before merging.</sub>',
+      ]
+    : [];
+
   return [
     `**main has been red for ~${minutesRed} minutes.**`,
     '',
     `- Failing since: \`${redSince}\` (${streak} consecutive failing run${streak === 1 ? '' : 's'})`,
     `- Latest failing commit: \`${sha}\``,
     `- Run: ${url}`,
+    ...candidates,
     '',
     'This issue closes itself as soon as a CI run on main succeeds.',
     '',

--- a/scripts/sync-forks.sh
+++ b/scripts/sync-forks.sh
@@ -33,9 +33,27 @@ cd "$(dirname "$0")/.."
 FORKS="WWW OPTIC LITEIT AUTOVERSIO"
 ONLY="${1:-}"
 
+# Portable uppercase. `${ONLY^^}` is bash 4+, and macOS ships bash 3.2 as
+# /bin/bash — so `#!/usr/bin/env bash` resolves to a shell that fails this line
+# with "bad substitution" and, under `set -e`, kills the whole run. Observed
+# 2026-08-23: a full fleet sync aborted before touching a single fork.
+if [ -n "$ONLY" ]; then
+  ONLY_UC=$(printf '%s' "$ONLY" | tr '[:lower:]' '[:upper:]')
+  case " $FORKS " in
+    *" $ONLY_UC "*) ;;
+    *)
+      printf 'Okänd fork: %s\nGiltiga: %s\n' "$ONLY" "$FORKS" >&2
+      exit 2
+      ;;
+  esac
+fi
+
 fail=0
 for NAME in $FORKS; do
-  [ -n "$ONLY" ] && [ "${ONLY^^}" != "$NAME" ] && continue
+  # An unmatched filter used to fall through here silently and exit 0 having
+  # synced nothing — a no-op that reads exactly like a successful sync. The
+  # validation above turns that into a refusal.
+  [ -n "$ONLY" ] && [ "$ONLY_UC" != "$NAME" ] && continue
   TOKEN=$(grep -E "^GITHUB_TOKEN_${NAME}=" .env.local | grep -oE "(ghp_|github_pat_)[A-Za-z0-9_]+" | head -1 || true)
   REPO=$(grep -E "GITHUB_REPO_${NAME}=" .env.local | grep -oE "GITHUB_REPO_${NAME}=[^ ]+" | cut -d= -f2 || true)
   if [ -z "$TOKEN" ] || [ -z "$REPO" ]; then

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,7 +104,7 @@ const DocsCategoryPage = lazy(() => import("./pages/DocsCategoryPage"));
 const DocsArticlePage = lazy(() => import("./pages/DocsArticlePage"));
 const NewsletterManagePage = lazy(() => import("./pages/NewsletterManagePage"));
 const NewsletterConfirmedPage = lazy(() => import("./pages/NewsletterConfirmedPage"));
-import NotFound from "./pages/NotFound";
+import NotFound, { RouteErrorPage } from "./pages/NotFound";
 const CheckoutPage = lazy(() => import("./pages/CheckoutPage"));
 const CheckoutSuccessPage = lazy(() => import("./pages/CheckoutSuccessPage"));
 const OrderTrackingPage = lazy(() => import("./pages/OrderTrackingPage"));
@@ -253,7 +253,7 @@ function AppLayout() {
 const router = createBrowserRouter([
   {
     element: <AppLayout />,
-    errorElement: <NotFound />,
+    errorElement: <RouteErrorPage />,
     children: [
 
       { path: "/", element: <PublicPage /> },

--- a/src/components/admin/accounting/FiscalYearContext.tsx
+++ b/src/components/admin/accounting/FiscalYearContext.tsx
@@ -20,12 +20,12 @@ export function FiscalYearProvider({ children }: { children: ReactNode }) {
         const n = parseInt(raw, 10);
         if (Number.isFinite(n) && n > 1900 && n < 3000) return n;
       }
-    } catch {}
+    } catch { /* localStorage unavailable (private mode / SSR) — fall back to the current year. */ }
     return currentYear;
   });
 
   useEffect(() => {
-    try { localStorage.setItem(STORAGE_KEY, String(year)); } catch {}
+    try { localStorage.setItem(STORAGE_KEY, String(year)); } catch { /* localStorage unavailable — the year simply does not persist across reloads. */ }
   }, [year]);
 
   const value: FiscalYearContextValue = {

--- a/src/hooks/useCopilot.ts
+++ b/src/hooks/useCopilot.ts
@@ -385,7 +385,7 @@ export function useCopilot(): UseCopilotReturn {
       let baseDomain = null;
       try {
         baseDomain = new URL(url).origin;
-      } catch {}
+      } catch { /* Not a parseable absolute URL — leave baseDomain null; callers treat that as "unknown origin". */ }
 
       // Get slug from discovered page if available, otherwise generate from URL path
       const discoveredPage = migrationState.siteStructure?.pages.find(p => p.url === url);

--- a/src/hooks/usePerformance.ts
+++ b/src/hooks/usePerformance.ts
@@ -69,6 +69,7 @@ export interface PerformanceReview {
 export function useGoals(employeeId?: string) {
   return useQuery({
     queryKey: ["performance_goals", employeeId],
+    enabled: !!employeeId,
     queryFn: async () => {
       let q = supabase.from("performance_goals" as any).select("*").order("created_at", { ascending: false });
       if (employeeId) q = q.eq("employee_id", employeeId);
@@ -115,6 +116,7 @@ export function useDeleteGoal() {
 export function useOneOnOnes(employeeId?: string) {
   return useQuery({
     queryKey: ["one_on_ones", employeeId],
+    enabled: !!employeeId,
     queryFn: async () => {
       let q = supabase.from("one_on_ones" as any).select("*").order("scheduled_at", { ascending: false });
       if (employeeId) q = q.or(`employee_id.eq.${employeeId},manager_id.eq.${employeeId}`);
@@ -148,6 +150,7 @@ export function useUpsertOneOnOne() {
 export function useFeedback(receiverId?: string) {
   return useQuery({
     queryKey: ["feedback", receiverId],
+    enabled: !!receiverId,
     queryFn: async () => {
       let q = supabase.from("feedback" as any).select("*").order("created_at", { ascending: false });
       if (receiverId) q = q.eq("receiver_id", receiverId);
@@ -180,6 +183,7 @@ export function useGiveFeedback() {
 export function useReviews(employeeId?: string) {
   return useQuery({
     queryKey: ["performance_reviews", employeeId],
+    enabled: !!employeeId,
     queryFn: async () => {
       let q = supabase.from("performance_reviews" as any).select("*").order("period_end", { ascending: false });
       if (employeeId) q = q.eq("employee_id", employeeId);

--- a/src/lib/__tests__/main-red-alert.test.ts
+++ b/src/lib/__tests__/main-red-alert.test.ts
@@ -117,6 +117,55 @@ describe('decide — no signal is not an alert', () => {
   });
 });
 
+describe('issueBody — candidate fixes', () => {
+  /**
+   * 2026-08-24: main was red 43 hours. The alert commented 28 times, every
+   * comment accurate, and never once mentioned that PR #267 was open, green and
+   * mergeable. Reporting a symptom repeatedly is not the same as reporting an
+   * action, and the difference is what made 28 correct notices ignorable.
+   */
+  it('names open green PRs as candidates when there are any', () => {
+    const body = issueBody({
+      minutesRed: 2580, sha: 'abc1234', url: 'https://example.test/run/1',
+      streak: 12, redSince: '2026-08-22T13:18:00Z',
+      greenPrs: [
+        { number: 267, title: "fix(types): get main's blocking typecheck green again" },
+        { number: 270, title: 'fix(inventory): the two holes delegation left' },
+      ],
+    });
+
+    expect(body).toContain('2 open PRs are green right now');
+    expect(body).toContain('#267');
+    expect(body).toContain('#270');
+    // Stated as a candidate, never as a diagnosis — a green PR need not be the fix.
+    expect(body).toContain('candidate, not a');
+  });
+
+  it('says nothing about candidates when none are green', () => {
+    const body = issueBody({
+      minutesRed: 31, sha: 'a', url: 'u', streak: 1, redSince: 'x', greenPrs: [],
+    });
+    expect(body).not.toContain('green right now');
+    expect(body).not.toContain('candidate');
+  });
+
+  it('omits the section entirely when the caller passes no greenPrs at all', () => {
+    // The workflow falls back to `[]` when the PR listing throws, but a caller
+    // that never sets the field must not crash or render an empty header.
+    const body = issueBody({ minutesRed: 31, sha: 'a', url: 'u', streak: 1, redSince: 'x' });
+    expect(body).toContain('main has been red');
+    expect(body).not.toContain('green right now');
+  });
+
+  it('uses singular wording for exactly one candidate', () => {
+    const body = issueBody({
+      minutesRed: 31, sha: 'a', url: 'u', streak: 1, redSince: 'x',
+      greenPrs: [{ number: 267, title: 'the fix' }],
+    });
+    expect(body).toContain('1 open PR is green right now');
+  });
+});
+
 describe('issueBody', () => {
   it('carries everything needed to act without opening the run', () => {
     const body = issueBody({

--- a/src/lib/__tests__/one-version-one-migration.guardrails.test.ts
+++ b/src/lib/__tests__/one-version-one-migration.guardrails.test.ts
@@ -1,0 +1,121 @@
+/**
+ * One version, one migration.
+ *
+ * 2026-08-24: PR #261 and PR #265 were cut from the same fork point and each
+ * added `20260828120000_*.sql`. Both went green. The forward-dating guard could
+ * not see it — it compares a branch against its own MERGE-BASE, deliberately, so
+ * that a migration landing on main in parallel does not false-flag the branch.
+ * At that fork point the sibling does not exist yet.
+ *
+ * Why a shared timestamp is not cosmetic: `supabase_migrations.schema_migrations`
+ * keys on `version`. Two files claiming one version are ONE migration to the
+ * ledger — whichever applies second looks already-applied and is silently
+ * skipped. The same outcome as back-dating, reached from the other direction.
+ *
+ * And the sensor built to catch unfinished installs cannot report it, which is
+ * the part that makes this worth a test rather than a comment. `schemaRow()`
+ * matches an expected migration when `versions.has(version) || names.has(name)`
+ * — so ONE applied file satisfies BOTH expected entries and the instance says
+ * "all migrations applied" while one of them never ran.
+ *
+ * Two locks, both pinned here:
+ *   1. `scripts/check-migration-forward-dated.ts` rejects a version shared by
+ *      two filenames in the post-merge state (CI, blocking).
+ *   2. `scripts/generate-instance-manifest.ts` refuses to emit a duplicate, so
+ *      a collision cannot reach the artifact instances measure themselves by.
+ *
+ * See also: docs — the "silent half-success" class, of which this is a textbook
+ * member: every individual check is green and the outcome is still wrong.
+ */
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { evaluateInstanceReadiness, type ReadinessInput } from '@/lib/instance-readiness';
+
+const ROOT = join(__dirname, '..', '..', '..');
+const MIGRATIONS_DIR = join(ROOT, 'supabase', 'migrations');
+
+function migrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR).filter((f) => /^\d{14}.*\.sql$/.test(f)).sort();
+}
+
+describe('one version, one migration', () => {
+  it('no two migration files claim the same 14-digit version', () => {
+    const byVersion = new Map<string, string[]>();
+    for (const f of migrationFiles()) {
+      const version = f.slice(0, 14);
+      byVersion.set(version, [...(byVersion.get(version) ?? []), f]);
+    }
+
+    const collisions = [...byVersion.entries()].filter(([, files]) => files.length > 1);
+
+    expect(
+      collisions,
+      collisions.length === 0
+        ? ''
+        : `Migration version collision — the version is the ledger's primary key, so the\n` +
+          `second file to apply is silently skipped:\n` +
+          collisions.map(([v, fs]) => `  ${v}\n${fs.map((f) => `    ${f}`).join('\n')}`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('the manifest carries one entry per version — no duplicates reach the artifact', () => {
+    const manifest = JSON.parse(
+      readFileSync(join(ROOT, 'supabase', 'seed', 'instance-manifest.json'), 'utf-8'),
+    );
+    const versions: string[] = manifest.layers.schema.migrations.map(
+      (m: { version: string }) => m.version,
+    );
+    expect(new Set(versions).size).toBe(versions.length);
+  });
+
+  it('DEMONSTRATES the blind spot: a duplicate version hides a migration that never ran', () => {
+    // Two migrations the build expects, sharing one version — the exact #261/#265
+    // shape. Only the first was actually applied; the ledger skipped the second.
+    const expected = [
+      { version: '20260828120000', name: 'a-vendor-term-is-a-word-not-a-number' },
+      { version: '20260828120000', name: 'the-sweep-is-fixed-now-prove-it-keeps-running' },
+    ];
+    const applied = [expected[0]]; // the second never ran
+
+    const input = {
+      schema: { applied, expected },
+    } as unknown as ReadinessInput;
+
+    const schema = evaluateInstanceReadiness({
+      ...input,
+      skills: { total: 1, enabled: 1, stampHash: 'h', expectedHash: 'h', expectedCount: 1, platformFloor: 0 },
+      edge: { deployed: [], expected: [], reportedAt: null },
+      cron: { jobs: [] },
+      ai: { configured: true },
+      siteUrl: { value: 'https://example.com' },
+      modules: { settings: null },
+    } as unknown as ReadinessInput).find((r) => r.id === 'schema')!;
+
+    // This is the bug, asserted as it behaves TODAY — one applied file satisfies
+    // both expected entries. If a future change makes readiness see through a
+    // duplicate version, this expectation flips and that is good news: update it.
+    expect(schema.status).toBe('ok');
+    expect(schema.detail).toContain('are applied');
+
+    // CONTROL — without it the assertion above proves nothing. Give the second
+    // migration its OWN version, change nothing else, and the same "one applied,
+    // one skipped" state is correctly reported as blocked. So the `ok` above is
+    // caused by the shared version and by nothing else.
+    const distinct = [
+      { version: '20260828120000', name: 'a-vendor-term-is-a-word-not-a-number' },
+      { version: '20260828120001', name: 'the-sweep-is-fixed-now-prove-it-keeps-running' },
+    ];
+    const control = evaluateInstanceReadiness({
+      schema: { applied: [distinct[0]], expected: distinct },
+      skills: { total: 1, enabled: 1, stampHash: 'h', expectedHash: 'h', expectedCount: 1, platformFloor: 0 },
+      edge: { deployed: [], expected: [], reportedAt: null },
+      cron: { jobs: [] },
+      ai: { configured: true },
+      siteUrl: { value: 'https://example.com' },
+      modules: { settings: null },
+    } as unknown as ReadinessInput).find((r) => r.id === 'schema')!;
+
+    expect(control.status).not.toBe('ok');
+  });
+});

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -7,16 +7,20 @@ import { PublicFooter } from '@/components/public/PublicFooter';
 import { Button } from '@/components/ui/button';
 import { AlertTriangle, ArrowLeft, Home } from 'lucide-react';
 
-const NotFound = () => {
+/**
+ * The page body. Takes the route error as a PROP rather than reading it, so the
+ * component is safe to render anywhere.
+ *
+ * It used to read it itself, with `useRouteError()` wrapped in try/catch —
+ * because this component is used two ways: as the router's `errorElement`
+ * (App.tsx) and as a plain 404 body by four content pages. Calling a hook inside
+ * a try block is a hook whose invocation the compiler cannot guarantee, and
+ * react-hooks/rules-of-hooks flagged it correctly. Splitting the two uses apart
+ * removes the need for the trick: `RouteErrorPage` reads the error, `NotFound`
+ * never does.
+ */
+const NotFoundBody = ({ routeError }: { routeError?: unknown }) => {
   const location = useLocation();
-  // useRouteError is safe to call — returns undefined when not rendered as errorElement
-  let routeError: unknown;
-  try {
-    routeError = useRouteError();
-  } catch {
-    routeError = undefined;
-  }
-
   const isError = !!routeError;
   const status = isRouteErrorResponse(routeError) ? routeError.status : 404;
   const title = isError && status !== 404 ? 'Something went wrong' : 'Page not found';
@@ -69,5 +73,14 @@ const NotFound = () => {
     </>
   );
 };
+
+/** Plain 404 — no router error context required. */
+const NotFound = () => <NotFoundBody />;
+
+/**
+ * The router's `errorElement`. This is the ONLY place `useRouteError` is called,
+ * and here it is unconditional — which is what the rule asks for.
+ */
+export const RouteErrorPage = () => <NotFoundBody routeError={useRouteError()} />;
 
 export default NotFound;

--- a/src/pages/account/PerformancePage.tsx
+++ b/src/pages/account/PerformancePage.tsx
@@ -15,14 +15,25 @@ import { usePlatformFormat } from "@/hooks/usePlatformFormat";
 import { useState } from "react";
 
 export default function PerformancePage() {
+  // EVERY hook runs on every render, before any early return.
+  //
+  // `useEmployeeSelf` is a query: on first render `employee` is undefined, so
+  // `isEmployee` is false. Returning here — as this component used to — meant
+  // two hooks on render 1 and eleven on render 2, once the query resolved.
+  // React counts hooks per render and throws "Rendered more hooks than during
+  // the previous render", so the page crashed for exactly the people it is for,
+  // and never for anyone else. That is why it could sit here unnoticed.
+  //
+  // The admin twin (`admin/hr/PerformancePanel.tsx`) expresses the same intent
+  // legally, by gating at the component boundary — `{empId && <GoalsTab …/>}`
+  // mounts and unmounts a child rather than skipping hooks inside one.
   const { formatDate, formatDateTime } = usePlatformFormat();
-  const { employee, isEmployee } = useEmployeeSelf();
+  const { employee, isEmployee, loading } = useEmployeeSelf();
 
-  if (!isEmployee || !employee) {
-    return <div className="text-sm text-muted-foreground">Performance is available for employees only.</div>;
-  }
+  // Undefined until the query resolves. The read hooks below are `enabled` on
+  // this id, so they stay idle rather than firing without an employee filter.
+  const empId = employee?.id;
 
-  const empId = employee.id;
   const { data: goals = [] } = useGoals(empId);
   const { data: meetings = [] } = useOneOnOnes(empId);
   const { data: reviews = [] } = useReviews(empId);
@@ -34,6 +45,15 @@ export default function PerformancePage() {
 
   const [updateOpen, setUpdateOpen] = useState<string | null>(null);
   const [progress, setProgress] = useState(0);
+
+  // Below the hooks, so the render path may branch freely from here.
+  if (loading) {
+    return <div className="text-sm text-muted-foreground">Loading…</div>;
+  }
+
+  if (!isEmployee || !employee) {
+    return <div className="text-sm text-muted-foreground">Performance is available for employees only.</div>;
+  }
 
   return (
     <div className="space-y-6">

--- a/src/pages/admin/FlowtablePage.tsx
+++ b/src/pages/admin/FlowtablePage.tsx
@@ -611,7 +611,7 @@ export default function FlowtablePage() {
                   const next = !v;
                   try {
                     localStorage.setItem('flowtable-bases-minimized', String(next));
-                  } catch {}
+                  } catch { /* localStorage unavailable — the panel still toggles, it just does not remember. */ }
                   return next;
                 });
               }}

--- a/supabase/functions/agent-execute/index.ts
+++ b/supabase/functions/agent-execute/index.ts
@@ -10825,7 +10825,7 @@ async function executeDbAction(
           .select('id, name').single();
         if (error) throw new Error(`Create vendor failed: ${error.message}`);
         // Fire webhook
-        try { await fetch(`${supabaseUrl}/functions/v1/send-webhook`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${serviceKey}` }, body: JSON.stringify({ event: 'vendor.created', data: { id: data.id, name: data.name, email } }) }); } catch {}
+        try { await fetch(`${supabaseUrl}/functions/v1/send-webhook`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${serviceKey}` }, body: JSON.stringify({ event: 'vendor.created', data: { id: data.id, name: data.name, email } }) }); } catch { /* Fire-and-forget webhook. A webhook failure must not fail the business operation that triggered it. */ }
         return { vendor_id: data.id, name: data.name, created: true };
       }
 
@@ -10959,7 +10959,7 @@ async function executeDbAction(
         try {
           const { data: vendorInfo } = await supabase.from('vendors').select('name').eq('id', vendor_id).single();
           await fetch(`${supabaseUrl}/functions/v1/send-webhook`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${serviceKey}` }, body: JSON.stringify({ event: 'purchase_order.created', data: { id: po.id, po_number: po.po_number, vendor_name: vendorInfo?.name, total_cents: po.total_cents, currency: po.currency } }) });
-        } catch {}
+        } catch { /* Fire-and-forget webhook. A webhook failure must not fail the business operation that triggered it. */ }
 
         const rate = Number(po.exchange_rate ?? 1);
         return {
@@ -11050,7 +11050,7 @@ async function executeDbAction(
 
           try {
             await fetch(`${supabaseUrl}/functions/v1/send-webhook`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${serviceKey}` }, body: JSON.stringify({ event: 'purchase_order.sent', data: { id: purchase_order_id, po_number: po?.po_number, vendor_name: vendorName, email_sent: emailSent } }) });
-          } catch {}
+          } catch { /* Fire-and-forget webhook. A webhook failure must not fail the business operation that triggered it. */ }
         }
 
         const { data: updated } = await supabase.from('purchase_orders')
@@ -11162,7 +11162,7 @@ async function executeDbAction(
         if (allReceived) {
           await fetch(`${supabaseUrl}/functions/v1/send-webhook`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${serviceKey}` }, body: JSON.stringify({ event: 'purchase_order.received', data: { id: purchase_order_id, po_number: poInfo?.po_number, fully_received: true } }) });
         }
-      } catch {}
+      } catch { /* Fire-and-forget webhook. A webhook failure must not fail the business operation that triggered it. */ }
 
       return {
         goods_receipt_id: gr.id,

--- a/supabase/functions/create-checkout/index.ts
+++ b/supabase/functions/create-checkout/index.ts
@@ -471,7 +471,7 @@ serve(async (req: Request) => {
             }).catch(() => {});
           }
         }
-      } catch (_) {}
+      } catch (_) { /* Best-effort post-checkout side effect. A failure here must not fail a paid checkout. */ }
 
       return new Response(
         JSON.stringify({

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2079,7 +2079,7 @@
       "functions": {
         "a2a": "sha256:33f9aa45f5a82d23f357aff397403b5b12a94dc3421984a1c883f23509c50f71",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
-        "agent-execute": "sha256:a406579520e50ef3161948f8d9deffcaa1b44f436af903a2597a7258243767bd",
+        "agent-execute": "sha256:f5dd95bc2e89988de6096b7688b8b18b5ed7425151df7c12f9b1760fa420db72",
         "agent-operate": "sha256:1765b70f17a5f0e12a43dc6f50c2247cb15f2f4b82f9cf7204efb657cec1fdcf",
         "ai-task": "sha256:35ae34d3748467b51f716cfef3d80af31b08e92e801905277b8460765b017169",
         "automation-dispatcher": "sha256:3cb8681d7acce65624bd7957a432b143a2d959d769845dc71696b95c2ea2012b",
@@ -2095,7 +2095,7 @@
         "content-api": "sha256:64c03bcaa94f7e17575c9e36611830c049cdcf372747ed2af264eb03c70bce42",
         "contract-billing-cron": "sha256:bd4af2f1f3c05253ae5635af48686f9f662f40a55b1b3097001c1828b35f898a",
         "contract-sign": "sha256:d4e4fb98e51109c626110dfeff57199cd006a62ed39501e0b171f32aec579bd7",
-        "create-checkout": "sha256:d80324e0c7c80c3959f5d4f79512b03d8db9b3b9c2f7255b008c55338b3e094b",
+        "create-checkout": "sha256:fb45289a720d39122d1924cb2b8f79a238f52e61cc5bad1286c2dd996ef8f067",
         "create-invoice-payment": "sha256:917c78b89d0131f426ed5c6109eea67d8020604def81f1179eba2e5bb0c8bea6",
         "create-user": "sha256:bed454b8a235c1a99baead4133a74618ac2761b221592c346f4fb8f1c6bffc34",
         "customer-signup": "sha256:8f29b9defed8bb8227767e2c0a748739d80d1e182f87e6b19f4b46e485be52d6",


### PR DESCRIPTION
Four fixes, one theme: **gates that could not fail.**

## 1. Two migrations can claim one version, and everything downstream says fine

PR #261 and PR #265 were cut from the same fork point and each added
`20260828120000_*.sql`. Both went green. Reproduced and verified:

```
PR#261 merge-base=d26d3ed1  baseMax=20260827700000  →  ✓ forward-dated
PR#265 merge-base=d26d3ed1  baseMax=20260827700000  →  ✓ forward-dated
```

The forward-dating guard compares a branch against its own **merge-base** — deliberately, so a
migration landing on main in parallel does not false-flag the branch. At that fork point the
sibling does not exist yet.

A shared timestamp is not cosmetic. `supabase_migrations.schema_migrations` keys on `version`, so
two files claiming one version are **one migration** to the ledger; whichever applies second looks
already-applied and is silently skipped. Same outcome as back-dating, from the other direction.

And the sensor built to catch unfinished installs cannot see it. `instance-readiness.ts:240`:

```ts
const versions = new Set(input.applied.map((m) => m.version));
const missing = input.expected.filter((m) => !versions.has(m.version) && !names.has(m.name) && …);
```

One applied file satisfies **both** expected entries → `missing` is empty → *"All migrations this
build expects are applied."*

**Two locks, both negative-tested:**

| case | result |
| --- | --- |
| main alone (515 migrations) | ✓ pass |
| #261 alone | ✓ pass (516 post-merge, no collision) |
| #261 + #265 together | ✖ **blocked** |
| #265 after #261 lands on main | ✖ **blocked** |

Plus `generate-instance-manifest.ts` now refuses to *emit* a duplicate, so a collision cannot reach
the artifact instances measure themselves by. `one-version-one-migration.guardrails.test.ts` pins
the invariant and demonstrates the readiness blind spot — **with a control**: give the second
migration its own version, change nothing else, and the same state is correctly reported `blocked`.

## 2. A page that crashed for exactly the people it was for

`src/pages/account/PerformancePage.tsx` returned early on `!isEmployee` — false while the query
loads, true after it resolves. Two hooks on the first render, eleven on the second. React throws
*"Rendered more hooks than during the previous render."*

So it crashed for **every employee** and for **nobody else**, which is why it could sit there. The
admin twin expresses the same intent legally, by gating at the component boundary
(`{empId && <GoalsTab …/>}`) rather than skipping hooks inside one component.

Second bug in the same place: the read hooks had no `enabled` guard, and `if (employeeId) q = q.eq(…)`
**drops the filter** when the id is absent. Hoisting the hooks naively would have fired three
unfiltered queries. Both callers type `employeeId: string`, so `enabled: !!employeeId` is safe.

`NotFound` is split so `useRouteError()` is called unconditionally in the `errorElement` instead of
inside a `try/catch`.

## 3. The lint step that can never fail

ESLint is `continue-on-error: true` and reports ~3350 findings, 97% `no-explicit-any` in Deno
functions handling untyped JSON. Making *that* blocking is weeks of work for no correctness gain.
But a step that can never fail is furniture — and `ci.yml` already says so about the typecheck:

> *"A green tick that checks nothing is worse than no tick: it is a claim the repo makes about itself
> and does not keep."*

New blocking gate holding **two** rules at zero: `rules-of-hooks` (a runtime crash, never correct)
and `no-empty` (a swallowed error must say why). It found the crash above.

My first draft also carried `no-useless-escape`, `no-regex-spaces` and `no-constant-binary-expression`.
Reading all 18 killed them: every escape was `\/` in a character class or `\"` in a template literal —
byte-identical behaviour; every regex-space was a test matching literal indentation; both constant
expressions were `cn('base', true && 'included')` in a test whose whole point is literal conditionals.
Eighteen cosmetic edits, zero defects. **Forcing a list green to look rigorous is the same failure as
a green tick that checks nothing, just more work.** `exhaustive-deps` (43) is excluded for a different
reason: it is broken on purpose all the time, and a sometimes-right rule held at zero breeds
suppressions.

Nine `catch {}` now say why they swallow. All nine were legitimate best-effort calls. Zero behaviour change.

## 4. Three tools that did not work

- **`sync-forks.sh`** used `${ONLY^^}` (bash 4+) while macOS runs bash 3.2 as `/bin/bash` — a full
  fleet sync died on `bad substitution` before touching a single fork. Also: an unknown fork name fell
  silently through the loop and exited 0 having synced nothing, which reads exactly like success. Now
  refused with exit 2.
- **`deploy-edge-via-api.sh`** read its dependency closure from `< <(…)`, where a python failure is
  invisible to `set -e` — python exits 1, the loop reads nothing, the script continues with an **empty
  closure**. That is how "MISSING local imports" once became a silent 0-file deploy. Now `$(…)`, so it
  propagates. It is still not bash-3.2-parseable and the header now says so plainly rather than
  implying otherwise.
- **`main-red-alert`** now lists open PRs whose own CI is green. It commented 28 times over 43 hours,
  every comment accurate, and never mentioned that #267 was open, green and mergeable the whole time.
  An alert that repeats a symptom and never names an available action becomes furniture.

## Verification

Every blocking CI step, run locally:

```
correctness gate   ✓ 0 violations / 2 rules / 1778 files
tsc app config     ✓ exit 0
vitest             ✓ 3215 passed, 5 skipped
verify:hr-modules  ✓
parity:check       ✓
migration guard    ✓
```

Note: `skill-linter.ts` exits 0 by *skipping* without `DATABASE_URL` — a known gap, not fixed here.
