### PR TITLE
fix(blocks): cta-panelen bär systemets panelradie

### DIFF
--- a/src/components/public/blocks/CTABlock.tsx
+++ b/src/components/public/blocks/CTABlock.tsx
@@ -15,7 +15,7 @@ export function CTABlock({ data }: CTABlockProps) {
   // Split variant - image on one side, content on the other
   if (variant === 'split') {
     return (
-      <section>
+      <section className="rounded-[var(--radius-block,1rem)] overflow-hidden">
         <div className="grid md:grid-cols-2 min-h-[400px]">
           {/* Image side */}
           <div className="relative bg-muted">
@@ -102,7 +102,7 @@ export function CTABlock({ data }: CTABlockProps) {
   // With-image variant - full background image with overlay
   if (variant === 'with-image' && data.backgroundImage) {
     return (
-      <section className="relative px-6 py-12 md:py-16">
+      <section className="relative px-6 py-12 md:py-16 rounded-[var(--radius-block,1rem)] overflow-hidden">
         {/* Background image */}
         <div className="absolute inset-0">
           <img
@@ -155,7 +155,11 @@ export function CTABlock({ data }: CTABlockProps) {
   return (
     <section
       className={cn(
-      'px-6 py-12 md:py-16',
+      // cta är INTE full-bleed (BlockRenderer.FULL_BLEED_TYPES) — den ritar en
+      // färgad panel INUTI innehållscontainern, och varje annan indragen panel
+      // i systemet (Newsletter, PricingCalculator, AiFaq) bär --radius-block.
+      // Raka hörn här var Lovable-arvet Magnus såg på optic 2026-08-25.
+      'px-6 py-12 md:py-16 rounded-[var(--radius-block,1rem)] overflow-hidden',
         useGradient
           ? 'bg-gradient-to-r from-primary to-primary/80 text-primary-foreground'
           : 'bg-primary text-primary-foreground'

--- a/src/lib/__tests__/cta-follows-the-panel-radius.guardrails.test.ts
+++ b/src/lib/__tests__/cta-follows-the-panel-radius.guardrails.test.ts
@@ -1,0 +1,43 @@
+/**
+ * En indragen färgpanel bär systemets panelradie.
+ *
+ * cta är inte full-bleed: BlockRenderer lägger den i innehållscontainern, så
+ * dess primärfärgade yta är en PANEL — samma form som Newsletter,
+ * PricingCalculator och AiFaq, vilka alla bär rounded-[var(--radius-block)].
+ * CTA:n (Lovable-ursprung) ritade panelen med raka hörn — det enda blocket i
+ * systemet som avvek, upptäckt av Magnus på optic 2026-08-25 som "ovanligt
+ * kantiga hörn mot övriga designelement".
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const CTA = readFileSync(
+  join(__dirname, '../../components/public/blocks/CTABlock.tsx'),
+  'utf-8',
+);
+const RENDERER = readFileSync(
+  join(__dirname, '../../components/public/BlockRenderer.tsx'),
+  'utf-8',
+);
+
+describe('cta följer panelradien', () => {
+  it('alla tre indragna varianter (split, with-image, default) bär --radius-block', () => {
+    const hits = CTA.match(/rounded-\[var\(--radius-block/g) ?? [];
+    expect(hits.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('bakgrundsbilder klipps till hörnen — radie utan overflow-hidden är en radie som inte syns', () => {
+    // Varje sektion som bär radien måste också klippa: with-image/split har
+    // absolutpositionerade bilder som annars målar över hörnen.
+    const sections = CTA.match(/rounded-\[var\(--radius-block[^"']*/g) ?? [];
+    for (const cls of sections) {
+      expect(cls, `radie utan clip: ${cls}`).toContain('overflow-hidden');
+    }
+  });
+
+  it('pinnen vilar på att cta förblir icke-full-bleed — flyttas den, ompröva radien', () => {
+    const fullBleed = RENDERER.match(/FULL_BLEED_TYPES = new Set\(\[[\s\S]*?\]\)/)?.[0] ?? '';
+    expect(fullBleed).not.toContain("'cta'");
+  });
+});


### PR DESCRIPTION
Optic-rapporterat: CTA-blockets default har ovanligt kantiga hörn mot övriga designelement.

**Uppmätt i koden:** cta är inte full-bleed → dess färgade yta är en indragen PANEL, och den var systemets enda med raka hörn — Newsletter/PricingCalculator/AiFaq bär alla `rounded-[var(--radius-block,1rem)]`. Lovable-arv.

**Fixen:** panel-token + `overflow-hidden` (bakgrundsbilder ska klippas till hörnen) på alla tre indragna varianter. Guardrail pinnar radie, clip och icke-full-bleed-antagandet.

**Separat designfråga, noterad ej smugglad:** `--radius-block` är statisk medan branding styr `--radius` — ska panelradien följa branding?