### PR TITLE
fix(blocks): statusfärgerna adopterar sina tokens

### DIFF
--- a/src/components/public/blocks/AiAssistantBlock.tsx
+++ b/src/components/public/blocks/AiAssistantBlock.tsx
@@ -239,7 +239,7 @@ export function AiAssistantBlock({ data }: AiAssistantBlockProps) {
                 'mt-6 flex items-center gap-1 text-xs text-muted-foreground',
                 !isSplit && 'justify-center',
               )}>
-                <Star className="h-3 w-3 fill-current text-yellow-500" />
+                <Star className="h-3 w-3 fill-current text-warning" />
                 <span>Powered by AI • Knows our entire product catalog</span>
               </div>
             </>

--- a/src/components/public/blocks/ConsultantMatcherBlock.tsx
+++ b/src/components/public/blocks/ConsultantMatcherBlock.tsx
@@ -58,9 +58,11 @@ const strengthLabel: Record<Strength, string> = {
 };
 
 const strengthClass: Record<Strength, string> = {
-  strong:
-    'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-950/40 dark:border-green-900',
-  good: 'text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-300 dark:bg-amber-950/40 dark:border-amber-900',
+  // Statusfärgerna bor i tokens (--success/--warning, index.css) — de bär sina
+  // egna dark-värden, så inga dark:-varianter behövs här. Revisionen 2026-08-25
+  // trodde först att tokens saknades; de fanns, adoptionen saknades.
+  strong: 'text-success bg-success/10 border-success/20',
+  good: 'text-warning bg-warning/10 border-warning/20',
   fair: 'text-muted-foreground bg-muted border-border',
 };
 
@@ -108,7 +110,7 @@ const MatchCard = memo(function MatchCard({
         <div className="flex items-start justify-between mb-2 gap-2">
           <div className="min-w-0">
             <div className="flex items-center gap-1.5">
-              {index === 0 && <Star className="w-4 h-4 text-amber-500 fill-amber-500 shrink-0" />}
+              {index === 0 && <Star className="w-4 h-4 text-warning fill-warning shrink-0" />}
               <span className="text-xs text-muted-foreground">#{index + 1}</span>
               <span className="font-semibold text-foreground truncate">{match.name}</span>
             </div>

--- a/src/components/public/blocks/ProductsBlock.tsx
+++ b/src/components/public/blocks/ProductsBlock.tsx
@@ -190,7 +190,7 @@ export function ProductsBlock({ data }: ProductsBlockProps) {
                             className={cn(
                               'absolute bottom-3 right-3 rounded-full shadow-lg',
                               'opacity-0 translate-y-2 group-hover:opacity-100 group-hover:translate-y-0 transition-all duration-200',
-                              inCart && 'bg-green-600 hover:bg-green-700'
+                              inCart && 'bg-success text-success-foreground hover:bg-success/90'
                             )}
                             onClick={() => handleAddToCart(product)}
                           >

--- a/src/components/public/blocks/WebinarBlock.tsx
+++ b/src/components/public/blocks/WebinarBlock.tsx
@@ -316,7 +316,7 @@ function WebinarCard({
             )}
 
             {registered && (
-              <div className="flex items-center gap-2 text-sm text-green-600">
+              <div className="flex items-center gap-2 text-sm text-success">
                 <CheckCircle className="h-4 w-4" />
                 You're registered! Check your email for details.
               </div>

--- a/src/lib/__tests__/cta-follows-the-panel-radius.guardrails.test.ts
+++ b/src/lib/__tests__/cta-follows-the-panel-radius.guardrails.test.ts
@@ -87,3 +87,23 @@ describe('inga hårdkodade panelradier i publika block', () => {
     expect(offenders, offenders.join(', ')).toEqual([]);
   });
 });
+
+describe('statusfärger bär tokens, inte palett', () => {
+  /**
+   * Revisionen 2026-08-25 trodde att success/warning-tokens saknades — de
+   * fanns (index.css ljus+mörk, tailwind-mappning, brett använda i admin).
+   * Det som saknades var ADOPTION i fyra publika block. Migrerade; pinnen
+   * håller populationen på noll. Vitt/svart över foton berörs inte (ankrat i
+   * bilden), och grays är layouttoner, inte status — bara statuspaletten fälls.
+   */
+  it('green/amber/yellow/emerald/lime-klasser förekommer inte i publika block', () => {
+    const dir = join(__dirname, '../../components/public/blocks');
+    const raw = /\b(?:bg|text|border|fill|stroke|from|to|via)-(?:green|amber|yellow|emerald|lime)-\d{2,3}\b/g;
+    const offenders: string[] = [];
+    for (const f of readdirSync(dir).filter((x) => x.endsWith('Block.tsx'))) {
+      const hits = readFileSync(join(dir, f), 'utf-8').match(raw) ?? [];
+      if (hits.length > 0) offenders.push(`${f}: ${[...new Set(hits)].join(' ')}`);
+    }
+    expect(offenders, offenders.join('; ')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Uppföljning på designrevisionens sista öppna punkt, beslut Magnus — och en rättelse av revisionens eget påstående: **tokens saknades inte** (`--success`/`--warning` finns kompletta med mörkvärden och tailwind-mappning, brett använda i admin). Adoptionen saknades.

Fyra publika block migrerade: Products, Webinar, ConsultantMatcher (dark:-varianter faller — tokens bär mörkläget själva), AiAssistant. Populationspinne håller statuspaletten på noll i publika block.

8 pinnar gröna · tsc 0 · full svit grön