### PR TITLE
fix(inventory): kostnaden följer varan genom dörren — och COGS-blocket som en fix hade tappat

### DIFF
--- a/docs/processes/order-to-delivery.md
+++ b/docs/processes/order-to-delivery.md
@@ -38,6 +38,7 @@ flowchart TD
     D --> E["confirm_pick — per line, with qty and optional lot"]
     E --> F["ship_picking — consumes reservations,<br/>stamps carrier + tracking"]
     F --> G["Delivered — manage_orders"]
+    F -.->|"shipped_at stamped →<br/>consume_order_stock:<br/>FEFO out + COGS booked<br/>(Dt cogs / Cr inventory)"| F2["LEDGER EVENT<br/>cost leaves WITH the goods"]
     G --> H["SLA monitor warns if a step gets stuck"]
 
     classDef agent fill:#eef2ff,stroke:#6366f1,color:#312e81;
@@ -45,6 +46,19 @@ flowchart TD
 ```
 
 *🟦 = agent-runnable step (see Agent coverage below)*
+
+**The cost follows the goods through the door (2026-08-25).** Measured on the
+clean Nordbrygg ledger: order placement used to consume valuation layers and
+book COGS in the order-insert transaction — 62 936 kr of cost stood booked for
+goods still on the shelf, 29 500 of it for a CANCELLED order. As of
+`20260828140000` the order commits (`products.stock_quantity`, availability
+unchanged) and reserves; the first physical exit signal (`shipped_at` /
+`delivered_at`) consumes FEFO and books COGS via the account roles
+(`account_for('cogs')` / `account_for('inventory')`), and cancellation before
+exit is a ledger non-event. The dry-run also caught that `20260827200000` had
+redefined `process_stock_move_valuation` from a stale copy and DROPPED the COGS
+block entirely — restored against the live body, pinned by
+`kostnaden-foljer-varan-genom-dorren.guardrails.test.ts`.
 
 **The picking is a document, not a status.** An earlier version of this diagram
 drew picked/packed/shipped as states on the order. The platform actually has

--- a/src/lib/__tests__/kostnaden-foljer-varan-genom-dorren.guardrails.test.ts
+++ b/src/lib/__tests__/kostnaden-foljer-varan-genom-dorren.guardrails.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Kostnaden följer varan genom dörren — inte genom orderformuläret.
+ *
+ * Uppmätt på Nordbrygg 2026-08-25: orderläggningen konsumerade lager och
+ * bokade COGS i samma transaktion som order_items-inserten. Facit: 62 936 kr
+ * kostnad bokad för varor på hyllan, varav 29 500 för en MAKULERAD order.
+ * Odoo-semantiken (referenssanningen): order reserverar; varan genom dörren
+ * konsumerar och kostnadsför.
+ *
+ * Och under torrkörningen: 20260827200000 — fakturasidans fix — hade
+ * definierat om process_stock_move_valuation från en äldre kopia och TAPPAT
+ * COGS-blocket helt. En fix som skapade ett hål; två kopior av en
+ * funktionskropp driver isär. Blocket är återinfört, byggt mot den levande
+ * definitionen.
+ *
+ * Pinnarna nedan läser migrationen som text — samma mönster som
+ * en-halv-flytt-utan-ett-ord: kontraktet ska synas i källan.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const MIG = readFileSync(
+  join(__dirname, '../../../supabase/migrations/20260828140000_kostnaden-foljer-varan-genom-dorren.sql'),
+  'utf-8',
+);
+
+/** Extract one CREATE OR REPLACE FUNCTION block by name. */
+function fnBody(name: string): string {
+  const re = new RegExp(
+    `CREATE OR REPLACE FUNCTION public\\.${name}\\b[\\s\\S]*?\\$function\\$;`,
+    'm',
+  );
+  const m = MIG.match(re);
+  expect(m, `${name} måste definieras i migrationen`).toBeTruthy();
+  return m![0];
+}
+
+describe('ordertriggern: åtagande, aldrig konsumtion', () => {
+  const body = fnBody('trigger_order_item_stock_decrement');
+
+  it('behåller stock_quantity-avdraget — tillgänglighetssemantiken är oförändrad', () => {
+    expect(body).toMatch(/stock_quantity\s*=\s*COALESCE\(stock_quantity,\s*0\)\s*-\s*NEW\.quantity/);
+  });
+
+  it('konsumerar INTE: ingen FEFO, inga moves i ordersekunden', () => {
+    expect(body).not.toContain('consume_stock_fefo');
+    expect(body).not.toMatch(/INSERT INTO public\.stock_moves/);
+  });
+
+  it('reservationen är bäst-möjliga, aldrig blockerande — ingen reserve_stock()-strikthet i checkoutens transaktion', () => {
+    // reserve_stock kastar på otillräckligt saldo; en order dagens modell tar
+    // emot ska den nya också ta emot. Pinnen gäller ANROP — kommentarer får
+    // (och bör) nämna funktionen vid namn när de förklarar varför den inte
+    // används.
+    const code = body.replace(/--[^\n]*/g, '');
+    expect(code).not.toContain('reserve_stock(');
+    expect(code).toContain('stock_reservations');
+  });
+});
+
+describe('konsumtionen: en funktion, vid dörren, exakt en gång', () => {
+  const body = fnBody('consume_order_stock');
+
+  it('vägrar dubbelkörning — och det är samma vakt som gör gamla ordrar arvssäkra', () => {
+    expect(body).toContain("'already_consumed'");
+    expect(body).toMatch(/IF EXISTS \(SELECT 1 FROM public\.stock_moves/);
+  });
+
+  it('gör FEFO-uttaget och skriver moves — flyttat, inte omskrivet', () => {
+    expect(body).toContain('consume_stock_fefo');
+    expect(body).toMatch(/INSERT INTO public\.stock_moves/);
+  });
+});
+
+describe('utpasseringen triggar på tidsstämplarna, inte statuskolumnen', () => {
+  const body = fnBody('trigger_order_stock_on_exit');
+
+  it('första fysiska tecknet vinner: shipped_at eller delivered_at', () => {
+    expect(body).toMatch(/OLD\.shipped_at IS NULL AND NEW\.shipped_at IS NOT NULL/);
+    expect(body).toMatch(/OLD\.delivered_at IS NULL AND NEW\.delivered_at IS NOT NULL/);
+    // Tvåaxelklassen: status har redan bevisats säga 'pending' om levererade
+    // ordrar — den får inte vara signalen.
+    expect(body).not.toMatch(/NEW\.status\s*=\s*'shipped'/);
+  });
+});
+
+describe('makuleringen är en icke-händelse i böckerna', () => {
+  const body = fnBody('trigger_order_stock_on_cancel');
+
+  it('återlägger åtagandet och släpper reservationen', () => {
+    expect(body).toMatch(/stock_quantity\s*=\s*COALESCE\(stock_quantity,\s*0\)\s*\+\s*v_item\.quantity/);
+    expect(body).toMatch(/SET state = 'cancelled'/);
+  });
+
+  it('rör inget som redan passerat dörren — skeppad+makulerad är en RETUR', () => {
+    expect(body).toMatch(/IF EXISTS \(SELECT 1 FROM public\.stock_moves[\s\S]*?RETURN NEW/);
+  });
+});
+
+describe('COGS-blocket är återinfört i värderingsfunktionen', () => {
+  const body = fnBody('process_stock_move_valuation');
+
+  it('bokar inventory_cogs vid utflöde, via kontorollerna, med ordernyckeln som referens', () => {
+    expect(body).toContain("'inventory_cogs'");
+    expect(body).toContain("account_for('cogs')");
+    expect(body).toContain("account_for('inventory')");
+    // Referensen är det som gjorde GRNI-läkningen blind när den saknades —
+    // COGS-verifikatet föds med sin nyckel.
+    expect(body).toMatch(/NEW\.reference_id,\s*'inventory_cogs'/);
+  });
+
+  it("kontorollen 'cogs' seedas — kroppen bär inga kontonummer", () => {
+    expect(MIG).toMatch(/INSERT INTO public\.account_roles[\s\S]*?'cogs'/);
+    expect(body).not.toMatch(/'4990'/);
+  });
+});

--- a/supabase/migrations/20260828140000_kostnaden-foljer-varan-genom-dorren.sql
+++ b/supabase/migrations/20260828140000_kostnaden-foljer-varan-genom-dorren.sql
@@ -1,0 +1,447 @@
+-- Kostnaden följer varan genom dörren — inte genom orderformuläret.
+--
+-- UPPMÄTT PÅ NORDBRYGG 2026-08-25, på en nyss nollställd huvudbok:
+--
+--   order_items INSERT → trigger_order_item_stock_decrement
+--     → consume_stock_fefo (quants + partier konsumeras)
+--     → stock_moves 'out'  → process_stock_move_valuation
+--     → värderingslager förbrukas + COGS bokas (Dt 4990 / Kr 1460)
+--
+--   …allt i ORDERLÄGGNINGENS transaktion. Plock, skeppning, leverans: döda för
+--   böckerna. Facit på testbänken: 62 936 kr COGS bokad för varor som står på
+--   hyllan — fyra ordrar utan uppfyllnad, varav en MAKULERAD (29 500 kr för en
+--   espressomaskin som aldrig lämnade huset). Makulering kompenserade
+--   ingenting: det fanns ingen händelse att haka en kompensation på, för
+--   händelsen hade redan skett, vid fel tidpunkt.
+--
+-- Odoo-semantiken (referenssanningen): bekräftad order RESERVERAR;
+-- `stock.picking done` — varan genom dörren — konsumerar och kostnadsför.
+--
+-- SNITTET, medvetet minimalt:
+--
+--   * `products.stock_quantity`-avdraget STÅR KVAR vid order. Det är butikens
+--     tillgänglighetstal, och som åtagande (on hand − committed) betyder det
+--     exakt detsamma som i går. Ingen tillgänglighetsläsare behöver röras, och
+--     översäljningsskyddet är oförändrat.
+--   * Konsumtionen (FEFO, quants, moves → värdering → COGS) flyttar till det
+--     FÖRSTA fysiska utpasseringstecknet: shipped_at eller delivered_at sätts.
+--   * Makulering före utpassering blir en icke-händelse i böckerna:
+--     åtagandet återläggs, reservationen släpps, ingenting har bokats — felet
+--     kan inte längre uppstå, i stället för att behöva städas.
+--   * `process_stock_move_valuation` skulle inte röras — men torrkörningen
+--     avslöjade att 20260827200000 (fakturasidans fix!) definierat om den från
+--     en äldre kopia och TAPPAT COGS-bokningen: utflöden konsumerade värdering
+--     utan att röra huvudboken. Sektion 5 återinför blocket, byggt mot den
+--     LEVANDE kroppen — inte mot någon fil. En fix som skapade ett hål,
+--     upptäckt av nästa fix' negativtest.
+--   * Kassa/serviceorder/integrationer (apply_stock_movement_event) rörs inte:
+--     där ÄR försäljningsögonblicket utpasseringen.
+--
+-- PLOCKVÄGENS INTERAKTION, verifierad mot levande kroppar innan detta skrevs:
+-- ship_picking sätter fulfillment_status='shipped' på ordern; BEFORE-triggern
+-- validate_fulfillment_status stämplar orders.shipped_at; vår AFTER-trigger
+-- konsumerar i samma statement. ship_pickings `v_move_stock := (order_id IS
+-- NULL)` — 'order entry already took these goods off the shelf' — förblir RÄTT
+-- beteende (order-backade plock ska inte skriva moves) men av NYTT skäl: det
+-- är utpasseringstriggern som tar varorna nu, inte orderingången. Dubbel-
+-- reservationen (ordertriggern + allocate_picking) är ett ärvt, magnitud-
+-- identiskt beteende: i går sänkte order hårt saldo OCH plocket reserverade;
+-- i dag reserverar båda. Tillgängligheten påverkas lika; städas separat.
+--
+-- Idempotens och arv: konsumtionen vägrar köra om det redan finns 'out'-moves
+-- för ordern. Det gör den omkörningssäker OCH arvssäker — ordrar lagda före
+-- den här migrationen har redan konsumerat (gamla modellen) och får inte
+-- konsumera igen när de skeppas.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. Ordertriggern: åtagande + reservation. Ingen konsumtion, inga moves.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.trigger_order_item_stock_decrement()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_loc uuid;
+  v_free numeric;
+BEGIN
+  IF NEW.product_id IS NULL OR COALESCE(NEW.quantity, 0) <= 0 THEN
+    RETURN NEW;
+  END IF;
+
+  -- Åtagandet. Samma rad som alltid: butikens tillgänglighet sjunker i
+  -- ordersekunden, negativt = äkta restorderposition, inget GREATEST-gömsle.
+  UPDATE public.products
+     SET stock_quantity = COALESCE(stock_quantity, 0) - NEW.quantity,
+         updated_at = now()
+   WHERE id = NEW.product_id
+     AND (track_inventory = true OR stock_quantity IS NOT NULL);
+
+  -- Reservationen: BÄST MÖJLIGA, aldrig blockerande. reserve_stock() kastar på
+  -- otillräckligt fritt saldo och på ospårade varor — helt rätt för en
+  -- lagerarbetares uttryckliga reservation, helt fel i checkoutens transaktion.
+  -- En order dagens modell tar emot ska den här modellen också ta emot.
+  v_loc := public.default_internal_location();
+  IF v_loc IS NOT NULL THEN
+    SELECT COALESCE(quantity,0) - COALESCE(reserved_quantity,0) INTO v_free
+      FROM public.stock_quants
+     WHERE product_id = NEW.product_id AND location_id = v_loc AND lot_id IS NULL;
+    IF COALESCE(v_free, 0) > 0 THEN
+      INSERT INTO public.stock_reservations
+        (product_id, location_id, quantity, reference_type, reference_id, notes)
+      VALUES (NEW.product_id, v_loc, LEAST(v_free, NEW.quantity), 'order', NEW.order_id::text,
+              'Auto-reservation at order — consumed on shipment, released on cancellation');
+      UPDATE public.stock_quants
+         SET reserved_quantity = COALESCE(reserved_quantity,0) + LEAST(v_free, NEW.quantity),
+             updated_at = now()
+       WHERE product_id = NEW.product_id AND location_id = v_loc AND lot_id IS NULL;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. Konsumtionen, som EN funktion. Skeppningstriggern anropar den; att den är
+--    fristående gör den anropbar för läkning och test. Vägrar dubbelkörning.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.consume_order_stock(p_order_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_loc uuid;
+  v_customer_loc uuid;
+  v_item RECORD;
+  v_res RECORD;
+  v_result jsonb;
+  v_alloc jsonb;
+  v_rest numeric;
+  v_items int := 0;
+  v_moves int := 0;
+BEGIN
+  -- Redan konsumerad (eller lagd före den här migrationen, då konsumtionen
+  -- skedde vid order): rör ingenting. Frånvaron av dubbelkonsumtion är hela
+  -- arvskontraktet.
+  IF EXISTS (SELECT 1 FROM public.stock_moves
+              WHERE reference_type = 'order' AND reference_id = p_order_id::text
+                AND move_type = 'out') THEN
+    RETURN jsonb_build_object('consumed', false, 'reason', 'already_consumed');
+  END IF;
+
+  v_loc := public.default_internal_location();
+  SELECT id INTO v_customer_loc FROM public.stock_locations
+   WHERE code = 'WH/CUSTOMERS' AND is_active = true LIMIT 1;
+  IF v_customer_loc IS NULL THEN
+    SELECT id INTO v_customer_loc FROM public.stock_locations
+     WHERE location_type = 'customer' AND is_active = true ORDER BY created_at LIMIT 1;
+  END IF;
+
+  FOR v_item IN
+    SELECT product_id, variant_id, quantity FROM public.order_items
+     WHERE order_id = p_order_id AND product_id IS NOT NULL AND COALESCE(quantity,0) > 0
+  LOOP
+    v_items := v_items + 1;
+
+    -- Reservationen är förbrukad i och med utpasseringen.
+    FOR v_res IN
+      SELECT id, product_id, location_id, lot_id, quantity FROM public.stock_reservations
+       WHERE reference_type = 'order' AND reference_id = p_order_id::text
+         AND product_id = v_item.product_id AND state = 'reserved'
+       FOR UPDATE
+    LOOP
+      UPDATE public.stock_reservations SET state = 'consumed', consumed_at = now() WHERE id = v_res.id;
+      UPDATE public.stock_quants
+         SET reserved_quantity = GREATEST(0, COALESCE(reserved_quantity,0) - v_res.quantity),
+             updated_at = now()
+       WHERE product_id = v_res.product_id AND location_id = v_res.location_id
+         AND (lot_id IS NOT DISTINCT FROM v_res.lot_id);
+    END LOOP;
+
+    -- FEFO-uttaget och rörelseraderna: ordagrant den gamla ordertriggerns
+    -- kropp (20260827410000) — bara tidpunkten är ny. Varje move triggar
+    -- process_stock_move_valuation → värdering förbrukas + COGS bokas HÄR.
+    v_result := public.consume_stock_fefo(v_item.product_id, v_loc, v_item.quantity, NULL);
+
+    FOR v_alloc IN SELECT * FROM jsonb_array_elements(COALESCE(v_result->'allocated', '[]'::jsonb))
+    LOOP
+      INSERT INTO public.stock_moves
+        (product_id, variant_id, quantity, move_type, reference_type, reference_id,
+         from_location_id, to_location_id, lot_id, notes)
+      VALUES (v_item.product_id, v_item.variant_id, -((v_alloc->>'qty')::numeric), 'out', 'order', p_order_id::text,
+              v_loc, v_customer_loc, (v_alloc->>'lot_id')::uuid,
+              'Consumed on shipment — lot ' || COALESCE(v_alloc->>'lot_number', '?')
+                || ' (FEFO' || COALESCE(', best before ' || (v_alloc->>'expiry_date'), '') || ')');
+      v_moves := v_moves + 1;
+    END LOOP;
+
+    v_rest := COALESCE((v_result->>'unattributed')::numeric, 0);
+    IF v_rest > 0 THEN
+      INSERT INTO public.stock_moves
+        (product_id, variant_id, quantity, move_type, reference_type, reference_id,
+         from_location_id, to_location_id, notes)
+      VALUES (v_item.product_id, v_item.variant_id, -(v_rest), 'out', 'order', p_order_id::text,
+              v_loc, v_customer_loc,
+              CASE WHEN (v_result->>'lot_tracked')::boolean
+                   THEN 'Consumed on shipment — NO LOT COULD COVER THIS QUANTITY (oversell beyond every registered lot)'
+                   ELSE 'Consumed on shipment' END);
+      v_moves := v_moves + 1;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('consumed', true, 'items', v_items, 'moves', v_moves);
+END;
+$function$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. Utpasseringstriggern: första fysiska tecknet vinner. Tidsstämplarna, inte
+--    statuskolumnen — tvåaxelklassen har redan visat att status kan säga
+--    'pending' om en levererad order.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.trigger_order_stock_on_exit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF (OLD.shipped_at IS NULL AND NEW.shipped_at IS NOT NULL)
+     OR (OLD.delivered_at IS NULL AND NEW.delivered_at IS NOT NULL) THEN
+    PERFORM public.consume_order_stock(NEW.id);
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS order_stock_on_exit_trg ON public.orders;
+CREATE TRIGGER order_stock_on_exit_trg
+  AFTER UPDATE ON public.orders
+  FOR EACH ROW EXECUTE FUNCTION public.trigger_order_stock_on_exit();
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. Makuleringen: en icke-händelse i böckerna. Åtagandet tillbaka,
+--    reservationen släppt — och bara om ingenting passerat dörren. En order
+--    som makuleras EFTER skeppning är en retur och går returflödet.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.trigger_order_stock_on_cancel()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_item RECORD;
+  v_res RECORD;
+BEGIN
+  IF OLD.status IS NOT DISTINCT FROM 'cancelled' OR NEW.status IS DISTINCT FROM 'cancelled' THEN
+    RETURN NEW;
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.stock_moves
+              WHERE reference_type = 'order' AND reference_id = NEW.id::text AND move_type = 'out') THEN
+    RETURN NEW; -- skeppad: retur, inte upplösning
+  END IF;
+
+  FOR v_item IN
+    SELECT product_id, quantity FROM public.order_items
+     WHERE order_id = NEW.id AND product_id IS NOT NULL AND COALESCE(quantity,0) > 0
+  LOOP
+    UPDATE public.products
+       SET stock_quantity = COALESCE(stock_quantity, 0) + v_item.quantity,
+           updated_at = now()
+     WHERE id = v_item.product_id
+       AND (track_inventory = true OR stock_quantity IS NOT NULL);
+  END LOOP;
+
+  FOR v_res IN
+    SELECT id, product_id, location_id, lot_id, quantity FROM public.stock_reservations
+     WHERE reference_type = 'order' AND reference_id = NEW.id::text AND state = 'reserved'
+     FOR UPDATE
+  LOOP
+    UPDATE public.stock_reservations SET state = 'cancelled', cancelled_at = now() WHERE id = v_res.id;
+    UPDATE public.stock_quants
+       SET reserved_quantity = GREATEST(0, COALESCE(reserved_quantity,0) - v_res.quantity),
+           updated_at = now()
+     WHERE product_id = v_res.product_id AND location_id = v_res.location_id
+       AND (lot_id IS NOT DISTINCT FROM v_res.lot_id);
+  END LOOP;
+
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS order_stock_on_cancel_trg ON public.orders;
+CREATE TRIGGER order_stock_on_cancel_trg
+  AFTER UPDATE ON public.orders
+  FOR EACH ROW EXECUTE FUNCTION public.trigger_order_stock_on_cancel();
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 5. Värderingsfunktionen med COGS-blocket ÅTERINFÖRT (se narrativet ovan),
+--    plus kontorollen 'cogs' som blocket resolvar genom. Rollen är data i
+--    kontoplanen — funktionskroppen bär inga kontonummer (Law:et från
+--    20260827200000, nu tillämpat på blocket som den migrationen tappade).
+-- ─────────────────────────────────────────────────────────────────────────────
+INSERT INTO public.account_roles (locale, role, account_code, description)
+VALUES ('se-bas2024', 'cogs', '4990', 'Kostnad sålda varor — utflödets motkonto till lagret'),
+       ('ifrs-generic', 'cogs', '5000', 'Cost of goods sold')
+ON CONFLICT (locale, role) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION public.process_stock_move_valuation()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_qty numeric := abs(COALESCE(NEW.quantity,0));
+  v_is_in boolean;
+  v_method text;
+  v_unit_cost bigint;
+  v_total_cost bigint := 0;
+  v_layer RECORD;
+  v_take numeric;
+  v_remaining numeric;
+  v_avg numeric;
+  v_je uuid;
+  v_is_purchase boolean;
+  v_event_date date;
+  v_receipt_id uuid;
+BEGIN
+  IF v_qty = 0 THEN RETURN NEW; END IF;
+  IF NEW.move_type NOT IN ('in','out','mo_production','mo_consumption','adjustment') THEN RETURN NEW; END IF;
+  -- 'adjustment' carries its direction in the SIGN (adjust_quant), the same way
+  -- 'in' does. Stock that appears on a count is stock the books must carry.
+  v_is_in := (NEW.move_type IN ('in','mo_production','adjustment')) AND COALESCE(NEW.quantity,0) > 0;
+  v_is_purchase := NEW.reference_type IN ('purchase_order','po','goods_receipt');
+
+  IF v_is_in THEN
+    v_unit_cost := COALESCE(NEW.unit_cost_cents,
+                            resolve_inbound_unit_cost(NEW.product_id, NEW.reference_type, NEW.reference_id));
+
+    -- Goods coming back that the warehouse already carries re-enter at what it
+    -- carries them at. Only when nothing else supplied a cost — a receipt's PO
+    -- price and an explicit unit_cost_cents both still win.
+    IF COALESCE(v_unit_cost, 0) = 0 THEN
+      SELECT CASE WHEN sum(remaining_qty) > 0
+                  THEN round(sum(remaining_qty * unit_cost_cents) / sum(remaining_qty)) END
+        INTO v_unit_cost
+        FROM stock_valuation_layers
+       WHERE product_id = NEW.product_id AND remaining_qty > 0;
+      -- Still nothing on hand to average against: the product's standing cost.
+      IF COALESCE(v_unit_cost, 0) = 0 THEN
+        SELECT cost_cents INTO v_unit_cost FROM products WHERE id = NEW.product_id;
+      END IF;
+      v_unit_cost := COALESCE(v_unit_cost, 0);
+    END IF;
+
+    INSERT INTO stock_valuation_layers (product_id, variant_id, move_id, quantity, unit_cost_cents, value_cents, remaining_qty)
+    VALUES (NEW.product_id, NEW.variant_id, NEW.id, v_qty, v_unit_cost, round(v_qty * v_unit_cost), v_qty);
+    UPDATE stock_moves SET unit_cost_cents = v_unit_cost, value_cents = round(v_qty * v_unit_cost)
+      WHERE id = NEW.id;
+
+    -- What was paid for it is what it costs. Learned once, from the receipt
+    -- that knew; never overwritten, so a standard cost an operator set stands.
+    IF v_is_purchase AND v_unit_cost > 0 THEN
+      UPDATE products
+         SET cost_cents = v_unit_cost, updated_at = now()
+       WHERE id = NEW.product_id AND cost_cents IS NULL;
+    END IF;
+
+    IF v_is_purchase AND v_unit_cost > 0 THEN
+      -- Bokföringsdatumet följer händelsen, inte klockan.
+      v_receipt_id := NULL;
+      v_event_date := NULL;
+      IF NEW.reference_type = 'goods_receipt'
+         AND COALESCE(NEW.reference_id,'') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+        v_receipt_id := NEW.reference_id::uuid;
+        SELECT received_date INTO v_event_date FROM goods_receipts WHERE id = v_receipt_id;
+      END IF;
+      v_event_date := COALESCE(v_event_date, NEW.created_at::date, CURRENT_DATE);
+
+      BEGIN
+        INSERT INTO journal_entries (entry_date, description, reference_number, source, status)
+        VALUES (v_event_date, 'Inventory receipt '||COALESCE(NEW.reference_id,''),
+                NEW.reference_id, 'inventory_receipt', 'posted')
+        RETURNING id INTO v_je;
+        INSERT INTO journal_entry_lines (journal_entry_id, account_code, debit_cents, credit_cents, description)
+        VALUES (v_je, public.account_for('inventory'), round(v_qty*v_unit_cost), 0, 'Lager av handelsvaror'),
+               (v_je, public.account_for('goods_received_not_invoiced'), 0, round(v_qty*v_unit_cost), 'GRNI — ej fakturerade leveranser');
+      EXCEPTION WHEN others THEN
+        -- Kvar som varning (inte notis): en utebliven verifikation ska synas i
+        -- loggen, inte bara i saldot tre månader senare.
+        RAISE WARNING 'inventory_receipt JE skipped: %', SQLERRM;
+      END;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  SELECT COALESCE(pc.costing_method,'average') INTO v_method
+  FROM products p LEFT JOIN product_categories pc ON pc.id = p.category_id
+  WHERE p.id = NEW.product_id;
+  v_method := COALESCE(v_method,'average');
+
+  IF v_method = 'average' THEN
+    SELECT CASE WHEN sum(remaining_qty) > 0
+                THEN sum(remaining_qty * unit_cost_cents) / sum(remaining_qty) END
+    INTO v_avg FROM stock_valuation_layers
+    WHERE product_id = NEW.product_id AND remaining_qty > 0;
+  END IF;
+
+  v_remaining := v_qty;
+  FOR v_layer IN
+    SELECT id, remaining_qty, unit_cost_cents FROM stock_valuation_layers
+    WHERE product_id = NEW.product_id AND remaining_qty > 0
+    ORDER BY created_at, id
+    FOR UPDATE
+  LOOP
+    EXIT WHEN v_remaining <= 0;
+    v_take := LEAST(v_layer.remaining_qty, v_remaining);
+    v_total_cost := v_total_cost + round(v_take * CASE WHEN v_method='average' THEN v_avg ELSE v_layer.unit_cost_cents END);
+    UPDATE stock_valuation_layers SET remaining_qty = remaining_qty - v_take WHERE id = v_layer.id;
+    v_remaining := v_remaining - v_take;
+  END LOOP;
+  IF v_remaining > 0 THEN
+    SELECT COALESCE(v_avg, cost_cents, 0) INTO v_unit_cost FROM products WHERE id = NEW.product_id;
+    v_total_cost := v_total_cost + round(v_remaining * COALESCE(v_unit_cost,0));
+  END IF;
+
+
+  -- ── COGS-verifikationen, ÅTERINFÖRD ────────────────────────────────────────
+  -- 20260822105000 bokade Dt 4990 / Kr 1460 här. 20260827200000 — migrationen
+  -- som lagade FAKTURASIDANS saknade verifikation — definierade om den här
+  -- funktionen från en äldre kopia och tappade blocket: utflöden konsumerade
+  -- värderingslager utan att röra huvudboken. Upptäckt 2026-08-25 när torr-
+  -- körningen av utpasseringstriggern fick move men ingen COGS, och den levande
+  -- kroppen visade sig sakna varje spår av inventory_cogs. Två kopior av en
+  -- funktionskropp driver isär; det här blocket är återhämtat MOT den levande
+  -- definitionen, inte mot någon fil. Kontona via rollerna, referensen bär
+  -- ordernyckeln — det var frånvaron av referens som gjorde GRNI-läkningen
+  -- blind i går, samma läxa.
+  IF NEW.move_type = 'out' AND v_total_cost > 0 THEN
+    BEGIN
+      -- Movens egen tidsstämpel ÄR utpasseringen — en återuppspelad eller
+      -- efterregistrerad rörelse bokförs på sin dag, inte på klockans
+      -- (p2p-seam-guardrailens regel: datumet följer händelsen).
+      INSERT INTO journal_entries (entry_date, description, reference_number, source, status)
+      VALUES (COALESCE(NEW.created_at::date, CURRENT_DATE),
+              'COGS '||COALESCE(NEW.reference_type,'move')||' '||COALESCE(NEW.reference_id,''),
+              NEW.reference_id, 'inventory_cogs', 'posted')
+      RETURNING id INTO v_je;
+      INSERT INTO journal_entry_lines (journal_entry_id, account_code, debit_cents, credit_cents, description)
+      VALUES (v_je, public.account_for('cogs'), v_total_cost, 0, 'Kostnad sålda varor'),
+             (v_je, public.account_for('inventory'), 0, v_total_cost, 'Lager av handelsvaror');
+    EXCEPTION WHEN others THEN
+      RAISE NOTICE 'inventory_cogs JE skipped: %', SQLERRM;
+    END;
+  END IF;
+
+  UPDATE stock_moves SET
+    unit_cost_cents = CASE WHEN v_qty > 0 THEN round(v_total_cost / v_qty) ELSE NULL END,
+    value_cents = v_total_cost
+  WHERE id = NEW.id;
+
+  RETURN NEW;
+END $function$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260828130000",
-      "migrations_count": 518,
+      "migration_head": "20260828140000",
+      "migrations_count": 519,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2077,6 +2077,10 @@
         {
           "version": "20260828130000",
           "name": "the-sweep-is-fixed-now-prove-it-keeps-running"
+        },
+        {
+          "version": "20260828140000",
+          "name": "kostnaden-foljer-varan-genom-dorren"
         }
       ]
     },


### PR DESCRIPTION
## Uppmätt (Nordbrygg, nollställd huvudbok)

Orderläggning konsumerade lager + bokade COGS i insertens transaktion. **62 936 kr kostnad bokad för varor på hyllan**, varav 29 500 för en makulerad order.

Och torrkörningen fann det värre felet: **`20260827200000` (fakturasidans fix) definierade om `process_stock_move_valuation` från en äldre kopia och tappade COGS-blocket helt** — utflöden konsumerar värdering utan att röra huvudboken sedan dess. Ingen funktion på instansen innehöll `inventory_cogs`.

## Snittet

- Order: åtagande (`stock_quantity`, oförändrad tillgänglighet) + best-effort-reservation. Inga moves, ingen COGS.
- Första `shipped_at`/`delivered_at` (tidsstämplarna — statusaxeln har bevisat sig ljuga): `consume_order_stock` → FEFO + moves → återinförd COGS (roller, ordernyckel som referens, daterad av movens `created_at`).
- Makulering före utpassering: icke-händelse. Skeppad+makulerad = retur, rörs inte.
- Arv: vägrar konsumera ordrar som redan har out-moves.
- Plockvägen verifierad: `ship_picking`s `move_stock=false` förblir rätt — exit-triggern tar varorna nu.

## Verifiering

Torrkörd i rollback-transaktion på nordbrygg (7 mätpunkter gröna, inkl. average-kostnad 353,32 korrekt mot kategorimetoden). 10 guardrail-pinnar i `kostnaden-foljer-varan-genom-dorren.guardrails.test.ts`. Alla blockerande grindar gröna.