### PR TITLE
fix(blocks): ett kryss stänger

### DIFF
--- a/src/components/public/blocks/GalleryBlock.tsx
+++ b/src/components/public/blocks/GalleryBlock.tsx
@@ -97,7 +97,11 @@ export function GalleryBlock({ data }: GalleryBlockProps) {
 
         {/* Lightbox */}
         <Dialog open={lightboxIndex !== null} onOpenChange={closeLightbox}>
-          <DialogContent className="max-w-5xl p-0 bg-black/95 border-none">
+          {/* [&>button]:hidden gömmer DialogContents INBYGGDA kryss (sidebar-
+              prejudikatet): mot bg-black/95 är det temafärgade krysset nära
+              osynligt — därför finns blockets egna vita — och två kryss i
+              samma hörn var dubbelstängningen Magnus såg 2026-08-26. */}
+          <DialogContent className="max-w-5xl p-0 bg-black/95 border-none [&>button]:hidden">
             <div className="relative">
               <Button
                 variant="ghost"

--- a/src/lib/__tests__/one-cross-to-close.guardrails.test.ts
+++ b/src/lib/__tests__/one-cross-to-close.guardrails.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Ett kryss stänger.
+ *
+ * GalleryBlocks lightbox bar TVÅ stängningskryss i samma hörn: blockets egna
+ * vita (byggt för den mörka botten där shadcn-dialogens temafärgade kryss är
+ * nära osynligt) OCH DialogContents inbyggda. Fixen följer sidebar-
+ * prejudikatet: [&>button]:hidden på DialogContent när ytan bär ett eget,
+ * bättre lämpat kryss. Pinnen är en populationsvakt: varje publikt block som
+ * ritar eget X inuti en DialogContent MÅSTE gömma det inbyggda.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIR = join(__dirname, '../../components/public/blocks');
+
+describe('ett kryss stänger', () => {
+  it('eget X i en DialogContent ⇒ det inbyggda är gömt', () => {
+    const offenders: string[] = [];
+    for (const f of readdirSync(DIR).filter((x) => x.endsWith('.tsx'))) {
+      const src = readFileSync(join(DIR, f), 'utf-8');
+      if (!src.includes('DialogContent') || !/<X className/.test(src)) continue;
+      if (!src.includes('[&>button]:hidden')) offenders.push(f);
+    }
+    expect(offenders, `dubbelkryss: ${offenders.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Galleriets lightbox: blockets egna vita kryss (motiverat — dialogens inbyggda är nära osynligt mot `bg-black/95`) + DialogContents inbyggda = dubbelkryss. Sidebar-prejudikatet `[&>button]:hidden` tillämpat; populationsvakt pinnar klassen (eget X ⇒ inbyggt gömt). Enda förekomsten, svept.