### PR TITLE
fix(blocks): skannern hade en blind fläck — och vakten ärvde den

### DIFF
--- a/src/components/public/blocks/ChatBlock.tsx
+++ b/src/components/public/blocks/ChatBlock.tsx
@@ -47,7 +47,7 @@ export function ChatBlock({ data }: ChatBlockProps) {
   if (data.variant === 'card') {
     return (
       <section
-        className="py-12 px-4"
+       
         {...(hasTitle ? { 'aria-labelledby': headingId } : { 'aria-label': 'Chat' })}
       >
         <div className="container max-w-4xl mx-auto">
@@ -69,7 +69,7 @@ export function ChatBlock({ data }: ChatBlockProps) {
 
   return (
     <section
-      className="py-8"
+     
       {...(hasTitle ? { 'aria-labelledby': headingId } : { 'aria-label': 'Chat' })}
     >
       <div className="container max-w-4xl mx-auto">

--- a/src/components/public/blocks/TwoColumnBlock.tsx
+++ b/src/components/public/blocks/TwoColumnBlock.tsx
@@ -201,8 +201,13 @@ export function TwoColumnBlock({ data }: TwoColumnBlockProps) {
 
   // Image+Text layout (original)
   return (
-    <section 
-      className="px-6"
+    <section
+      /* px-6 här var dubbelskalet som ÖVERLEVDE #287-svepet: skannern läste
+         bara enradiga <section className="…"> och det här attributet bor på
+         egen rad. Uppmätt på /why (mobil): 16+24 = 40 px per sida mot
+         grannarnas 16. backgroundColor får panelbehandling (samma linje som
+         TextBlock) — målad yta bär radie + invändig padding, omålad bär inget. */
+      className={data.backgroundColor ? 'rounded-[var(--radius-block,1rem)] p-6 md:p-8' : undefined}
       style={{ backgroundColor: data.backgroundColor }}
     >
       <div className="container mx-auto max-w-6xl">

--- a/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
+++ b/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
@@ -33,12 +33,18 @@ const FULL_BLEED = new Set([
  * padding, struktur orörd), Contact omklassad till panel, CTA var redan panel. */
 const PANEL_SECTIONS = new Set(['CTABlock', 'ContactBlock']);
 
-const OWN_SHELL = /<section className="[^"]*\bp[xy]-/;
+// Multiline-medveten: #287-svepets skanner läste bara enradiga
+// <section className="…"> — TwoColumn (attribut på egen rad) och ChatBlock
+// slank igenom, upptäckta av Magnus på /why (mobil) 2026-08-26. Vakten
+// läser nu HELA öppningstaggen, radbrytningar inräknade.
+const SECTION_TAG = /<section\b[^>]*?>/gs;
+const ownShell = (src: string): boolean =>
+  [...src.matchAll(SECTION_TAG)].some((m) => /className="[^"]*\bp[xy]-/.test(m[0]));
 
 describe('renderaren äger skalet', () => {
   it('TextBlock bär inget eget sektionsskal — det rapporterade blocket är normaliserat', () => {
     const src = readFileSync(join(DIR, 'TextBlock.tsx'), 'utf-8');
-    expect(src).not.toMatch(OWN_SHELL);
+    expect(ownShell(src)).toBe(false);
     expect(src).not.toContain('container mx-auto');
   });
 
@@ -47,7 +53,7 @@ describe('renderaren äger skalet', () => {
     for (const f of readdirSync(DIR).filter((x) => x.endsWith('Block.tsx'))) {
       const name = f.replace('.tsx', '');
       if (FULL_BLEED.has(name) || PANEL_SECTIONS.has(name)) continue;
-      if (OWN_SHELL.test(readFileSync(join(DIR, f), 'utf-8'))) offenders.push(name);
+      if (ownShell(readFileSync(join(DIR, f), 'utf-8'))) offenders.push(name);
     }
     expect(offenders, `dubbelskal: ${offenders.join(', ')}`).toEqual([]);
   });


### PR DESCRIPTION
Magnus på /why: two-column 'lite indragen från båda hållen' på mobil. **Inte design** — dubbelskal som överlevde #287: svepets skanner läste bara enradiga `<section className>`, TwoColumns attribut bor på egen rad. Samma lucka: ChatBlock ×2. Och **guardrailen bar samma regex** — vakten var blind för sin egen klass.

TwoColumn px-6 fälld (backgroundColor → panelbehandling à la TextBlock), ChatBlock fälld, vakten multiline-medveten. Full svit grön.