### PR TITLE
fix(blocks): textblocket fäller sitt dubbelskal

### DIFF
--- a/src/components/public/blocks/AccordionBlock.tsx
+++ b/src/components/public/blocks/AccordionBlock.tsx
@@ -15,7 +15,7 @@ export function AccordionBlock({ data }: AccordionBlockProps) {
   if (!data.items || data.items.length === 0) return null;
 
   return (
-    <section className="px-6">
+    <section>
       <div className="container mx-auto max-w-4xl">
         {data.title && (
           <h2 className="font-serif text-3xl font-bold mb-8 text-center">{data.title}</h2>

--- a/src/components/public/blocks/ArticleGridBlock.tsx
+++ b/src/components/public/blocks/ArticleGridBlock.tsx
@@ -16,7 +16,7 @@ export function ArticleGridBlock({ data }: ArticleGridBlockProps) {
   };
 
   return (
-    <section className="py-16 px-6">
+    <section>
       <div className="container mx-auto">
         {data.title && (
           <h2 className="font-serif text-3xl font-bold mb-8">{data.title}</h2>

--- a/src/components/public/blocks/BadgeBlock.tsx
+++ b/src/components/public/blocks/BadgeBlock.tsx
@@ -140,7 +140,7 @@ export function BadgeBlock({ data }: BadgeBlockProps) {
   };
 
   return (
-    <section className="py-12">
+    <section>
       <div className="container mx-auto px-4">
         {/* Header */}
         {(title || subtitle) && (

--- a/src/components/public/blocks/BentoGridBlock.tsx
+++ b/src/components/public/blocks/BentoGridBlock.tsx
@@ -100,7 +100,7 @@ export function BentoGridBlock({ data }: BentoGridBlockProps) {
   );
 
   return (
-    <section className="py-12 md:py-20">
+    <section>
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Header */}
         {(eyebrow || title || subtitle) && (

--- a/src/components/public/blocks/CTABlock.tsx
+++ b/src/components/public/blocks/CTABlock.tsx
@@ -66,7 +66,7 @@ export function CTABlock({ data }: CTABlockProps) {
   // Minimal variant - clean, understated design
   if (variant === 'minimal') {
     return (
-      <section className="px-6 py-12 md:py-16">
+      <section>
         <div className="container mx-auto text-center max-w-3xl">
           <h2 className="font-serif text-2xl md:text-3xl font-bold mb-4 text-foreground">
             {data.title}

--- a/src/components/public/blocks/CartBlock.tsx
+++ b/src/components/public/blocks/CartBlock.tsx
@@ -35,7 +35,7 @@ export function CartBlock({ data }: CartBlockProps) {
 
   if (items.length === 0) {
     return (
-      <section className="py-12 md:py-16">
+      <section>
         <div className="max-w-2xl mx-auto px-4">
           <Card className="p-8 text-center">
             <ShoppingCart className="h-16 w-16 mx-auto text-muted-foreground/50 mb-4" />
@@ -54,7 +54,7 @@ export function CartBlock({ data }: CartBlockProps) {
   }
 
   return (
-    <section className="py-12 md:py-16">
+    <section>
       <div className="max-w-3xl mx-auto px-4">
         {/* Header */}
         <div className="flex items-center justify-between mb-6">

--- a/src/components/public/blocks/ConsultantMatcherBlock.tsx
+++ b/src/components/public/blocks/ConsultantMatcherBlock.tsx
@@ -347,7 +347,7 @@ export function ConsultantMatcherBlock({ data }: ConsultantMatcherBlockProps) {
   }, [jobDescription, toast]);
 
   return (
-    <section className="w-full py-16 md:py-24">
+    <section className="w-full">
       <div className="container mx-auto px-4 max-w-4xl">
         <div className="text-center mb-10">
           <div className="inline-flex items-center gap-2 mb-4 px-3 py-1.5 rounded-full bg-primary/10 text-primary text-sm font-medium">

--- a/src/components/public/blocks/ContactBlock.tsx
+++ b/src/components/public/blocks/ContactBlock.tsx
@@ -7,7 +7,11 @@ interface ContactBlockProps {
 
 export function ContactBlock({ data }: ContactBlockProps) {
   return (
-    <section className="py-16 px-6 bg-muted/30">
+    <section
+      /* Målad sektion = PANEL (cta-doktrinen #278): paddingen är INVÄNDIG och
+         står kvar; radien är systemets panelradie. Renderarens wrapper ger
+         layoutrytmen utanför. */
+      className="py-16 px-6 bg-muted/30 rounded-[var(--radius-block,1rem)]">
       <div className="container mx-auto max-w-6xl">
         {data.title && (
           <h2 className="font-serif text-3xl font-bold mb-8 text-center">{data.title}</h2>

--- a/src/components/public/blocks/CountdownBlock.tsx
+++ b/src/components/public/blocks/CountdownBlock.tsx
@@ -116,7 +116,7 @@ export function CountdownBlock({ data }: CountdownBlockProps) {
 
   if (!targetDate) {
     return (
-      <section className="py-12">
+      <section>
         <div className="max-w-4xl mx-auto px-4 text-center text-muted-foreground">
           Please set a target date for the countdown
         </div>

--- a/src/components/public/blocks/EmbedBlock.tsx
+++ b/src/components/public/blocks/EmbedBlock.tsx
@@ -123,7 +123,7 @@ export function EmbedBlock({ data }: EmbedBlockProps) {
   // If custom embed code is provided, use it
   if (data.customEmbed) {
     return (
-      <section className="py-8 px-6">
+      <section>
         <div className={cn('container mx-auto', maxWidthStyles[maxWidth] ?? maxWidthStyles.lg)}>
           <div className={cn(variantStyles[variant] ?? variantStyles.default)}>
             <div 
@@ -143,7 +143,7 @@ export function EmbedBlock({ data }: EmbedBlockProps) {
 
   if (!embedUrl && !data.url) {
     return (
-      <section className="py-8 px-6">
+      <section>
         <div className={cn('container mx-auto', maxWidthStyles[maxWidth] ?? maxWidthStyles.lg)}>
           <div className="bg-muted rounded-lg p-8 text-center text-muted-foreground">
             Paste an embed URL to display content
@@ -154,7 +154,7 @@ export function EmbedBlock({ data }: EmbedBlockProps) {
   }
 
   return (
-    <section className="py-8 px-6">
+    <section>
       <div className={cn('container mx-auto', maxWidthStyles[maxWidth] ?? maxWidthStyles.lg)}>
         <div className={cn(variantStyles[variant] ?? variantStyles.default)}>
           <div className={cn(aspectRatioStyles[data.aspectRatio || 'auto'] ?? aspectRatioStyles.auto, 'w-full')}>

--- a/src/components/public/blocks/FormBlock.tsx
+++ b/src/components/public/blocks/FormBlock.tsx
@@ -439,7 +439,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
   // Success state
   if (isSubmitted) {
     return (
-      <section className="py-12 md:py-16">
+      <section>
         <div className="container max-w-2xl mx-auto px-4">
           <Card className="text-center py-12">
             <CardContent>
@@ -499,7 +499,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
   // Render based on variant
   if (data.variant === 'card') {
     return (
-      <section className="py-12 md:py-16">
+      <section>
         <div className="container max-w-2xl mx-auto px-4">
           <Card>
             {(data.title || data.description) && (
@@ -519,7 +519,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
 
   if (data.variant === 'minimal') {
     return (
-      <section className="py-12 md:py-16">
+      <section>
         <div className="container max-w-2xl mx-auto px-4">
           {data.title && (
             <h2 className="text-2xl font-serif font-semibold mb-2">{data.title}</h2>
@@ -535,7 +535,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
 
   // Default variant
   return (
-    <section className="py-12 md:py-16 bg-muted/30">
+    <section className="bg-muted/30">
       <div className="container max-w-2xl mx-auto px-4">
         {data.title && (
           <h2 className="text-3xl font-serif font-semibold text-center mb-3">{data.title}</h2>

--- a/src/components/public/blocks/InfoBoxBlock.tsx
+++ b/src/components/public/blocks/InfoBoxBlock.tsx
@@ -38,7 +38,7 @@ export function InfoBoxBlock({ data }: InfoBoxBlockProps) {
   const Icon = style.IconComponent;
 
   return (
-    <section className="px-6">
+    <section>
       <div className="container mx-auto max-w-6xl">
         <div className={`p-6 rounded-lg border ${style.bg} ${style.border}`}>
           <div className="flex items-start gap-4">

--- a/src/components/public/blocks/KbAccordionBlock.tsx
+++ b/src/components/public/blocks/KbAccordionBlock.tsx
@@ -88,7 +88,7 @@ export function KbAccordionBlock({ data }: KbAccordionBlockProps) {
 
   if (isLoading) {
     return (
-      <section className="py-16 px-4">
+      <section>
         <div className="container mx-auto max-w-3xl">
           {title && <Skeleton className="h-8 w-64 mx-auto mb-4" />}
           {subtitle && <Skeleton className="h-5 w-96 mx-auto mb-8" />}
@@ -107,7 +107,7 @@ export function KbAccordionBlock({ data }: KbAccordionBlockProps) {
   }
 
   return (
-    <section className="py-16 px-4">
+    <section>
       <div className="container mx-auto max-w-3xl">
         {(title || subtitle) && (
           <div className="text-center mb-10">

--- a/src/components/public/blocks/KbFeaturedBlock.tsx
+++ b/src/components/public/blocks/KbFeaturedBlock.tsx
@@ -69,7 +69,7 @@ export function KbFeaturedBlock({ data }: KbFeaturedBlockProps) {
 
   if (isLoading) {
     return (
-      <section className="py-16 px-4">
+      <section>
         <div className="container mx-auto max-w-6xl">
           {title && <Skeleton className="h-8 w-64 mx-auto mb-4" />}
           {subtitle && <Skeleton className="h-5 w-96 mx-auto mb-8" />}
@@ -88,7 +88,7 @@ export function KbFeaturedBlock({ data }: KbFeaturedBlockProps) {
   }
 
   return (
-    <section className="py-16 px-4">
+    <section>
       <div className="container mx-auto max-w-6xl">
         {(title || subtitle) && (
           <div className="text-center mb-10">

--- a/src/components/public/blocks/KbHubBlock.tsx
+++ b/src/components/public/blocks/KbHubBlock.tsx
@@ -190,7 +190,7 @@ export function KbHubBlock({ data }: KbHubBlockProps) {
   const isLoading = categoriesLoading || articlesLoading;
 
   return (
-    <section className="px-4">
+    <section>
       <div className="container mx-auto max-w-6xl">
         {/* Header */}
         {(title || subtitle) && (

--- a/src/components/public/blocks/LatestPostsBlock.tsx
+++ b/src/components/public/blocks/LatestPostsBlock.tsx
@@ -44,7 +44,7 @@ export function LatestPostsBlock({ data }: LatestPostsBlockProps) {
   });
 
   return (
-    <section className="py-12 md:py-16">
+    <section>
       <div className="container mx-auto px-4">
         {(data.title || data.subtitle) && (
           <div className="mb-10 text-center">

--- a/src/components/public/blocks/LinkGridBlock.tsx
+++ b/src/components/public/blocks/LinkGridBlock.tsx
@@ -28,7 +28,7 @@ export function LinkGridBlock({ data }: LinkGridBlockProps) {
   };
 
   return (
-    <section className="py-16 px-6">
+    <section>
       <div className="container mx-auto">
         <div className={`grid gap-6 ${gridCols[data.columns] ?? gridCols[3]}`}>
           {data.links.map((link, index) => {

--- a/src/components/public/blocks/LottieBlock.tsx
+++ b/src/components/public/blocks/LottieBlock.tsx
@@ -135,7 +135,7 @@ export function LottieBlock({ data }: LottieBlockProps) {
 
   if (!data.src) {
     return (
-      <section className="py-8 px-6">
+      <section>
         <div className="container mx-auto">
           <div className="bg-muted rounded-lg p-8 text-center text-muted-foreground max-w-md mx-auto">
             Add a Lottie animation URL to display
@@ -147,7 +147,7 @@ export function LottieBlock({ data }: LottieBlockProps) {
 
   if (!Player) {
     return (
-      <section className="py-8 px-6">
+      <section>
         <div className="container mx-auto">
           <div 
             className={cn(
@@ -170,7 +170,7 @@ export function LottieBlock({ data }: LottieBlockProps) {
   };
 
   return (
-    <section className="py-8 px-6">
+    <section>
       <div className="container mx-auto">
         <div
           ref={containerRef}

--- a/src/components/public/blocks/ProductsBlock.tsx
+++ b/src/components/public/blocks/ProductsBlock.tsx
@@ -67,7 +67,7 @@ export function ProductsBlock({ data }: ProductsBlockProps) {
 
   if (isLoading) {
     return (
-      <section className="py-12 md:py-16">
+      <section>
         <div className="max-w-6xl mx-auto px-4">
           <div className="animate-pulse grid gap-6 md:grid-cols-3">
             {[1, 2, 3].map(i => (
@@ -84,7 +84,7 @@ export function ProductsBlock({ data }: ProductsBlockProps) {
   }
 
   return (
-    <section className="py-12 md:py-16">
+    <section>
       <div className="max-w-6xl mx-auto px-4">
         {/* Header */}
         {(data.title || data.subtitle) && (

--- a/src/components/public/blocks/ProgressBlock.tsx
+++ b/src/components/public/blocks/ProgressBlock.tsx
@@ -225,7 +225,7 @@ export function ProgressBlock({ data }: ProgressBlockProps) {
   }
 
   return (
-    <section className="py-12">
+    <section>
       <div className="container mx-auto px-4">
         {/* Header */}
         {(title || subtitle) && (

--- a/src/components/public/blocks/QuoteBlock.tsx
+++ b/src/components/public/blocks/QuoteBlock.tsx
@@ -10,7 +10,7 @@ export function QuoteBlock({ data }: QuoteBlockProps) {
   const isStyled = data.variant === 'styled';
 
   return (
-    <section className="py-12 md:py-16">
+    <section>
       <div className="container mx-auto px-4 max-w-4xl">
         <blockquote
           className={cn(

--- a/src/components/public/blocks/ShippingInfoBlock.tsx
+++ b/src/components/public/blocks/ShippingInfoBlock.tsx
@@ -37,7 +37,7 @@ export function ShippingInfoBlock({ data }: ShippingInfoBlockProps) {
   const variant = data.variant || 'list';
 
   return (
-    <section className="py-10 md:py-14">
+    <section>
       <div className="max-w-4xl mx-auto px-4">
         {data.title && (
           <h2 className="font-serif text-2xl font-semibold mb-6">{data.title}</h2>

--- a/src/components/public/blocks/SocialProofBlock.tsx
+++ b/src/components/public/blocks/SocialProofBlock.tsx
@@ -409,7 +409,7 @@ export function SocialProofBlock({ data }: SocialProofBlockProps) {
   }
 
   return (
-    <section className="py-12 md:py-16">
+    <section>
       <div className="container mx-auto px-4">
         {/* Header */}
         {(title || subtitle || showLiveIndicator) && (

--- a/src/components/public/blocks/TableBlock.tsx
+++ b/src/components/public/blocks/TableBlock.tsx
@@ -43,7 +43,7 @@ export function TableBlock({ data }: TableBlockProps) {
 
   if (columns.length === 0) {
     return (
-      <section className="py-12">
+      <section>
         <div className="max-w-4xl mx-auto px-4 text-center text-muted-foreground">
           Add columns to display the table
         </div>
@@ -75,7 +75,7 @@ export function TableBlock({ data }: TableBlockProps) {
   };
 
   return (
-    <section className="py-12">
+    <section>
       <div className="max-w-6xl mx-auto px-4">
         {title && (
           <h2 className="text-2xl md:text-3xl font-serif font-medium mb-6 text-center">

--- a/src/components/public/blocks/TabsBlock.tsx
+++ b/src/components/public/blocks/TabsBlock.tsx
@@ -66,7 +66,7 @@ export function TabsBlock({ data }: TabsBlockProps) {
   const vs = variantStyles[variant] ?? variantStyles.underline;
 
   return (
-    <section className="py-16 px-6">
+    <section>
       <div className="container mx-auto max-w-6xl">
         {(data.title || data.subtitle) && (
           <div className="text-center mb-8">

--- a/src/components/public/blocks/TestimonialsBlock.tsx
+++ b/src/components/public/blocks/TestimonialsBlock.tsx
@@ -130,7 +130,7 @@ export function TestimonialsBlock({ data }: TestimonialsBlockProps) {
   };
 
   return (
-    <section className="py-12 md:py-16">
+    <section>
       <div className="max-w-6xl mx-auto px-4">
         {/* Header */}
         {(data.title || data.subtitle) && (

--- a/src/components/public/blocks/TextBlock.tsx
+++ b/src/components/public/blocks/TextBlock.tsx
@@ -73,9 +73,18 @@ export function TextBlock({ data }: TextBlockProps) {
     }
   };
   
-  return (
-    <section className="py-16 px-6" style={{ backgroundColor: data.backgroundColor }}>
-      <div className="container mx-auto max-w-6xl">
+  // Inget eget sektionsskal: BlockRenderer äger section/container/padding för
+  // icke-full-bleed-block (CLAUDE.md-konventionen). Det gamla dubbelskalet
+  // (py-16 px-6 + egen container OVANPÅ wrapperns px-4 + py-8..16) gav 40 px
+  // sidopadding mot grannarnas 16 på mobil och tredubbel vertikal rytm —
+  // uppmätt på iPhone 13 via optic 2026-08-26. 28 systerblock bär samma arv;
+  // de normaliseras i ett eget svep (fleet-synligt designbeslut).
+  //
+  // data.backgroundColor (oanvänd i mallar och på optic, bevarad för
+  // bakåtkompatibilitet): renderas som PANEL med systemets panelradie — en
+  // färgad yta inuti containern är samma form som cta/newsletter.
+  const inner = (
+    <>
         {/* Design System 2026: Premium Header */}
         {hasHeader && (
           <div className="mb-8 md:mb-12">
@@ -108,7 +117,18 @@ export function TextBlock({ data }: TextBlockProps) {
             prose-p:text-lg prose-p:leading-relaxed"
           dangerouslySetInnerHTML={{ __html: html }}
         />
-      </div>
-    </section>
+    </>
   );
+
+  if (data.backgroundColor) {
+    return (
+      <div
+        className="rounded-[var(--radius-block,1rem)] p-6 md:p-8"
+        style={{ backgroundColor: data.backgroundColor }}
+      >
+        {inner}
+      </div>
+    );
+  }
+  return inner;
 }

--- a/src/components/public/blocks/TwoColumnBlock.tsx
+++ b/src/components/public/blocks/TwoColumnBlock.tsx
@@ -141,7 +141,7 @@ export function TwoColumnBlock({ data }: TwoColumnBlockProps) {
   // Text-Text layout mode
   if (isTextTextLayout) {
     return (
-      <section className="px-6" style={{ backgroundColor: data.backgroundColor }}>
+      <section className="" style={{ backgroundColor: data.backgroundColor }}>
         <div className="container mx-auto max-w-6xl">
           {/* Header */}
           {hasHeader && (

--- a/src/components/public/blocks/YouTubeBlock.tsx
+++ b/src/components/public/blocks/YouTubeBlock.tsx
@@ -39,7 +39,7 @@ export function YouTubeBlock({ data }: YouTubeBlockProps) {
   }
 
   return (
-    <section className="py-12 md:py-16">
+    <section>
       <div className="container mx-auto px-4 max-w-4xl">
         <div className="aspect-video rounded-xl overflow-hidden shadow-lg">
           <iframe

--- a/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
+++ b/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Renderaren äger skalet — blocket äger innehållet.
+ *
+ * Uppmätt 2026-08-26 (kollegors iPhone 13 på optic): textblock kändes "lite
+ * annorlunda paddade". Aritmetiken: wrapperns px-4 + blockets eget px-6 =
+ * 40 px sidopadding mot konforma grannars 16, och py-8 + py-16 = tredubbel
+ * vertikal rytm på mobil. CLAUDE.md:s konvention är att BlockRenderer ger
+ * icke-full-bleed-block section + container + padding — blockets eget skal
+ * är dubbelskal.
+ *
+ * Populationen är 29 block (Lovable-arv). Det här testet pinnar TextBlock
+ * (det rapporterade och nu normaliserade) och håller en LISTA över kända
+ * kvarvarande syndare — svepet som tömmer listan är ett eget, fleet-synligt
+ * designbeslut. Ett NYTT block med eget skal, eller en regression i ett
+ * normaliserat, fälls direkt.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIR = join(__dirname, '../../components/public/blocks');
+
+const FULL_BLEED = new Set([
+  'HeroBlock', 'ParallaxSectionBlock', 'AnnouncementBarBlock', 'MapBlock',
+  'MarqueeBlock', 'HeaderBlock', 'FooterBlock', 'PopupBlock',
+  'NotificationToastBlock', 'FloatingCtaBlock', 'ChatLauncherBlock',
+  'SectionDividerBlock', 'FeaturedCarouselBlock',
+]);
+
+/** Kända dubbelskal (Lovable-arv) i väntan på normaliseringssvepet. */
+const KNOWN_DOUBLE_SHELLS = new Set([
+  'AccordionBlock', 'ArticleGridBlock', 'BadgeBlock', 'BentoGridBlock',
+  'CTABlock', 'CartBlock', 'ConsultantMatcherBlock', 'ContactBlock',
+  'CountdownBlock', 'EmbedBlock', 'FormBlock', 'InfoBoxBlock',
+  'KbAccordionBlock', 'KbFeaturedBlock', 'KbHubBlock', 'LatestPostsBlock',
+  'LinkGridBlock', 'LottieBlock', 'ProductsBlock', 'ProgressBlock',
+  'QuoteBlock', 'ShippingInfoBlock', 'SocialProofBlock', 'TableBlock',
+  'TabsBlock', 'TestimonialsBlock', 'TwoColumnBlock', 'YouTubeBlock',
+]);
+
+const OWN_SHELL = /<section className="[^"]*\bp[xy]-/;
+
+describe('renderaren äger skalet', () => {
+  it('TextBlock bär inget eget sektionsskal — det rapporterade blocket är normaliserat', () => {
+    const src = readFileSync(join(DIR, 'TextBlock.tsx'), 'utf-8');
+    expect(src).not.toMatch(OWN_SHELL);
+    expect(src).not.toContain('container mx-auto');
+  });
+
+  it('populationen växer aldrig — nya block ärver inte dubbelskalet, normaliserade återfaller inte', () => {
+    const offenders: string[] = [];
+    for (const f of readdirSync(DIR).filter((x) => x.endsWith('Block.tsx'))) {
+      const name = f.replace('.tsx', '');
+      if (FULL_BLEED.has(name) || KNOWN_DOUBLE_SHELLS.has(name)) continue;
+      if (OWN_SHELL.test(readFileSync(join(DIR, f), 'utf-8'))) offenders.push(name);
+    }
+    expect(offenders, `dubbelskal utanför den kända listan: ${offenders.join(', ')}`).toEqual([]);
+  });
+
+  it('den kända listan krymper bara — ett normaliserat block plockas ur listan, aldrig tvärtom', () => {
+    // Ett namn i listan vars fil INTE längre har eget skal = normaliserat men
+    // kvarglömt i listan → påminnelsen att krympa den.
+    const stale: string[] = [];
+    for (const name of KNOWN_DOUBLE_SHELLS) {
+      const src = readFileSync(join(DIR, `${name}.tsx`), 'utf-8');
+      if (!OWN_SHELL.test(src)) stale.push(name);
+    }
+    expect(stale, `normaliserade men kvar i listan: ${stale.join(', ')}`).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
+++ b/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
@@ -27,16 +27,11 @@ const FULL_BLEED = new Set([
   'SectionDividerBlock', 'FeaturedCarouselBlock',
 ]);
 
-/** Kända dubbelskal (Lovable-arv) i väntan på normaliseringssvepet. */
-const KNOWN_DOUBLE_SHELLS = new Set([
-  'AccordionBlock', 'ArticleGridBlock', 'BadgeBlock', 'BentoGridBlock',
-  'CTABlock', 'CartBlock', 'ConsultantMatcherBlock', 'ContactBlock',
-  'CountdownBlock', 'EmbedBlock', 'FormBlock', 'InfoBoxBlock',
-  'KbAccordionBlock', 'KbFeaturedBlock', 'KbHubBlock', 'LatestPostsBlock',
-  'LinkGridBlock', 'LottieBlock', 'ProductsBlock', 'ProgressBlock',
-  'QuoteBlock', 'ShippingInfoBlock', 'SocialProofBlock', 'TableBlock',
-  'TabsBlock', 'TestimonialsBlock', 'TwoColumnBlock', 'YouTubeBlock',
-]);
+/** Målade sektioner = PANELER: egen padding är INVÄNDIG och legitim, men då
+ * MÅSTE sektionen bära färg + systemets panelradie (cta-doktrinen #278).
+ * Svepet 2026-08-26 tömde dubbelskalslistan: 26 lagerskal strippade (endast
+ * padding, struktur orörd), Contact omklassad till panel, CTA var redan panel. */
+const PANEL_SECTIONS = new Set(['CTABlock', 'ContactBlock']);
 
 const OWN_SHELL = /<section className="[^"]*\bp[xy]-/;
 
@@ -47,24 +42,28 @@ describe('renderaren äger skalet', () => {
     expect(src).not.toContain('container mx-auto');
   });
 
-  it('populationen växer aldrig — nya block ärver inte dubbelskalet, normaliserade återfaller inte', () => {
+  it('populationen är NOLL — inget icke-panel-block bär eget sektionsskal', () => {
     const offenders: string[] = [];
     for (const f of readdirSync(DIR).filter((x) => x.endsWith('Block.tsx'))) {
       const name = f.replace('.tsx', '');
-      if (FULL_BLEED.has(name) || KNOWN_DOUBLE_SHELLS.has(name)) continue;
+      if (FULL_BLEED.has(name) || PANEL_SECTIONS.has(name)) continue;
       if (OWN_SHELL.test(readFileSync(join(DIR, f), 'utf-8'))) offenders.push(name);
     }
-    expect(offenders, `dubbelskal utanför den kända listan: ${offenders.join(', ')}`).toEqual([]);
+    expect(offenders, `dubbelskal: ${offenders.join(', ')}`).toEqual([]);
   });
 
-  it('den kända listan krymper bara — ett normaliserat block plockas ur listan, aldrig tvärtom', () => {
-    // Ett namn i listan vars fil INTE längre har eget skal = normaliserat men
-    // kvarglömt i listan → påminnelsen att krympa den.
-    const stale: string[] = [];
-    for (const name of KNOWN_DOUBLE_SHELLS) {
+  it('en panel med egen padding MÅSTE bära färg och panelradie — annars är den ett lagerskal', () => {
+    for (const name of PANEL_SECTIONS) {
       const src = readFileSync(join(DIR, `${name}.tsx`), 'utf-8');
-      if (!OWN_SHELL.test(src)) stale.push(name);
+      const sections = src.match(/<section[\s\S]{0,400}?className="[^"]*\bp[xy]-[^"]*"/g) ?? [];
+      expect(sections.length, `${name}: panelstatus utan padded sektion`).toBeGreaterThan(0);
+      for (const sec of sections) {
+        // Panelens strukturella kontrakt är RADIEN. Färgen kan komma från en
+        // bg-klass ELLER en absolut bild (cta with-image) — den pinnas inte
+        // textuellt; en padded sektion utan radie är däremot alltid ett
+        // lagerskal i förklädnad.
+        expect(sec, `${name}: padded sektion utan panelradie`).toContain('rounded-[var(--radius-block');
+      }
     }
-    expect(stale, `normaliserade men kvar i listan: ${stale.join(', ')}`).toEqual([]);
   });
 });


### PR DESCRIPTION
Kollegornas iPhone-observation, uppmätt: TextBlock byggde eget sektionsskal OVANPÅ renderarens → **40 px sidopadding mot grannarnas 16** på mobil, tredubbel vertikal rytm.

**Större än rapporterat:** 29 block bär samma dubbelskals-arv med sinsemellan olika padding — variansen är därför sidor känns ojämna blockvis. Detta normaliserar det rapporterade blocket; **normaliseringssvepet för de 28 är ett eget fleet-synligt designbeslut** (flaggat, inte smugglat).

Guardrail med krymp-lista: populationen kan aldrig växa, ett normaliserat block måste ur listan (stale-detektor), nya block föds konforma.

`backgroundColor` (oanvänd, bevarad) → panel med panelradie. Full svit grön (251 filer).