### PR TITLE
feat(bookings): mailet är sajtinnehåll

### DIFF
--- a/src/components/public/blocks/SmartBookingBlock.tsx
+++ b/src/components/public/blocks/SmartBookingBlock.tsx
@@ -27,6 +27,9 @@ type BookingStep = 'service' | 'datetime' | 'details' | 'confirmed';
 export function SmartBookingBlock({ data, blockId, pageId }: SmartBookingBlockProps) {
   const { formatCurrency, formatDate } = usePlatformFormat();
   const [step, setStep] = useState<BookingStep>('service');
+  // Sant först när comms-send SVARAT att mailet gick (inte skipped/blocked) —
+  // skärmen lovar bara det inkorgen faktiskt håller.
+  const [confirmationEmailed, setConfirmationEmailed] = useState(false);
   const [selectedServiceId, setSelectedServiceId] = useState<string | null>(null);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [selectedSlot, setSelectedSlot] = useState<string | null>(null);
@@ -214,7 +217,7 @@ export function SmartBookingBlock({ data, blockId, pageId }: SmartBookingBlockPr
       // No payment needed — standard flow
       // Trigger confirmation email
       try {
-        await fetch(
+        const emailResp = await fetch(
           `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/comms-send?kind=booking_confirmation`,
           {
             method: 'POST',
@@ -225,6 +228,9 @@ export function SmartBookingBlock({ data, blockId, pageId }: SmartBookingBlockPr
             body: JSON.stringify({ bookingId: bookingData.id }),
           }
         );
+        const emailResult = await emailResp.json().catch(() => null);
+        // Lova bara det som hände: success utan skipped = mailet är på väg.
+        setConfirmationEmailed(Boolean(emailResult?.success && !emailResult?.skipped));
       } catch (emailErr) {
         logger.warn('Could not trigger confirmation email:', emailErr);
       }
@@ -301,6 +307,11 @@ export function SmartBookingBlock({ data, blockId, pageId }: SmartBookingBlockPr
           <p className="text-muted-foreground mb-4">
             {data.successMessage || "Thank you! We'll contact you to confirm your appointment."}
           </p>
+          {confirmationEmailed && (
+            <p className="text-sm text-muted-foreground mt-2">
+              A confirmation email is on its way to {formData.email}.
+            </p>
+          )}
           {selectedService && selectedDate && selectedSlot && (
             <div className="bg-muted/50 rounded-lg p-4 text-left space-y-2">
               <p><span className="font-medium">Service:</span> {selectedService.name}</p>

--- a/src/lib/__tests__/booking-mail-is-site-content.guardrails.test.ts
+++ b/src/lib/__tests__/booking-mail-is-site-content.guardrails.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Bokningsmailet är sajtinnehåll — och skärmen lovar bara det inkorgen håller.
+ *
+ * Rälsen fanns (email_templates + {{variabler}} + routerns template_name);
+ * bekräftelsen gick förbi den med 40 rader hårdkodad engelsk HTML. Samma
+ * klass som statusfärgerna: byggd men inte adopterad.
+ *
+ * Tre kontrakt:
+ *   1. Seeden är återhävdbar och rör ALDRIG operatörens omskrivning
+ *      (WHERE NOT EXISTS by name) — instansens röst är data.
+ *   2. Handlern renderar mallen med legacy som Law 4-fallback, och defaulten
+ *      är TJÄNST-GENERISK (Magnus reservation: en bokning kan vara en
+ *      klipptid — plattformen antar aldrig samtal eller möte).
+ *   3. Blocket visar "mail på väg" ENDAST när comms-send svarat success utan
+ *      skipped — skärmen grundas i svaret, inte i hopp.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(__dirname, '../../..');
+const SEED = readFileSync(join(ROOT, 'supabase/migrations/20260828170000_mailet-ar-sajtinnehall.sql'), 'utf-8');
+const HANDLER = readFileSync(join(ROOT, 'supabase/functions/comms-send/booking_confirmation.ts'), 'utf-8');
+const BLOCK = readFileSync(join(__dirname, '../../components/public/blocks/SmartBookingBlock.tsx'), 'utf-8');
+
+describe('bokningsmailet är sajtinnehåll', () => {
+  it('seeden är återhävdbar och skriver aldrig över en redigerad mall', () => {
+    expect(SEED).toMatch(/WHERE NOT EXISTS[\s\S]*booking_confirmation/);
+    expect(SEED).not.toMatch(/ON CONFLICT[\s\S]*DO UPDATE/);
+  });
+
+  it('defaultmallen är tjänst-generisk — inga antaganden om samtal, möte eller plats', () => {
+    // Pinnen läser MALLEN (SQL-satsen), inte migrationens kommentarer — och
+    // med ordgränser: 'rendering'/'redigering' är inte 'ring'.
+    const content = SEED.split('\n').filter((l) => !l.trimStart().startsWith('--')).join('\n');
+    for (const banned of [/\bcall you\b/i, /\bring(er|a)?\b/i, /\bphone\b/i, /\bmeeting\b/i, /\bzoom\b/i, /\bsamtal\b/i]) {
+      expect(banned.test(content), `defaulten antar: ${banned}`).toBe(false);
+    }
+    expect(content).toContain('{{service_name}}');
+  });
+
+  it('handlern renderar ur email_templates med legacy-HTML som Law 4-fallback', () => {
+    expect(HANDLER).toMatch(/from\('email_templates'\)[\s\S]*booking_confirmation/);
+    expect(HANDLER).toContain('templateHtml ??');
+    expect(HANDLER).toContain('templateSubject ??');
+  });
+
+  it('skärmen lovar mail endast på success utan skipped — grundat i svaret', () => {
+    expect(BLOCK).toMatch(/success && !emailResult\?\.skipped/);
+    expect(BLOCK).toMatch(/confirmationEmailed &&/);
+  });
+});

--- a/supabase/functions/comms-send/booking_confirmation.ts
+++ b/supabase/functions/comms-send/booking_confirmation.ts
@@ -258,7 +258,43 @@ export const handler = async (req: Request): Promise<Response> => {
     }
 
     // Build email HTML
-    const emailHtml = `
+    // ── Mallen är sajtinnehåll ────────────────────────────────────────────
+    // Rendera ur email_templates ('booking_confirmation', seedad återhävdbart i
+    // 20260828170000) så admin och agent äger texten via manage_email_template.
+    // Renderingen sker HÄR (inte i email-send) så Gmail-transporten får samma
+    // mall som routern. Saknas mallen faller vi till legacy-HTML:en nedan —
+    // Law 4: mailet uteblir aldrig för att en mall fattas. Defaulten är
+    // TJÄNST-GENERISK med flit: plattformen antar aldrig samtal, möte eller
+    // klipptid — instansens röst är en mallredigering, aldrig kod.
+    let templateSubject: string | null = null;
+    let templateHtml: string | null = null;
+    try {
+      const { data: tpl } = await supabase
+        .from('email_templates')
+        .select('subject, html, active')
+        .eq('name', 'booking_confirmation')
+        .maybeSingle();
+      if (tpl?.active && tpl.html) {
+        const vars: Record<string, string> = {
+          customer_name: booking.customer_name ?? '',
+          service_name: booking.service?.name ?? '',
+          date: formattedDate,
+          start_time: formattedStartTime,
+          end_time: formattedEndTime,
+          notes_block: booking.notes
+            ? `<div style="background:#f3f4f6;border-radius:8px;padding:12px 16px;margin:16px 0;"><p style="margin:0;"><strong>Your note:</strong> ${booking.notes}</p></div>`
+            : '',
+          site_name: siteName,
+        };
+        const render = (t: string) => t.replace(/\{\{(\w+)\}\}/g, (_, k) => vars[k] ?? '');
+        templateHtml = render(tpl.html);
+        templateSubject = tpl.subject ? render(tpl.subject) : null;
+      }
+    } catch (tplErr) {
+      console.warn('[send-booking-confirmation] template read failed — using built-in fallback:', (tplErr as Error).message);
+    }
+
+    const emailHtml = templateHtml ?? `
       <!DOCTYPE html>
       <html>
       <head>
@@ -316,7 +352,7 @@ export const handler = async (req: Request): Promise<Response> => {
           action: 'GMAIL_SEND_EMAIL',
           arguments: {
             recipient_email: booking.customer_email,
-            subject: `Booking Confirmation - ${formattedDate}`,
+            subject: templateSubject ?? `Booking Confirmation - ${formattedDate}`,
             body: emailHtml,
             content_type: 'text/html',
           },
@@ -335,7 +371,7 @@ export const handler = async (req: Request): Promise<Response> => {
       const { data: emailResponse, error: emailError } = await supabase.functions.invoke('email-send', {
         body: {
           to: booking.customer_email,
-          subject: `Booking Confirmation - ${formattedDate}`,
+          subject: templateSubject ?? `Booking Confirmation - ${formattedDate}`,
           html: emailHtml,
           fromOverride: `${emailConfig.fromName} <${emailConfig.fromEmail}>`,
           tags: { source: 'send-booking-confirmation', booking_id: bookingId },

--- a/supabase/migrations/20260828170000_mailet-ar-sajtinnehall.sql
+++ b/supabase/migrations/20260828170000_mailet-ar-sajtinnehall.sql
@@ -1,0 +1,41 @@
+-- Mailet är sajtinnehåll.
+--
+-- Bokningsbekräftelsen var 40 rader engelsk HTML hårdkodad i funktionskroppen
+-- (Lovable-lila gradient, "Hello {name}") — oredigerbar för admin OCH agent,
+-- trots att hela mallrälsen redan fanns: email_templates + {{variabler}} +
+-- email-send-routerns template_name-stöd (dunning använder den i dag).
+-- Klassen är samma som statusfärgerna: rälsen byggd, adoptionen saknades.
+--
+-- Default-mallen är TJÄNST-GENERISK med flit (Magnus reservation 2026-08-25):
+-- en bokning är tid + tjänst + namn — plattformen antar aldrig samtal, möte
+-- eller klipptid. Instansens röst ("vi ringer dig på {{customer_phone}}",
+-- "välkommen till salongen") är en MALLREDIGERING, via admin-UI:t eller
+-- manage_email_template — aldrig kod.
+--
+-- Återhävdbar seed (plattformskonfig-klassen): INSERT bara när namnet saknas,
+-- så en operatörs omskrivning ÖVERLEVER varje omkörning och deploy.
+INSERT INTO public.email_templates (name, subject, html, text, category, variables, active)
+SELECT
+  'booking_confirmation',
+  'Booking confirmation — {{date}}',
+  '<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Booking confirmation</title></head>'
+  || '<body style="font-family: -apple-system, BlinkMacSystemFont, ''Segoe UI'', Roboto, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">'
+  || '<h1 style="font-size: 22px; margin: 0 0 16px;">Booking confirmation</h1>'
+  || '<p>Hello {{customer_name}},</p>'
+  || '<p>Thank you for your booking. Here are the details:</p>'
+  || '<div style="background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; padding: 20px; margin: 20px 0;">'
+  || '<p style="margin:4px 0;"><strong>Service:</strong> {{service_name}}</p>'
+  || '<p style="margin:4px 0;"><strong>Date:</strong> {{date}}</p>'
+  || '<p style="margin:4px 0;"><strong>Time:</strong> {{start_time}}–{{end_time}}</p>'
+  || '</div>'
+  || '{{notes_block}}'
+  || '<p>If anything changes, just reply to this email.</p>'
+  || '<p style="color:#6b7280; font-size: 13px; margin-top: 28px;">{{site_name}}</p>'
+  || '</body></html>',
+  'Hello {{customer_name}}, your booking of {{service_name}} on {{date}} at {{start_time}}–{{end_time}} is received. {{site_name}}',
+  'transactional',
+  '["customer_name","service_name","date","start_time","end_time","notes_block","site_name"]'::jsonb,
+  true
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.email_templates WHERE name = 'booking_confirmation'
+);

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260828150000",
-      "migrations_count": 520,
+      "migration_head": "20260828170000",
+      "migrations_count": 521,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2085,6 +2085,10 @@
         {
           "version": "20260828150000",
           "name": "paminnaren-som-aldrig-kunde-fodas"
+        },
+        {
+          "version": "20260828170000",
+          "name": "mailet-ar-sajtinnehall"
         }
       ]
     },
@@ -2108,7 +2112,7 @@
         "chat-completion": "sha256:b2bfe35ae9e8f896e717776d33dfa9ec8ce39e37a788413a14351b8c4b866b3a",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
-        "comms-send": "sha256:70122ef5a3cbfa7b1f0f8b8212ca5756493c16f8318fd7d872e2831a39929564",
+        "comms-send": "sha256:831b17d08500f424390b4bc0fa5c6d0398271cc9fa60bbeca574483318ddccae",
         "composio-proxy": "sha256:08477e4658cee04b6a09458a5e8dc45fbf9737c2188f7b972ae954782a4bdc95",
         "composio-webhook": "sha256:27f17b7198bfbab422931ef1c872da083299e095792e43b98b4154ec79c858ca",
         "consultant-match": "sha256:1419717affb3711a2d7f13d44c9a228e1557a3d927e3aa05ee5e179584131e1b",
@@ -2154,7 +2158,7 @@
         "quote-pay": "sha256:f42a8accc1489304c32b0e3a2c5f30188faa898e48e9323698ed624ca9aea296",
         "quote-sign": "sha256:6f0e0aabc65a4d5375753109a8cc94992b3c56785bd341db925d446891e45d46",
         "run-autonomy-tests": "sha256:c01a22c4a9851de86317f233dce04e24f1c11014df9f3810bed75a6d2c32122a",
-        "run-platform-tests": "sha256:60f4e366e9fba1c45dffd0b8428012199b302529e37715d2ca4a866b6928e73e",
+        "run-platform-tests": "sha256:215443bbbea4551c3f0505a6545b57320437269456887f068cecbdc663822290",
         "score-visitor-intent": "sha256:c45442de0d34a5f9660a75a15c269aa5988ca7dbc2631e476418c66e58e6f79e",
         "send-webhook": "sha256:a8748b5e344f2dee419bb739707e938d093a3cc5ed0a43f3b69cb9de7dc76741",
         "setup-database": "sha256:49f03dc85ea4d48cd53b7760b0a68f4e2a628a217207b0fe4590d931f594e56e",


### PR DESCRIPTION
Mallbygget ur bokningsgenomgången, beslut Magnus — med hans reservation som designprincip: **defaulten är tjänst-generisk** (en bokning kan vara en klipptid), instansens röst är en mallredigering.

- Återhävdbar seed (`WHERE NOT EXISTS` — operatörens omskrivning överlever, trippelverifierat i rollback)
- Handlern renderar ur `email_templates` med legacy-HTML som Law 4-fallback; rendering i handlern så båda transporterna (router + Gmail) får mallen
- Blockets tack-yta lovar mailet **endast** när svaret säger sent — inte skipped, inte blocked

Guardrail: 4 pinnar (återhävdbarhet, generisk default med ordgräns-korrekt bann-lista, fallback, löfte-grundat-i-svar).