### PR TITLE
fix(bookings): bekräftelsen föds PÅ och påminnaren föds alls

### DIFF
--- a/src/components/admin/modules/ModuleDetailSheet.tsx
+++ b/src/components/admin/modules/ModuleDetailSheet.tsx
@@ -567,7 +567,7 @@ export function ModuleDetailSheet({
                       </div>
                       <Switch
                         id="booking-email-toggle"
-                        checked={moduleConfig.confirmationEmailEnabled ?? false}
+                        checked={moduleConfig.confirmationEmailEnabled ?? true}
                         onCheckedChange={(checked) => {
                           if (!modules) return;
                           updateModules.mutate({

--- a/src/hooks/useModules.tsx
+++ b/src/hooks/useModules.tsx
@@ -154,7 +154,12 @@ export const defaultModulesSettings: ModulesSettings = {
     autonomy: 'config-required',
     adminUI: true,
     optionalIntegrations: ['resend', 'stripe'],
-    confirmationEmailEnabled: false,
+    // Law 4 (Fail Forward, Don't Gate): fungerande mailcredentials ska inte
+    // gateas av en manuell flagga — och modulbeskrivningen LOVAR "email
+    // confirmations". Var false till 2026-08-25; uppmätt följd på optic: kund
+    // bokar, hör ingenting, admin ser inget om det. Utflödesallowlisten är
+    // fortfarande spärren som skyddar pilotinstanser.
+    confirmationEmailEnabled: true,
     bookingEmailProvider: 'resend',
   },
   pages: {

--- a/src/lib/__tests__/cron-jobs-have-a-runtime-registrar.guardrails.test.ts
+++ b/src/lib/__tests__/cron-jobs-have-a-runtime-registrar.guardrails.test.ts
@@ -47,6 +47,7 @@ const REGISTRARS = [
   'register_flowpilot_cron',
   'register_knowledge_indexer_cron',
   'register_retrieval_cron',
+  'register_booking_cron',
 ];
 
 const migrationFiles = readdirSync(MIGRATIONS).filter((f) => f.endsWith('.sql')).sort();
@@ -149,8 +150,16 @@ describe('a registrar never forgets a job it already knew', () => {
     const dropped = [...historical].filter((name) => !newest.includes(`'${name}'`));
 
     // A job may only be dropped once its target edge function is gone from the
-    // repo — otherwise the removal is amnesia, not a decision.
+    // repo — otherwise the removal is amnesia, not a decision. A job that MOVED
+    // to another registrar is also a decision, not amnesia: booking-reminders
+    // lived in an early register_flowpilot_cron, died with the standalone
+    // send-booking-reminders function, and was reborn 2026-08-25 in its own
+    // register_booking_cron targeting comms-send. Without this arm, reviving a
+    // once-dropped jobname anywhere would retroactively indict the registrar
+    // that legitimately dropped it.
     const unexplained = dropped.filter((name) => {
+      if (registrarText.includes(`'${name}'`)) return false; // carried by another registrar
+
       for (const sql of allSql) {
         for (const job of scheduledJobs(sql)) {
           if (job.name !== name) continue;

--- a/src/lib/__tests__/instance-readiness.test.ts
+++ b/src/lib/__tests__/instance-readiness.test.ts
@@ -329,6 +329,7 @@ describe('the platform cron floor is derived from what the registrars actually s
     expect([...PLATFORM_CRON_JOBS].sort()).toEqual(
       [
         'automation-dispatcher-every-minute',
+        'booking-reminders',
         'flowpilot-daily-briefing',
         'flowpilot-heartbeat',
         'flowpilot-learn',

--- a/src/lib/instance-readiness.ts
+++ b/src/lib/instance-readiness.ts
@@ -95,6 +95,7 @@ export const PLATFORM_CRON_JOBS: readonly string[] = [
   'instance-health-check',
   'knowledge-indexer',
   'newsletter-dispatch-scheduled',
+  'booking-reminders',
 ];
 
 export interface CronJobState {

--- a/src/lib/module-bootstrap.ts
+++ b/src/lib/module-bootstrap.ts
@@ -135,6 +135,15 @@ export async function ensurePlatformCron(): Promise<{ registered: boolean; error
     if (rErr && !/could not find|does not exist/i.test(rErr.message)) {
       logger.warn('[module-bootstrap] retrieval cron registration failed:', rErr.message);
     }
+    // Booking reminders — samma tolerans: en äldre instans utan registrarn är
+    // inte ett fel, den får jobbet vid nästa bootstrap efter sin migration.
+    const { error: bErr } = await (supabase.rpc as any)('register_booking_cron', {
+      p_supabase_url: url,
+      p_anon_key: key,
+    });
+    if (bErr && !/could not find|does not exist/i.test(bErr.message)) {
+      logger.warn('[module-bootstrap] booking cron registration failed:', bErr.message);
+    }
     logger.log('[module-bootstrap] platform cron ensured');
     return { registered: true };
   } catch (err) {

--- a/supabase/migrations/20260828150000_paminnaren-som-aldrig-kunde-fodas.sql
+++ b/supabase/migrations/20260828150000_paminnaren-som-aldrig-kunde-fodas.sql
@@ -1,0 +1,68 @@
+-- Påminnaren som aldrig kunde födas.
+--
+-- comms-send?kind=booking_reminders har funnits länge: sveper bekräftade
+-- bokningar som startar inom 24h med reminder_sent_at NULL, mailar, stämplar.
+-- Men inget cron-jobb skapades någonsin — migrationen 20260720120710 OMPEKAR
+-- befintliga jobb till comms-send, och ett jobb som aldrig fötts finns inte
+-- att ompeka. Uppmätt på optic 2026-08-25: cron.job saknar varje spår av
+-- booking/reminder, och Magnus bokning passerade sin mötestid med
+-- reminder_sent_at NULL. Momang 22-klassen: en självstartande cron kan inte
+-- starta sig själv (samma klass som knowledge-indexern).
+--
+-- Egen registrar bredvid register_flowpilot_cron — INTE en omdefinition av
+-- huvudkroppen. Två kopior av en funktionskropp driver isär; det var exakt så
+-- COGS-blocket försvann (20260827200000). Prejudikat: register_retrieval_cron.
+-- Klienten (ensurePlatformCron) anropar den tolerant — äldre instanser utan
+-- funktionen är inte ett fel.
+CREATE OR REPLACE FUNCTION public.register_booking_cron(p_supabase_url text, p_anon_key text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  job_exists boolean;
+  auth_header text;
+  result jsonb := '{}'::jsonb;
+BEGIN
+  -- Admin-anropad från bootstrap → intern vakt, inte revoke (husregeln från
+  -- anon-svepet). session_user-armen släpper migrations/psql-provisionering.
+  IF NOT (
+       auth.role() = 'service_role'
+    OR has_role(auth.uid(), 'admin'::app_role)
+    OR session_user IN ('postgres', 'supabase_admin')
+  ) THEN
+    RAISE EXCEPTION 'register_booking_cron: admin or service_role required';
+  END IF;
+
+  IF p_supabase_url IS NULL OR p_anon_key IS NULL THEN
+    RAISE EXCEPTION 'register_booking_cron: p_supabase_url and p_anon_key are required';
+  END IF;
+
+  auth_header := format('{"Content-Type": "application/json", "Authorization": "Bearer %s"}', p_anon_key);
+
+  -- Varje timme, minut 23 (spridd från heltimmesklustret). Svepfönstret är
+  -- 24h och stämpeln gör omkörning ofarlig — timvis är rätt upplösning.
+  SELECT EXISTS(SELECT 1 FROM cron.job WHERE jobname = 'booking-reminders') INTO job_exists;
+  IF NOT job_exists THEN
+    PERFORM cron.schedule(
+      'booking-reminders',
+      '23 * * * *',
+      format(
+        'SELECT net.http_post(url := %L, headers := %L::jsonb, body := ''{}''::jsonb) AS request_id;',
+        p_supabase_url || '/functions/v1/comms-send?kind=booking_reminders',
+        auth_header
+      )
+    );
+    result := result || '{"booking_reminders": "registered"}'::jsonb;
+  ELSE
+    result := result || '{"booking_reminders": "already_exists"}'::jsonb;
+  END IF;
+
+  RETURN result;
+END;
+$fn$;
+
+REVOKE ALL ON FUNCTION public.register_booking_cron(text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.register_booking_cron(text, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.register_booking_cron(text, text) TO authenticated, service_role;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260828140000",
-      "migrations_count": 519,
+      "migration_head": "20260828150000",
+      "migrations_count": 520,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2081,6 +2081,10 @@
         {
           "version": "20260828140000",
           "name": "kostnaden-foljer-varan-genom-dorren"
+        },
+        {
+          "version": "20260828150000",
+          "name": "paminnaren-som-aldrig-kunde-fodas"
         }
       ]
     },


### PR DESCRIPTION
Processgenomgång av bokningsflödet med Magnus bokning som mätpunkt. Två rötter, båda 'född av'-klassen:

1. **`confirmationEmailEnabled: false` som kodad default** (Law 4-brott — fungerande credentials bakom manuell flagga; beskrivningen lovar 'email confirmations'). Skarpt prov: `{skipped: confirmation_email_disabled}`, success:true, noll spår. → default **true**; allowlisten förblir pilotspärren.
2. **Påminnar-cronen kunde aldrig födas** — koden finns, ompeknings-migrationen förutsätter ett jobb som aldrig skapades (moment 22-klassen). → egen `register_booking_cron` (prejudikat: retrieval — ingen omdefinition av huvudkroppen, det var så COGS-blocket dog), tolerant anropad från `ensurePlatformCron`, mätt av readiness.

Registrar-guardrailen fick flytt-begreppet: ett jobbnamn som återföds i en NY registrar ska inte retroaktivt fälla den gamla som droppade det legitimt.

Torrkörd i rollback på nordbrygg · full svit grön