### PR TITLE
audit(guards): två vakter som svalde

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,8 +3,23 @@
 # staged — the CI guardrail (instance-manifest.guardrails.test.ts) fails the
 # build if the committed manifest lags the tree, and humans forget (three
 # times on 2026-08-18 alone). Machines don't.
+#
+# Failure handling, deliberately split in two (the old line was
+# `... >/dev/null 2>&1 || exit 0`, which swallowed BOTH cases — including the
+# generator's duplicate-version REFUSAL, whose whole point is to be loud):
+#   * tooling missing (no bun) → warn and let the commit through; CI's
+#     freshness test still catches a stale manifest.
+#   * generator FAILS with tooling present → show its output and BLOCK. A
+#     refusal converted to a silent pass is how a guard stops guarding.
 if git diff --cached --name-only | grep -qE '^supabase/(migrations|seed)/'; then
   echo "[pre-commit] migrations/seeds staged — regenerating instance manifest"
-  npm run --silent manifest:json >/dev/null 2>&1 || exit 0
-  git add supabase/seed/instance-manifest.json
+  if ! command -v bun >/dev/null 2>&1; then
+    echo "[pre-commit] bun not installed — skipping manifest regen (CI will verify freshness)"
+  elif ! npm run --silent manifest:json; then
+    echo "[pre-commit] manifest generation FAILED (output above) — commit blocked."
+    echo "             Fix the cause (e.g. a migration version collision), then retry."
+    exit 1
+  else
+    git add supabase/seed/instance-manifest.json
+  fi
 fi

--- a/scripts/check-migration-forward-dated.ts
+++ b/scripts/check-migration-forward-dated.ts
@@ -143,8 +143,19 @@ const baseName = (f: string) => f.split('/').pop() ?? '';
 
 let postMerge: Set<string>;
 try {
+  // Files DELETED on this branch are not part of the post-merge state. Without
+  // this, a legitimate in-place rename (delete old name + add new name, SAME
+  // version) reads as two files claiming one version — main still holds the
+  // old name until the merge lands. Found by this guard's own audit on
+  // 2026-08-24, one day after it shipped; the forward-dating check above has
+  // handled the identical case via --diff-filter=D since the sentinel rename.
+  const deletedOnBranch = new Set(
+    sh(`git diff --no-renames --name-only --diff-filter=D ${mergeBase} -- ${MIGRATIONS_DIR}`)
+      .split('\n').map((s) => s.trim()).filter(Boolean).map((f) => f.split('/').pop() ?? ''),
+  );
   const onMain = sh(`git ls-tree -r --name-only ${baseRef} -- ${MIGRATIONS_DIR}`)
-    .split('\n').map((s) => s.trim()).filter((f) => f.endsWith('.sql'));
+    .split('\n').map((s) => s.trim()).filter((f) => f.endsWith('.sql'))
+    .filter((f) => !deletedOnBranch.has(f.split('/').pop() ?? ''));
   const onBranch = sh(`git ls-tree -r --name-only HEAD -- ${MIGRATIONS_DIR}`)
     .split('\n').map((s) => s.trim()).filter((f) => f.endsWith('.sql'));
   const untrackedNow = sh(`git ls-files --others --exclude-standard -- ${MIGRATIONS_DIR}`)


### PR DESCRIPTION
Stickprovsrevision av de senaste dagarnas leveranser. Två fynd i gårdagens egna grindar, båda bevisade före och efter fix:

1. **Kollisionsvakten falsklarmade på omdöpning med behållen version** — filer raderade på grenen räknades in i post-merge-mängden. Nu `--diff-filter=D`-hanterade, samma mönster som forward-dating-delen. Omdöpning passerar; äkta krock fälls fortfarande (båda negativtestade).

2. **Pre-commit-hooken svalde generatorfel** (`>/dev/null 2>&1 || exit 0`) — dubblett-vägran blev ett tyst pass. Nu: verktyg-saknas släpps igenom högljutt, generatorfel blockerar med synlig utdata. Skarpt negativtestat: kollision + commit → exit 1.