### PR TITLE
fix(admin): mailförhandsvisningen är en ljus ö

### DIFF
--- a/src/components/admin/communications/CommunicationDetailDialog.tsx
+++ b/src/components/admin/communications/CommunicationDetailDialog.tsx
@@ -1,6 +1,7 @@
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle,
 } from "@/components/ui/dialog";
+import { EmailTemplatePreview } from '@/components/admin/email/EmailTemplatePreview';
 
 export type CommMetadata = {
   tags?: Record<string, string | undefined>;
@@ -63,8 +64,18 @@ export function CommunicationDetailDialog({
             {comm.body_html && (
               <div>
                 <div className="text-xs uppercase text-muted-foreground mb-1">Preview</div>
-                <div className="border rounded-md p-4 bg-card max-h-96 overflow-y-auto"
-                     dangerouslySetInnerHTML={{ __html: comm.body_html }} />
+                {/* Ett mail är ett LJUST dokument — inline-färger som #333 är
+                    författade mot vit botten, och bg-card i mörkt tema gjorde
+                    texten oläslig (Magnus, dark theme på optic 2026-08-26).
+                    EmailTemplatePreview finns för EXAKT detta: iframe srcDoc,
+                    isolerad från adminens tema och CSS. En renderare för
+                    mail-HTML, inte två. */}
+                <EmailTemplatePreview
+                  subject={comm.subject ?? ''}
+                  html={comm.body_html}
+                  values={{}}
+                  className="w-full h-96 bg-white"
+                />
               </div>
             )}
             {!comm.body_html && comm.body_text && (

--- a/src/lib/__tests__/mail-preview-is-a-light-island.guardrails.test.ts
+++ b/src/lib/__tests__/mail-preview-is-a-light-island.guardrails.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Ett mail förhandsvisas som det dokument det är — ljust och isolerat.
+ *
+ * Magnus i dark theme på optic 2026-08-26: bekräftelsemailet i Communications-
+ * modalen var oläsligt — mailets inline color:#333 mot temats mörka bg-card.
+ * Mail-HTML författas mot antagen vit botten; ett tema den aldrig sett får
+ * inte färga den. Husets renderare för detta finns (EmailTemplatePreview:
+ * iframe srcDoc, bg-white, isolerad från adminens CSS) — dialogen hade byggt
+ * en egen div-rendering bredvid. En renderare för mail-HTML, inte två.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIALOG = readFileSync(
+  join(__dirname, '../../components/admin/communications/CommunicationDetailDialog.tsx'), 'utf-8');
+const PREVIEW = readFileSync(
+  join(__dirname, '../../components/admin/email/EmailTemplatePreview.tsx'), 'utf-8');
+
+describe('mailförhandsvisningen är en ljus ö', () => {
+  it('dialogen renderar mail-HTML genom husets renderare — aldrig en egen div', () => {
+    expect(DIALOG).toContain('EmailTemplatePreview');
+    expect(DIALOG).not.toMatch(/dangerouslySetInnerHTML=\{\{ __html: comm\.body_html/);
+  });
+
+  it('renderaren är en isolerad ljus iframe — temat når aldrig mailet', () => {
+    expect(PREVIEW).toContain('srcDoc');
+    expect(PREVIEW).toContain('bg-white');
+  });
+});


### PR DESCRIPTION
Dark theme gjorde mail-HTML oläslig i Communications-modalen (inline `#333` mot mörk `bg-card`). Husets isolerade renderare fanns redan — `EmailTemplatePreview` (iframe srcDoc, bg-white) — dialogen adopterar den i stället för sin egen div. Adoptionsklassen, tredje gången denna vecka. Guardrail pinnar att dialogen aldrig div-renderar mail och att renderaren förblir isolerad ljus.