### PR TITLE
fix(email): providern hör hemma i routern

### DIFF
--- a/src/components/admin/modules/ModuleDetailSheet.tsx
+++ b/src/components/admin/modules/ModuleDetailSheet.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { useState, useEffect } from "react";
 import { 
   Sheet, 
@@ -37,7 +38,7 @@ import { moduleRegistry } from "@/lib/module-registry";
 import { getModuleWebhookEvents } from "@/lib/module-webhook-events";
 import type { ModuleCapability } from "@/types/module-contracts";
 import type { ModuleStats } from "@/hooks/useModuleStats";
-import type { ModuleAutonomy, ModuleConfig, ModulesSettings, BookingEmailProvider, ConsultantAnonymization } from "@/hooks/useModules";
+import type { ModuleAutonomy, ModuleConfig, ModulesSettings, ConsultantAnonymization } from "@/hooks/useModules";
 import { useModules, useUpdateModules } from "@/hooks/useModules";
 import { formatDistanceToNow } from "date-fns";
 import { useExtensionRelay } from "@/hooks/useExtensionRelay";
@@ -584,45 +585,27 @@ export function ModuleDetailSheet({
                     {moduleConfig.confirmationEmailEnabled && (
                       <>
                         <Separator />
-                        <div className="space-y-2">
-                          <Label htmlFor="booking-email-provider" className="text-sm">
-                            Email Provider
-                          </Label>
-                          <Select
-                            value={moduleConfig.bookingEmailProvider ?? 'resend'}
-                            onValueChange={(value: BookingEmailProvider) => {
-                              if (!modules) return;
-                              updateModules.mutate({
-                                ...modules,
-                                bookings: {
-                                  ...modules.bookings,
-                                  bookingEmailProvider: value,
-                                },
-                              });
-                            }}
-                          >
-                            <SelectTrigger id="booking-email-provider">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="resend">
-                                <span className="flex items-center gap-2">
-                                  Resend
-                                  <Badge variant="outline" className="text-[10px] px-1.5 py-0">API</Badge>
-                                </span>
-                              </SelectItem>
-                              <SelectItem value="composio_gmail">
-                                <span className="flex items-center gap-2">
-                                  Gmail (Composio)
-                                  <Badge variant="outline" className="text-[10px] px-1.5 py-0">OAuth</Badge>
-                                </span>
-                              </SelectItem>
-                            </SelectContent>
-                          </Select>
-                          <p className="text-[11px] text-muted-foreground">
-                            {(moduleConfig.bookingEmailProvider ?? 'resend') === 'resend'
-                              ? 'Uses Resend API — emails sent from your configured domain.'
-                              : 'Uses Composio Gmail OAuth — emails sent from your connected Gmail account.'}
+                        {/* Lagerkartan (2026-08-25): modulen säger OM flödet
+                            mailar. VAD som skickas bor i mallbiblioteket, HUR
+                            det transporteras i routern. Providerratten som
+                            stod här duplicerade routerns ansvar per modul —
+                            fröet till nästa två-kopior-drift — och dess
+                            composio-gren gick förbi allowlist och logg.
+                            Proveniensrader + länkar, inga duplicerade rattar. */}
+                        <div className="space-y-1.5 text-xs text-muted-foreground">
+                          <p>
+                            Content comes from the <span className="font-medium text-foreground">booking_confirmation</span> template
+                            {' '}·{' '}
+                            <Link to="/admin/email?tab=templates" className="text-primary hover:underline">
+                              Edit email content →
+                            </Link>
+                          </p>
+                          <p>
+                            Delivery follows the platform email router
+                            {' '}·{' '}
+                            <Link to="/admin/communications?tab=router" className="text-primary hover:underline">
+                              Router settings →
+                            </Link>
                           </p>
                         </div>
                       </>

--- a/src/hooks/useModules.tsx
+++ b/src/hooks/useModules.tsx
@@ -56,7 +56,14 @@ export interface ModuleConfig {
   pricesIncludeVat?: boolean; // true (default) = B2C "inkl. moms"; false = "exkl. moms"
   // Booking-specific settings
   confirmationEmailEnabled?: boolean; // Send confirmation email on new booking
-  bookingEmailProvider?: BookingEmailProvider; // Which provider to use for booking emails
+  /**
+   * @deprecated 2026-08-25 — providervalet hör hemma i e-postroutern
+   * (Communications → Router). Fältet läses bara som legacy-HINT av
+   * comms-send/booking_confirmation (composio_gmail → provider: composio) så
+   * att instanser som valt Gmail behåller beteendet — nu genom routerns
+   * allowlist och logg i stället för förbi dem. Ingen UI skriver det längre.
+   */
+  bookingEmailProvider?: BookingEmailProvider;
   // Consultants module — GDPR setting for public-facing match results
   publicAnonymization?: ConsultantAnonymization;
 }

--- a/src/lib/__tests__/provider-belongs-to-the-router.guardrails.test.ts
+++ b/src/lib/__tests__/provider-belongs-to-the-router.guardrails.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Providern hör hemma i routern — modulen säger OM, inte HUR.
+ *
+ * Lagerkartan 2026-08-25: bookingEmailProvider i modulpanelen var ett
+ * lagerbrott med en blind fläck — composio_gmail-grenen gick DIREKT mot
+ * composio-proxy, förbi routerns allowlist, suppressions och outbound-logg.
+ * Ett bokningsmail via Gmail lämnade inget spår där alla andra mail loggas.
+ *
+ * Varsam borttagning: lagrat legacy-värde följer med som provider-HINT till
+ * email-send (composio stöds där sedan edge-surface-arbetet) — ingen instans
+ * tappar beteende, men varje mail går genom vakterna. Panelen bär
+ * proveniensrader med djuplänkar i stället för en duplicerad ratt — och
+ * djuplänkar som ingen läser är rattar som ljuger, så sidorna läser ?tab=.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(__dirname, '../../..');
+const HANDLER = readFileSync(join(ROOT, 'supabase/functions/comms-send/booking_confirmation.ts'), 'utf-8');
+const PANEL = readFileSync(join(__dirname, '../../components/admin/modules/ModuleDetailSheet.tsx'), 'utf-8');
+const EMAILPAGE = readFileSync(join(__dirname, '../../pages/admin/EmailPage.tsx'), 'utf-8');
+const COMMSPAGE = readFileSync(join(__dirname, '../../pages/admin/CommunicationsPage.tsx'), 'utf-8');
+
+describe('providern hör hemma i routern', () => {
+  it('bokningsmailet har EN väg — alltid genom email-send, aldrig direkt mot composio-proxy', () => {
+    expect(HANDLER).not.toContain("invoke('composio-proxy'");
+    expect(HANDLER).toContain("invoke('email-send'");
+  });
+
+  it('legacy-värdet är en HINT till routern, inte en egen transport', () => {
+    expect(HANDLER).toMatch(/bookingEmailProvider === 'composio_gmail' \? 'composio'/);
+  });
+
+  it('panelen skriver aldrig providern — proveniensrader med länkar i stället', () => {
+    expect(PANEL).not.toContain('bookingEmailProvider:');
+    expect(PANEL).toContain('Edit email content');
+    expect(PANEL).toContain('Router settings');
+  });
+
+  it('djuplänkarna landar rätt — båda sidorna läser ?tab=', () => {
+    for (const [name, src] of [['EmailPage', EMAILPAGE], ['CommunicationsPage', COMMSPAGE]] as const) {
+      expect(src, `${name} läser inte ?tab=`).toContain("searchParams.get('tab')");
+      expect(src).toContain('defaultValue={initialTab}');
+    }
+  });
+});

--- a/src/pages/admin/CommunicationsPage.tsx
+++ b/src/pages/admin/CommunicationsPage.tsx
@@ -1,3 +1,4 @@
+import { useSearchParams } from 'react-router-dom';
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
@@ -32,6 +33,11 @@ const STATUS_META: Record<string, { label: string; variant: any; icon: any }> = 
 };
 
 export default function CommunicationsPage() {
+  const [searchParams] = useSearchParams();
+  // Djuplänkar (?tab=…) från proveniensrader ska landa rätt — en länk som
+  // öppnar fel flik är en ratt som inte gör vad etiketten säger.
+  const requestedTab = searchParams.get('tab');
+  const initialTab = requestedTab && ['log', 'router'].includes(requestedTab) ? requestedTab : 'log';
   const [channel, setChannel] = useState<string>("all");
   const [status, setStatus] = useState<string>("all");
   const [direction, setDirection] = useState<string>("all");
@@ -89,7 +95,7 @@ export default function CommunicationsPage() {
         >
           <Button variant="outline" onClick={() => refetch()}>Refresh log</Button>
         </AdminPageHeader>
-        <Tabs defaultValue="log" className="space-y-6">
+        <Tabs defaultValue={initialTab} className="space-y-6">
           <TabsList>
             <TabsTrigger value="log">Log</TabsTrigger>
             <TabsTrigger value="router">Router settings</TabsTrigger>

--- a/src/pages/admin/EmailPage.tsx
+++ b/src/pages/admin/EmailPage.tsx
@@ -1,3 +1,4 @@
+import { useSearchParams } from 'react-router-dom';
 import { useEffect, useMemo, useState } from 'react';
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
@@ -25,6 +26,11 @@ import {
 } from '@/hooks/useEmailModule';
 
 export default function EmailPage() {
+  const [searchParams] = useSearchParams();
+  // Djuplänkar (?tab=…) från proveniensrader ska landa rätt — en länk som
+  // öppnar fel flik är en ratt som inte gör vad etiketten säger.
+  const requestedTab = searchParams.get('tab');
+  const initialTab = requestedTab && ['templates', 'threads', 'signatures', 'suppressions'].includes(requestedTab) ? requestedTab : 'templates';
   return (
     <AdminLayout>
       <div className="space-y-6">
@@ -32,7 +38,7 @@ export default function EmailPage() {
           <h1 className="font-serif text-2xl font-bold text-foreground flex items-center gap-2"><Mail className="h-7 w-7" /> Email</h1>
           <p className="text-muted-foreground mt-1">Templates, threads, signatures and deliverability controls.</p>
         </div>
-        <Tabs defaultValue="templates" className="space-y-4">
+        <Tabs defaultValue={initialTab} className="space-y-4">
           <TabsList>
             <TabsTrigger value="templates"><FileText className="h-4 w-4 mr-1" /> Templates</TabsTrigger>
             <TabsTrigger value="threads"><MessagesSquare className="h-4 w-4 mr-1" /> Threads</TabsTrigger>

--- a/supabase/functions/comms-send/booking_confirmation.ts
+++ b/supabase/functions/comms-send/booking_confirmation.ts
@@ -213,7 +213,6 @@ export const handler = async (req: Request): Promise<Response> => {
       );
     }
 
-    const emailProvider = bookingsConfig?.bookingEmailProvider || 'resend';
     const siteName = (siteSettings?.value as { siteName?: string })?.siteName || "Our Website";
     
     // Get email configuration from integrations
@@ -223,7 +222,7 @@ export const handler = async (req: Request): Promise<Response> => {
       fromName: siteName,
     };
 
-    console.log(`[send-booking-confirmation] Provider: ${emailProvider}, Sender: ${emailConfig.fromName} <${emailConfig.fromEmail}>`);
+    console.log(`[send-booking-confirmation] Sender: ${emailConfig.fromName} <${emailConfig.fromEmail}>`);
 
     // Format date and time
     const startDate = new Date(booking.start_time);
@@ -341,38 +340,25 @@ export const handler = async (req: Request): Promise<Response> => {
       </html>
     `;
 
-    // Send email via selected provider
+    // ── EN väg: routern äger transporten ─────────────────────────────────────
+    // Tidigare valde bokningsMODULEN provider (bookingsConfig.bookingEmailProvider)
+    // och composio_gmail gick i en EGEN gren direkt mot composio-proxy — förbi
+    // routerns allowlist, suppressions och outbound-logg. Ett lagerbrott med
+    // en blind fläck: gmail-vägen lämnade inget spår i outbound_communications.
+    // email-send stödjer composio som provider (explicit/enabledMap) sedan
+    // edge-surface-arbetet, så grenen är legacy. Varsamt borttagen: ett lagrat
+    // legacy-värde 'composio_gmail' följer med som provider-HINT till routern —
+    // ingen instans tappar sitt gmail-beteende, men varje mail går nu genom
+    // vakterna och loggen. Providervalet hör hemma i Communications → Router.
     let emailId: string | undefined;
-
-    if (emailProvider === 'composio_gmail') {
-      // Send via Composio Gmail
-      console.log("[send-booking-confirmation] Sending via Composio Gmail");
-      const composioResponse = await supabase.functions.invoke('composio-proxy', {
-        body: {
-          action: 'GMAIL_SEND_EMAIL',
-          arguments: {
-            recipient_email: booking.customer_email,
-            subject: templateSubject ?? `Booking Confirmation - ${formattedDate}`,
-            body: emailHtml,
-            content_type: 'text/html',
-          },
-        },
-      });
-
-      if (composioResponse.error) {
-        console.error("[send-booking-confirmation] Composio Gmail error:", composioResponse.error);
-        throw new Error(`Composio Gmail failed: ${composioResponse.error.message || 'Unknown error'}`);
-      }
-
-      emailId = composioResponse.data?.id || 'composio-sent';
-      console.log("[send-booking-confirmation] Gmail sent successfully");
-    } else {
-      // Send via central email-send router (provider-agnostic SMTP/Resend)
+    {
+      const legacyHint = bookingsConfig?.bookingEmailProvider === 'composio_gmail' ? 'composio' : undefined;
       const { data: emailResponse, error: emailError } = await supabase.functions.invoke('email-send', {
         body: {
           to: booking.customer_email,
           subject: templateSubject ?? `Booking Confirmation - ${formattedDate}`,
           html: emailHtml,
+          ...(legacyHint ? { provider: legacyHint } : {}),
           fromOverride: `${emailConfig.fromName} <${emailConfig.fromEmail}>`,
           tags: { source: 'send-booking-confirmation', booking_id: bookingId },
         },
@@ -390,7 +376,7 @@ export const handler = async (req: Request): Promise<Response> => {
       .eq("id", bookingId);
 
     return new Response(
-      JSON.stringify({ success: true, emailId, provider: emailProvider }),
+      JSON.stringify({ success: true, emailId, provider: "router" }),
       { status: 200, headers: { "Content-Type": "application/json", ...corsHeaders } }
     );
 

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2112,7 +2112,7 @@
         "chat-completion": "sha256:b2bfe35ae9e8f896e717776d33dfa9ec8ce39e37a788413a14351b8c4b866b3a",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
-        "comms-send": "sha256:831b17d08500f424390b4bc0fa5c6d0398271cc9fa60bbeca574483318ddccae",
+        "comms-send": "sha256:dc520a70402923c53a93d04716fee838ee5667bc7902f27ab7783695cba4a820",
         "composio-proxy": "sha256:08477e4658cee04b6a09458a5e8dc45fbf9737c2188f7b972ae954782a4bdc95",
         "composio-webhook": "sha256:27f17b7198bfbab422931ef1c872da083299e095792e43b98b4154ec79c858ca",
         "consultant-match": "sha256:1419717affb3711a2d7f13d44c9a228e1557a3d927e3aa05ee5e179584131e1b",


### PR DESCRIPTION
Lagerkartans drag **1+4**, beslut Magnus ('kör på och ta det varsamt').

**Fyndet under flytten:** `composio_gmail`-grenen gick direkt mot composio-proxy — **förbi allowlist, suppressions och outbound-loggen**. Gmail-bokningsmail lämnade inget spår där allt annat loggas.

**Varsamt:** en väg (alltid email-send; composio stöds där), lagrat legacy-värde blir provider-hint — ingen instans tappar beteende, alla mail genom vakterna. Fältet @deprecated.

**Panelen:** proveniensrader med djuplänkar i stället för duplicerad ratt — och båda målsidorna läser nu `?tab=` (en djuplänk ingen läser är en ratt som ljuger; upptäckt av byggets egen kontroll).

4 guardrail-pinnar · deno check grön · full svit grön