### PR TITLE
fix(bootstrap): vaktens nej lästes som 67 saknade moduler

### DIFF
--- a/src/hooks/useFlowPilotBootstrap.ts
+++ b/src/hooks/useFlowPilotBootstrap.ts
@@ -4,6 +4,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/lib/logger';
 import { useToast } from '@/hooks/use-toast';
 import { useModules, defaultModulesSettings } from '@/hooks/useModules';
+import { useAuth } from '@/hooks/useAuth';
 import { bootstrapModule, ensureModulesRow, ensurePlatformCron, ensureSkillRegistry } from '@/lib/module-bootstrap';
 import { bootstrapPlatform, missingPlatformSkills, PLATFORM_SKILL_NAMES } from '@/lib/platform-seeds';
 
@@ -42,6 +43,18 @@ export function useFlowPilotBootstrap() {
   const { toast } = useToast();
   const { data: modules } = useModules();
   const isFlowPilotEnabled = modules?.flowpilot?.enabled ?? false;
+  // Every heal below ends in an admin-gated RPC (ensure_modules_settings,
+  // sync_skills_from_code, the cron registrar). AdminLayout mounts this hook
+  // BEFORE its auth redirect runs, so without this gate the first call went out
+  // as anon, the RPC correctly refused — and the catch path read that refusal
+  // as "all 67 modules missing" and raised a destructive toast on the login
+  // screen. A guard's refusal is not absence. Verified live on www 2026-08-24:
+  // the RPC denies anon (42501) while the row itself is complete and healthy.
+  //
+  // `rolesReady`, not just `user`: roles resolve a beat after the session, and
+  // gating on isAdmin before they land would skip the heal for real admins.
+  const { user, rolesReady, isAdmin } = useAuth();
+  const canHeal = !!user && rolesReady && isAdmin;
 
   const repair = useMutation({
     mutationFn: async () => {
@@ -130,6 +143,7 @@ export function useFlowPilotBootstrap() {
   // Cost on a healthy instance: one settings read plus one name-only read of
   // agent_skills, once per page load, and it writes nothing.
   useEffect(() => {
+    if (!canHeal) return; // wait for an admin session — see canHeal above
     let cancelled = false;
     (async () => {
       const result = await ensureModulesRow(defaultModulesSettings);
@@ -165,9 +179,10 @@ export function useFlowPilotBootstrap() {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [canHeal]); // re-runs when the admin session lands — the heal must still happen AFTER login
 
   useEffect(() => {
+    if (!canHeal) return; // wait for an admin session — see canHeal above
     if (platformHealStarted) return;
     platformHealStarted = true;
 
@@ -281,9 +296,10 @@ export function useFlowPilotBootstrap() {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [canHeal]); // re-runs when the admin session lands — the heal must still happen AFTER login
 
   useEffect(() => {
+    if (!canHeal) return; // wait for an admin session — see canHeal above
     if (!isFlowPilotEnabled || !modules || hasTriggered.current) return;
 
     let cancelled = false;
@@ -303,5 +319,5 @@ export function useFlowPilotBootstrap() {
     return () => {
       cancelled = true;
     };
-  }, [isFlowPilotEnabled, modules]);
+  }, [canHeal, isFlowPilotEnabled, modules]);
 }

--- a/src/lib/__tests__/platform-seed-selfheal.guardrails.test.ts
+++ b/src/lib/__tests__/platform-seed-selfheal.guardrails.test.ts
@@ -88,6 +88,40 @@ describe('platform self-heal condition', () => {
   });
 });
 
+describe('heals wait for an admin session', () => {
+  /**
+   * 2026-08-24, www.flowwink.com: a destructive toast on the LOGIN SCREEN read
+   * "Module settings not stored — 67 module(s) are missing". Nothing was
+   * missing. AdminLayout mounts this hook before its auth redirect runs, so the
+   * first ensureModulesRow() went out as anon; ensure_modules_settings
+   * correctly refused (42501); and the catch path counted a refusal as
+   * "all 67 modules absent". A guard's refusal is not absence.
+   *
+   * The RPCs these heals end in are admin-gated, so the gate is
+   * user + rolesReady + isAdmin — rolesReady because roles resolve a beat after
+   * the session, and gating on isAdmin before they land would skip the heal for
+   * real admins on every login.
+   */
+  const hook = readFileSync(join(__dirname, '../../hooks/useFlowPilotBootstrap.ts'), 'utf-8');
+
+  it('derives canHeal from an authenticated admin with roles resolved', () => {
+    expect(hook).toMatch(/const\s+canHeal\s*=\s*!!user\s*&&\s*rolesReady\s*&&\s*isAdmin/);
+  });
+
+  it('every heal effect returns early without canHeal', () => {
+    const gates = hook.match(/if \(!canHeal\) return;/g) ?? [];
+    // Three heal effects: modules-row + skill coverage, platform heal, soul repair.
+    expect(gates.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('the gated effects re-run when the admin session lands', () => {
+    // The gate must not strand the heal: canHeal flips true AFTER mount, so it
+    // has to sit in the dependency arrays or login never triggers the heal.
+    expect(hook.match(/\[canHeal\]/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    expect(hook).toContain('[canHeal, isFlowPilotEnabled, modules]');
+  });
+});
+
 describe('useFlowPilotBootstrap wiring', () => {
   it('uses the completeness condition, not a single-skill absence probe', () => {
     expect(HOOK_SOURCE).toContain('missingPlatformSkills');


### PR DESCRIPTION
## Symptomet

www.flowwink.com, på eller strax före inloggningsskärmen: **"Module settings not stored — 67 module(s) are missing from site_settings.modules"** som destruktiv toast.

## Uppmätt (inte resonerat) — inget är förstört

Probat live mot www:s Supabase med den publika anon-nyckeln:

1. `ensure_modules_settings` som anon → **42501 permission denied** (inte PGRST202 — funktionen finns, migrationen är applicerad, vakten fungerar)
2. `site_settings.modules` → **67 nycklar, 66 enabled, alla rikare än `{enabled}`** = en människa har sparat. Raden är hel.

## Roten

`AdminLayout` monterar `useFlowPilotBootstrap()` **före** sin auth-redirect. Första `ensureModulesRow()` gick ut som anon, RPC:n vägrade korrekt — och catch-grenen räknade vägran som *alla 67 moduler frånvarande*. **En vakts nej är inte frånvaro** — samma klass som obegränsad-läsning-buggen, från andra hållet.

## Fixen

Alla tre läkeffekter grindas på `user + rolesReady + isAdmin`:
- `rolesReady` — rollerna landar ett slag efter sessionen; grinda på `isAdmin` innan dess och läkningen skippas för riktiga admins
- `isAdmin` — RPC:erna kräver adminrollen; en inloggad **writer** hade annars fått samma falsklarm på varje sidladdning
- `canHeal` i beroendelistorna — grinden får inte stranda läkningen; den ska fortfarande köras **efter** inloggningen

Guardrail-test pinnar alla tre delarna.

## Verifiering

`tsc` exit 0 · 3218 tester gröna · correctness-gaten 0 fynd