### PR TITLE
fix(anchors): tvärsideslänken till ett block väntar in sidan

### DIFF
--- a/src/hooks/useAnchorScroll.ts
+++ b/src/hooks/useAnchorScroll.ts
@@ -6,34 +6,46 @@ import { useLocation } from 'react-router-dom';
  * - Scrolls to hash target on initial page load
  * - Listens for hash changes during navigation
  */
-export function useAnchorScroll() {
+/**
+ * @param ready pass the page's data-loaded state. Cross-page links like
+ *   /products#internet land BEFORE the async get-page fetch has rendered any
+ *   blocks — the old two-shot retry (0ms + 100ms) lost that race on every cold
+ *   load and gave up silently, and the effect never re-ran when the content
+ *   finally arrived (deps carried only the hash). Same-page clicks always
+ *   worked, which is why the gap survived: the broken case was the one you
+ *   only hit arriving from ANOTHER page.
+ */
+export function useAnchorScroll(ready: boolean = true) {
   const location = useLocation();
 
   useEffect(() => {
+    if (!ready) return; // re-runs when the content lands — ready is a dep
     const hash = location.hash;
     if (!hash) return;
 
-    // Remove the # prefix
     const targetId = hash.slice(1);
     if (!targetId) return;
 
-    // Small delay to ensure the page content is rendered
     const scrollToTarget = () => {
       const element = document.getElementById(targetId);
       if (element) {
-        element.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start',
-        });
+        element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        return true;
       }
+      return false;
     };
 
-    // Try immediately, then with a delay for dynamic content
-    scrollToTarget();
-    const timeoutId = setTimeout(scrollToTarget, 100);
+    // Bounded retry: blocks render a beat after the data flag flips (React
+    // commit + lazy chunks), so poll briefly rather than trust one timeout.
+    if (scrollToTarget()) return;
+    let attempts = 0;
+    const intervalId = setInterval(() => {
+      attempts += 1;
+      if (scrollToTarget() || attempts >= 30) clearInterval(intervalId); // ≤3s
+    }, 100);
 
-    return () => clearTimeout(timeoutId);
-  }, [location.hash]);
+    return () => clearInterval(intervalId);
+  }, [location.hash, ready]);
 }
 
 /**

--- a/src/lib/__tests__/cross-page-anchors-wait-for-content.guardrails.test.ts
+++ b/src/lib/__tests__/cross-page-anchors-wait-for-content.guardrails.test.ts
@@ -1,0 +1,41 @@
+/**
+ * En tvärsideslänk till ett block (/products#internet) måste vänta in sidan.
+ *
+ * Infrastrukturen fanns hela vägen: BlockRenderer sätter id={anchorId||block.id}
+ * på varje block, BlockAnchorControl låter redaktören namnge ankaret, och
+ * useAnchorScroll scrollar på hash. Men hooken sköt två skott (0ms + 100ms)
+ * mot innehåll som hämtas asynkront via get-page — tvärsideslandningen
+ * förlorade racet på varje kall last och gav upp tyst, och effekten omkördes
+ * aldrig när datan landade. Samma-sida-klick fungerade alltid, vilket är
+ * varför hålet överlevde: det trasiga fallet var det man bara når UTIFRÅN.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const HOOK = readFileSync(join(__dirname, '../../hooks/useAnchorScroll.ts'), 'utf-8');
+const PAGE = readFileSync(join(__dirname, '../../pages/PublicPage.tsx'), 'utf-8');
+
+describe('tvärsides-ankare väntar in innehållet', () => {
+  it('hooken tar en ready-flagga och bär den i beroendelistan — datan som landar omkör effekten', () => {
+    expect(HOOK).toMatch(/useAnchorScroll\(ready: boolean = true\)/);
+    expect(HOOK).toMatch(/\[location\.hash, ready\]/);
+  });
+
+  it('försöken är pollade och BEGRÄNSADE — inte två skott, inte för evigt', () => {
+    expect(HOOK).toContain('setInterval');
+    expect(HOOK).toMatch(/attempts >= \d+/);
+    expect(HOOK).toContain('clearInterval');
+  });
+
+  it('PublicPage passerar sidans dataflagga — inte ett blint true', () => {
+    expect(PAGE).toMatch(/useAnchorScroll\(!!page\)/);
+  });
+
+  it('varje block förblir adresserbart: BlockRenderer sätter id på sektionen', () => {
+    const renderer = readFileSync(
+      join(__dirname, '../../components/public/BlockRenderer.tsx'), 'utf-8',
+    );
+    expect(renderer).toMatch(/anchorId = block\.anchorId \|\| block\.id/);
+  });
+});

--- a/src/pages/PublicPage.tsx
+++ b/src/pages/PublicPage.tsx
@@ -51,9 +51,6 @@ export default function PublicPage() {
   const [authLoading, setAuthLoading] = useState(true);
   const [renderError, setRenderError] = useState<Error | null>(null);
 
-  // Handle smooth scrolling to anchors
-  useAnchorScroll();
-
   // Check for ?setup=true to force setup wizard (dev mode)
   const forceSetup = searchParams.get('setup') === 'true';
 
@@ -208,6 +205,11 @@ export default function PublicPage() {
     // Wait for generalSettings to load before fetching homepage (when no explicit slug)
     enabled: slug !== undefined || generalSettings !== undefined,
   });
+
+  // Smooth-scroll till #ankare — EFTER att sidan laddats: en tvärsideslänk
+  // (/products#internet) landar innan get-page-hämtningen renderat blocken,
+  // och en scroll mot ett id som inte finns än är en tyst no-op.
+  useAnchorScroll(!!page);
 
   // Check for connection error first
   const isConnectionError = page === CONNECTION_ERROR;


### PR DESCRIPTION
Magnus fråga: går det att länka /products#internet från ett feature-block? **Ja — allt fanns** (block-id:n i DOM, ankarkontroll i editorn, hash-scroll) — utom i exakt det fallet frågan gällde: tvärsides-landning förlorade racet mot den asynkrona get-page-hämtningen (två försök à 0+100ms, ingen omkörning när datan landade). Samma-sida fungerade, därför överlevde hålet.

Fixen: `useAnchorScroll(ready)` med sidans dataflagga i beroendelistan + begränsad poll (≤3s). Guardrail pinnar flaggan, gränsen och blockens adresserbarhet.