### PR TITLE
fix(editor): 'unsaved changes' kräver en gest

### DIFF
--- a/src/lib/__tests__/editor-dirty-needs-a-gesture.guardrails.test.ts
+++ b/src/lib/__tests__/editor-dirty-needs-a-gesture.guardrails.test.ts
@@ -1,0 +1,44 @@
+/**
+ * "Unsaved changes" kräver en gest.
+ *
+ * 2026-08-25, optic: öppna en sida, rör ingenting, stäng — och dialogen frågar
+ * om osparade ändringar. Tiptap normaliserar lagrat innehåll vid initiering
+ * (schema-lagningar, especially agent-written pages via markdownToTiptap), och
+ * normaliseringen fyrar samma onUpdate → onChange-väg som ett tangenttryck.
+ * En latchad hasChanges kan inte skilja dem åt.
+ *
+ * Regeln: allt som händer FÖRE första användargesten är per definition ingen
+ * redigering. Grinden (userInteracted-ref, armerad av pointer/key i
+ * editorplanen) absorberar init-skrivningar i state utan att märka smutsigt.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = readFileSync(
+  join(__dirname, '../../pages/admin/PageEditorPage.tsx'),
+  'utf-8',
+);
+
+describe('editor-dirty kräver en gest', () => {
+  it('block- och metaändringar latchar bara EFTER interaktion', () => {
+    // Båda handlarna ska vara grindade — en ovillkorlig setHasChanges(true) i
+    // någon av dem återinför falsklarmet för varje Tiptap-bärande sida.
+    const blocks = SRC.match(/handleBlocksChange[\s\S]{0,220}?\}, \[\]\)/)?.[0] ?? '';
+    const meta = SRC.match(/handleMetaChange[\s\S]{0,220}?\}, \[\]\)/)?.[0] ?? '';
+    for (const [name, body] of [['handleBlocksChange', blocks], ['handleMetaChange', meta]] as const) {
+      expect(body, `${name} hittades inte`).not.toBe('');
+      expect(body, `${name} latchar utan interaktionsgrind`).toContain('userInteracted.current');
+      expect(body).not.toMatch(/^\s*setHasChanges\(true\);\s*$/m);
+    }
+  });
+
+  it('grinden armeras av gester i editorplanen — capture, så inget stoppas', () => {
+    expect(SRC).toContain('onPointerDownCapture={armDirtyTracking}');
+    expect(SRC).toContain('onKeyDownCapture={armDirtyTracking}');
+  });
+
+  it('en ny sidladdning nollställer grinden — nästa sidas init-normalisering absorberas också', () => {
+    expect(SRC).toMatch(/setHasChanges\(false\);\s*\n\s*userInteracted\.current = false/);
+  });
+});

--- a/src/pages/admin/PageEditorPage.tsx
+++ b/src/pages/admin/PageEditorPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Save, Send, Check, X, Loader2, ExternalLink, Eye, Clock, Undo2, Redo2, Monitor, Smartphone, Tablet } from 'lucide-react';
 import { format } from 'date-fns';
@@ -71,17 +71,33 @@ export default function PageEditorPage() {
       resetBlocks(hydratedBlocks);
       setMeta(JSON.parse(JSON.stringify(page.meta_json || {})));
       setHasChanges(false);
+      userInteracted.current = false; // fresh page: absorb init-normalisation anew
     }
   }, [page?.id, page?.updated_at, resetBlocks]);
 
+  // Everything that happens before the FIRST user gesture is, by definition,
+  // not an edit. Tiptap normalises stored content on initialisation (schema
+  // fixes, trailing paragraphs — especially on agent-written pages that came
+  // through markdownToTiptap), and that normalisation fires the same onUpdate →
+  // onChange path a keystroke does. Latching hasChanges on it meant: open a
+  // page, touch nothing, get the "unsaved changes" prompt on the way out. The
+  // gate absorbs those mount-time writes into state WITHOUT marking dirty; the
+  // first pointer/keyboard gesture inside the editor arms the latch. A user
+  // action triggered by that gesture (including AI-toolbar generation) still
+  // marks dirty, because the gesture came first.
+  const userInteracted = useRef(false);
+  const armDirtyTracking = useCallback(() => {
+    userInteracted.current = true;
+  }, []);
+
   const handleBlocksChange = useCallback((newBlocks: ContentBlock[]) => {
     setBlocks(newBlocks);
-    setHasChanges(true);
+    if (userInteracted.current) setHasChanges(true);
   }, []);
 
   const handleMetaChange = useCallback((newMeta: PageMeta) => {
     setMeta(newMeta);
-    setHasChanges(true);
+    if (userInteracted.current) setHasChanges(true);
   }, []);
 
   const handleSave = useCallback(async () => {
@@ -214,7 +230,7 @@ export default function PageEditorPage() {
               <div>
                 <Input
                   value={title}
-                  onChange={(e) => { setTitle(e.target.value); setHasChanges(true); }}
+                  onChange={(e) => { userInteracted.current = true; setTitle(e.target.value); setHasChanges(true); }}
                   className="text-xl font-serif font-bold border-none p-0 h-auto focus-visible:ring-0"
                   disabled={!canEdit}
                 />
@@ -290,7 +306,11 @@ export default function PageEditorPage() {
         </div>
 
         {/* Block Editor - scrollable area */}
-        <div className="flex-1 min-h-0 overflow-auto p-8 bg-background">
+        <div
+          className="flex-1 min-h-0 overflow-auto p-8 bg-background"
+          onPointerDownCapture={armDirtyTracking}
+          onKeyDownCapture={armDirtyTracking}
+        >
           <div 
             className={`mx-auto pb-4 transition-all duration-300 ${
               previewMode === 'mobile' 


### PR DESCRIPTION
Optic-rapporterad störning: öppna sida → rör inget → stäng → "unsaved changes"-dialog.

**Roten:** Tiptap normaliserar lagrat innehåll vid init (schema-lagningar; särskilt agentskrivna sidor via `markdownToTiptap`) och fyrar samma `onUpdate → onChange`-väg som ett tangenttryck. Latchad `hasChanges` kan inte skilja dem.

**Fixen:** allt före första användargesten är per definition ingen redigering. `userInteracted`-ref armeras av pointer/key (capture) i editorplanen; handlarna latchar bara därefter; sidbyte nollställer. Centralt i `PageEditorPage`, inte per blockeditor (70 st). Guardrail-test pinnar grinden, armeringen och nollställningen.

tsc 0 · full svit grön