### PR TITLE
Add move up/down buttons to block toolbar for reordering

### DIFF
--- a/src/components/admin/blocks/BlockEditor.tsx
+++ b/src/components/admin/blocks/BlockEditor.tsx
@@ -717,6 +717,16 @@ export function BlockEditor({ blocks, onChange, canEdit }: BlockEditorProps) {
     [blocks, onChange]
   );
 
+  const handleMoveBlock = useCallback(
+    (blockId: string, direction: -1 | 1) => {
+      const oldIndex = blocks.findIndex((block) => block.id === blockId);
+      const newIndex = oldIndex + direction;
+      if (oldIndex === -1 || newIndex < 0 || newIndex >= blocks.length) return;
+      onChange(arrayMove(blocks, oldIndex, newIndex));
+    },
+    [blocks, onChange]
+  );
+
   const handleDeleteBlock = (blockId: string) => {
     onChange(blocks.filter((block) => block.id !== blockId));
     if (editingBlockId === blockId) {
@@ -1270,7 +1280,7 @@ export function BlockEditor({ blocks, onChange, canEdit }: BlockEditorProps) {
           items={blocks.map((b) => b.id)}
           strategy={verticalListSortingStrategy}
         >
-          {blocks.map((block) => (
+          {blocks.map((block, index) => (
             <BlockWrapper
               key={block.id}
               block={block}
@@ -1280,6 +1290,10 @@ export function BlockEditor({ blocks, onChange, canEdit }: BlockEditorProps) {
               }
               onDelete={() => handleDeleteBlock(block.id)}
               onCopy={() => handleCopyBlock(block)}
+              onMoveUp={() => handleMoveBlock(block.id, -1)}
+              onMoveDown={() => handleMoveBlock(block.id, 1)}
+              canMoveUp={index > 0}
+              canMoveDown={index < blocks.length - 1}
               onSpacingChange={(spacing) => handleUpdateBlockSpacing(block.id, spacing)}
               onAnimationChange={(animation) => handleUpdateBlockAnimation(block.id, animation)}
               onAnchorChange={(anchorId) => handleUpdateBlockAnchor(block.id, anchorId)}

--- a/src/components/admin/blocks/BlockWrapper.tsx
+++ b/src/components/admin/blocks/BlockWrapper.tsx
@@ -1,6 +1,6 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Trash2, Settings, Copy, Eye, EyeOff } from 'lucide-react';
+import { GripVertical, Trash2, Settings, Copy, Eye, EyeOff, ArrowUp, ArrowDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ContentBlock, ContentBlockType, BlockSpacing, BlockAnimation, SectionBackground } from '@/types/cms';
 import { cn } from '@/lib/utils';
@@ -88,6 +88,10 @@ interface BlockWrapperProps {
   onEdit: () => void;
   onDelete: () => void;
   onCopy?: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
   onSpacingChange?: (spacing: BlockSpacing) => void;
   onAnimationChange?: (animation: BlockAnimation) => void;
   onAnchorChange?: (anchorId: string | undefined) => void;
@@ -103,6 +107,10 @@ export function BlockWrapper({
   onEdit,
   onDelete,
   onCopy,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp = false,
+  canMoveDown = false,
   onSpacingChange,
   onAnimationChange,
   onAnchorChange,
@@ -157,6 +165,38 @@ export function BlockWrapper({
               {BLOCK_LABELS[block.type]}
             </span>
           </div>
+          {onMoveUp && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-7 w-7 bg-card"
+                  onClick={onMoveUp}
+                  disabled={!canMoveUp}
+                >
+                  <ArrowUp className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Move up</TooltipContent>
+            </Tooltip>
+          )}
+          {onMoveDown && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-7 w-7 bg-card"
+                  onClick={onMoveDown}
+                  disabled={!canMoveDown}
+                >
+                  <ArrowDown className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Move down</TooltipContent>
+            </Tooltip>
+          )}
           <Tooltip>
             <TooltipTrigger asChild>
               <Button


### PR DESCRIPTION
## Summary

Drag-and-drop reordering of blocks in the page editor can feel fiddly. This adds **Move up** / **Move down** buttons to the block toolbar (the same hover toolbar as edit/copy/hide/delete) as a complement — DnD is untouched.

## Changes

- **`src/components/admin/blocks/BlockEditor.tsx`** — new `handleMoveBlock(blockId, direction)` that reuses the exact same `arrayMove` reordering as the DnD drop handler (`handleDragEnd`); passes `onMoveUp`/`onMoveDown` handlers plus `canMoveUp`/`canMoveDown` flags to `BlockWrapper`.
- **`src/components/admin/blocks/BlockWrapper.tsx`** — two new shadcn/ui icon buttons with lucide `ArrowUp`/`ArrowDown` and tooltips ("Move up" / "Move down"), styled identically to the neighboring toolbar buttons. Up is disabled on the first block, down on the last.

## Verification

- `npx tsc -p tsconfig.app.json` — clean, 0 errors
- `npx vitest run` — 243 test files, 3288 tests passed (5 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01We5YgMnQGHAxznPynGAmAQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01We5YgMnQGHAxznPynGAmAQ)_