### PR TITLE
fix(blocks): 13 paneler lydde inte ratten

### DIFF
--- a/src/components/public/blocks/AiAssistantBlock.tsx
+++ b/src/components/public/blocks/AiAssistantBlock.tsx
@@ -174,7 +174,7 @@ export function AiAssistantBlock({ data }: AiAssistantBlockProps) {
                 isFocused && 'scale-[1.01]',
               )}>
                 <div className={cn(
-                  'relative flex items-center rounded-2xl border-2 bg-background transition-all duration-300',
+                  'relative flex items-center rounded-[var(--radius-block,1rem)] border-2 bg-background transition-all duration-300',
                   'hover:border-primary/40 hover:shadow-lg',
                   isFocused
                     ? 'border-primary shadow-xl ring-4 ring-primary/10'
@@ -262,7 +262,7 @@ export function AiAssistantBlock({ data }: AiAssistantBlockProps) {
                   <X className="h-4 w-4" />
                 </Button>
               </div>
-              <div className="border rounded-2xl overflow-hidden shadow-lg bg-background">
+              <div className="border rounded-[var(--radius-block,1rem)] overflow-hidden shadow-lg bg-background">
                 <ChatConversation
                   mode="block"
                   className="h-[450px]"

--- a/src/components/public/blocks/BentoGridBlock.tsx
+++ b/src/components/public/blocks/BentoGridBlock.tsx
@@ -93,7 +93,7 @@ export function BentoGridBlock({ data }: BentoGridBlockProps) {
   }, [items.length, staggeredReveal]);
 
   const cardBaseClasses = cn(
-    'relative overflow-hidden rounded-2xl p-6 transition-all duration-500 group',
+    'relative overflow-hidden rounded-[var(--radius-block,1rem)] p-6 transition-all duration-500 group',
     variant === 'default' && 'bg-card border border-border/50 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5',
     variant === 'glass' && 'bg-card/40 backdrop-blur-xl border border-white/10 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.08)] hover:bg-card/60 hover:border-white/20 hover:shadow-xl hover:shadow-primary/10',
     variant === 'bordered' && 'bg-transparent border-2 border-border hover:border-primary/40 hover:bg-card/30',

--- a/src/components/public/blocks/CategoryNavBlock.tsx
+++ b/src/components/public/blocks/CategoryNavBlock.tsx
@@ -32,7 +32,7 @@ export function CategoryNavBlock({ data }: CategoryNavBlockProps) {
         <div className="max-w-6xl mx-auto px-4">
           <div className={cn('grid grid-cols-2 gap-4', colClasses[columns] ?? colClasses[3])}>
             {Array.from({ length: columns }).map((_, i) => (
-              <div key={i} className="aspect-[4/3] bg-muted rounded-2xl animate-pulse" />
+              <div key={i} className="aspect-[4/3] bg-muted rounded-[var(--radius-block,1rem)] animate-pulse" />
             ))}
           </div>
         </div>
@@ -68,7 +68,7 @@ export function CategoryNavBlock({ data }: CategoryNavBlockProps) {
               className="group block"
             >
               {variant === 'overlay' && cat.image_url ? (
-                <div className="relative aspect-[4/3] rounded-2xl overflow-hidden">
+                <div className="relative aspect-[4/3] rounded-[var(--radius-block,1rem)] overflow-hidden">
                   <img
                     src={cat.image_url}
                     alt={cat.name}
@@ -98,7 +98,7 @@ export function CategoryNavBlock({ data }: CategoryNavBlockProps) {
                 </div>
               ) : (
                 /* cards variant */
-                <div className="rounded-2xl overflow-hidden border border-border/50 hover:border-primary/30 hover:shadow-lg transition-all duration-300 bg-card">
+                <div className="rounded-[var(--radius-block,1rem)] overflow-hidden border border-border/50 hover:border-primary/30 hover:shadow-lg transition-all duration-300 bg-card">
                   {cat.image_url ? (
                     <div className="aspect-[4/3] overflow-hidden bg-muted">
                       <img

--- a/src/components/public/blocks/ChatLauncherBlock.tsx
+++ b/src/components/public/blocks/ChatLauncherBlock.tsx
@@ -74,7 +74,7 @@ export function ChatLauncherBlock({ data }: ChatLauncherBlockProps) {
 
   const containerClasses = cn(
     'w-full max-w-3xl mx-auto',
-    variant === 'card' && 'bg-card rounded-2xl border shadow-lg p-6 md:p-8',
+    variant === 'card' && 'bg-card rounded-[var(--radius-block,1rem)] border shadow-lg p-6 md:p-8',
     variant === 'hero-integrated' && 'py-8 md:py-12',
     variant === 'minimal' && 'py-6 md:py-8'
   );

--- a/src/components/public/blocks/FeaturedProductBlock.tsx
+++ b/src/components/public/blocks/FeaturedProductBlock.tsx
@@ -46,7 +46,7 @@ export function FeaturedProductBlock({ data }: FeaturedProductBlockProps) {
       <section>
         <div className="max-w-6xl mx-auto px-4">
           <div className="animate-pulse grid md:grid-cols-2 gap-12">
-            <div className="aspect-square bg-muted rounded-2xl" />
+            <div className="aspect-square bg-muted rounded-[var(--radius-block,1rem)]" />
             <div className="space-y-4 py-8">
               <div className="h-8 bg-muted rounded w-3/4" />
               <div className="h-4 bg-muted rounded w-1/2" />
@@ -89,7 +89,7 @@ export function FeaturedProductBlock({ data }: FeaturedProductBlockProps) {
                 {data.badge}
               </Badge>
             )}
-            <div className="aspect-square rounded-2xl overflow-hidden bg-muted">
+            <div className="aspect-square rounded-[var(--radius-block,1rem)] overflow-hidden bg-muted">
               {product.image_url ? (
                 <Link to={`/products/${product.id}`}>
                   <img

--- a/src/components/public/blocks/KbHubBlock.tsx
+++ b/src/components/public/blocks/KbHubBlock.tsx
@@ -398,7 +398,7 @@ export function KbHubBlock({ data }: KbHubBlockProps) {
 
         {/* Contact CTA */}
         {showContactCta && (
-          <div className="bg-muted/50 rounded-2xl p-8 md:p-12 mt-16 text-center">
+          <div className="bg-muted/50 rounded-[var(--radius-block,1rem)] p-8 md:p-12 mt-16 text-center">
             <h3 className="text-2xl font-bold mb-4">{contactTitle}</h3>
             <p className="text-muted-foreground mb-6">{contactSubtitle}</p>
             <div className="flex flex-col sm:flex-row gap-3 justify-center">

--- a/src/components/public/blocks/NewsletterBlock.tsx
+++ b/src/components/public/blocks/NewsletterBlock.tsx
@@ -156,7 +156,7 @@ export function NewsletterBlock({ data }: NewsletterBlockProps) {
 
   // Default variant
   return (
-    <div className="px-6 py-10 md:py-14 bg-gradient-to-br from-primary/5 to-primary/10 rounded-2xl">
+    <div className="px-6 py-10 md:py-14 bg-gradient-to-br from-primary/5 to-primary/10 rounded-[var(--radius-block,1rem)]">
       <div className="max-w-xl mx-auto text-center">
         <div className="mx-auto mb-4 h-14 w-14 rounded-full bg-primary/10 flex items-center justify-center">
           <Mail className="h-7 w-7 text-accent-foreground" />

--- a/src/components/public/blocks/QuoteBlock.tsx
+++ b/src/components/public/blocks/QuoteBlock.tsx
@@ -15,7 +15,7 @@ export function QuoteBlock({ data }: QuoteBlockProps) {
         <blockquote
           className={cn(
             'relative',
-            isStyled && 'bg-primary/5 rounded-2xl p-8 md:p-12'
+            isStyled && 'bg-primary/5 rounded-[var(--radius-block,1rem)] p-8 md:p-12'
           )}
         >
           {isStyled && (

--- a/src/components/public/blocks/TwoColumnBlock.tsx
+++ b/src/components/public/blocks/TwoColumnBlock.tsx
@@ -74,7 +74,7 @@ export function TwoColumnBlock({ data }: TwoColumnBlockProps) {
     'md': 'rounded-md',
     'lg': 'rounded-lg',
     'xl': 'rounded-xl',
-    'full': 'rounded-2xl',
+    'full': 'rounded-[var(--radius-block,1rem)]',
   };
 
   const imageAspectClass = aspectRatioMap[imageAspect] ?? aspectRatioMap.auto;

--- a/src/lib/__tests__/cta-follows-the-panel-radius.guardrails.test.ts
+++ b/src/lib/__tests__/cta-follows-the-panel-radius.guardrails.test.ts
@@ -9,7 +9,7 @@
  * kantiga hörn mot övriga designelement".
  */
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 const CTA = readFileSync(
@@ -28,8 +28,6 @@ describe('cta följer panelradien', () => {
   });
 
   it('bakgrundsbilder klipps till hörnen — radie utan overflow-hidden är en radie som inte syns', () => {
-    // Varje sektion som bär radien måste också klippa: with-image/split har
-    // absolutpositionerade bilder som annars målar över hörnen.
     const sections = CTA.match(/rounded-\[var\(--radius-block[^"']*/g) ?? [];
     for (const cls of sections) {
       expect(cls, `radie utan clip: ${cls}`).toContain('overflow-hidden');
@@ -66,5 +64,26 @@ describe('panelradien följer branding-ratten', () => {
 
   it('admin-nollställningen släpper båda — annars läcker en sajts panelradie in i adminytan', () => {
     expect(PROVIDER).toMatch(/removeProperty\('--radius-block'\)/);
+  });
+});
+
+describe('inga hårdkodade panelradier i publika block', () => {
+  /**
+   * Revisionen 2026-08-25 fann 13 rounded-2xl i 9 block — paneler som inte
+   * lydde branding-ratten som --radius-block just kopplats till. Alla
+   * konverterade. Den här pinnen håller populationen på noll: en ny
+   * rounded-2xl/3xl i ett publikt block är en panel som ignorerar kundens
+   * rundhetsval. Legitima undantag (overlay-text över foton, fristående
+   * dokument som TermsBlock) rör inte radier och träffas inte.
+   */
+  it('rounded-2xl/3xl förekommer inte i publika blockrenderare', () => {
+    const dir = join(__dirname, '../../components/public/blocks');
+    const offenders: string[] = [];
+    for (const f of readdirSync(dir).filter((x) => x.endsWith('Block.tsx'))) {
+      const src = readFileSync(join(dir, f), 'utf-8');
+      const hits = src.match(/rounded-(?:2xl|3xl)/g) ?? [];
+      if (hits.length > 0) offenders.push(`${f}: ${hits.length}`);
+    }
+    expect(offenders, offenders.join(', ')).toEqual([]);
   });
 });


### PR DESCRIPTION
Design-systemrevision på Magnus fråga efter #278/#279: fanns CTA-klassen i övriga block?

**Ja, inverterad:** 13 `rounded-2xl` i 9 block (CategoryNav, AiAssistant, FeaturedProduct, BentoGrid, ChatLauncher, KbHub, Newsletter, Quote, TwoColumn) — paneler med radie, men hårdkodad. I samma sekund som #279 kopplade `--radius-block` till branding-ratten blev var och en en panel som ignorerar kundens val. Alla → token; populationspinne håller noll.

**Läst och friat:** Terms hex (fristående dokument), overlay-vitt/svart över foton (ankrat i bilden, inte temat).

**Flaggat för beslut, inte fixat:** Products/Webinar/ConsultantMatcher använder råa green/amber som statusfärger — systemet saknar success/warning-tokens. Att införa dem är designspråk, inte mekanik.

OBS: mergeas EFTER #279 (delar guardrail-fil, trivial textkonflikt hanteras vid rebase).