### PR TITLE
Editor device preview: render mobile/tablet in a real-viewport iframe

### DIFF
--- a/src/components/admin/PreviewFrame.tsx
+++ b/src/components/admin/PreviewFrame.tsx
@@ -1,0 +1,102 @@
+import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { applyBrandingToDocument } from '@/providers/BrandingProvider';
+import type { BrandingSettings } from '@/hooks/useSiteSettings';
+
+interface PreviewFrameProps {
+  /** Real viewport width in CSS pixels (375 = mobile, 768 = tablet). */
+  width: number;
+  title: string;
+  branding?: BrandingSettings | null;
+  children: ReactNode;
+}
+
+/**
+ * Read-only device preview rendered inside a real <iframe>.
+ *
+ * Shrinking a container (max-w-[375px]) does NOT shrink the viewport, so
+ * Tailwind's md:/lg: media queries still match the desktop window and the
+ * "mobile" preview shows desktop layout in a narrow column. An iframe has its
+ * own viewport, so media queries evaluate against the device width for real.
+ *
+ * Mechanics:
+ * - The children are React-portaled into the frame's <body>; they stay in the
+ *   parent React tree, so all contexts (QueryClient, Router, Branding, i18n)
+ *   keep working across the document boundary.
+ * - Parent stylesheets (<style> from Vite dev, <link rel="stylesheet"> from
+ *   builds, loaded Google Font links) are cloned into the frame's <head>.
+ * - The parent's <html> class list (next-themes' `dark`) is mirrored and kept
+ *   in sync via a MutationObserver.
+ * - Branding CSS variables are applied to the FRAME's documentElement — the
+ *   admin parent deliberately resets them, so the frame brands itself.
+ * - The surface is read-only: link navigation and form submits are blocked so
+ *   a click can never navigate the frame away from the portal document.
+ */
+export function PreviewFrame({ width, title, branding, children }: PreviewFrameProps) {
+  const [frame, setFrame] = useState<HTMLIFrameElement | null>(null);
+  const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
+
+  const frameRef = useCallback((node: HTMLIFrameElement | null) => setFrame(node), []);
+
+  useEffect(() => {
+    if (!frame) return;
+    const doc = frame.contentDocument;
+    if (!doc) return;
+
+    // Rewrite the about:blank document synchronously — Firefox replaces the
+    // initial iframe document asynchronously, and writing our own gives every
+    // browser the same stable document to portal into.
+    doc.open();
+    doc.write('<!DOCTYPE html><html><head></head><body></body></html>');
+    doc.close();
+
+    document.head
+      .querySelectorAll('style, link[rel="stylesheet"]')
+      .forEach((node) => doc.head.appendChild(node.cloneNode(true)));
+
+    const syncRootClass = () => {
+      doc.documentElement.className = document.documentElement.className;
+    };
+    syncRootClass();
+    const themeObserver = new MutationObserver(syncRootClass);
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+
+    const blockNavigation = (e: Event) => {
+      const target = e.target instanceof Element ? e.target : null;
+      if (target?.closest('a[href]')) e.preventDefault();
+    };
+    const blockSubmit = (e: Event) => e.preventDefault();
+    doc.addEventListener('click', blockNavigation, true);
+    doc.addEventListener('submit', blockSubmit, true);
+
+    const mount = doc.createElement('div');
+    doc.body.appendChild(mount);
+    setMountNode(mount);
+
+    return () => {
+      themeObserver.disconnect();
+      doc.removeEventListener('click', blockNavigation, true);
+      doc.removeEventListener('submit', blockSubmit, true);
+      setMountNode(null);
+    };
+  }, [frame]);
+
+  useEffect(() => {
+    if (!frame?.contentDocument || !mountNode || !branding) return;
+    applyBrandingToDocument(branding, frame.contentDocument);
+  }, [frame, mountNode, branding]);
+
+  return (
+    <iframe
+      ref={frameRef}
+      title={title}
+      style={{ width }}
+      className="h-full max-w-full shrink-0 rounded-lg border border-border bg-background shadow-sm"
+    >
+      {mountNode && createPortal(children, mountNode)}
+    </iframe>
+  );
+}

--- a/src/components/public/PageBlocks.tsx
+++ b/src/components/public/PageBlocks.tsx
@@ -1,0 +1,58 @@
+import { BlockRenderer } from './BlockRenderer';
+import { ContentBlock, SectionBackground } from '@/types/cms';
+
+// Full-bleed blocks skip the container wrapper AND the auto-background
+// alternation; self-styled blocks participate in the alternation count but
+// paint their own surface, so no background is applied to them.
+const FULL_BLEED = new Set([
+  'hero', 'parallax-section', 'announcement-bar', 'map', 'marquee',
+  'header', 'footer', 'popup', 'notification-toast', 'floating-cta',
+  'chat-launcher', 'section-divider', 'featured-carousel',
+]);
+const SELF_STYLED = new Set([
+  'cta', 'newsletter', 'pricing', 'form', 'booking', 'smart-booking',
+  'comparison', 'bento-grid', 'social-proof', 'badge', 'separator',
+  'kb-search', 'kb-hub', 'kb-featured', 'kb-accordion',
+  'features', 'stats', 'testimonials', 'team', 'tabs', 'accordion',
+  'timeline', 'consultant-matcher', 'quick-links', 'two-column', 'logos',
+  'table', 'countdown', 'products', 'cart', 'webinar', 'article-grid',
+]);
+
+interface PageBlocksProps {
+  blocks: ContentBlock[];
+  pageId?: string;
+}
+
+/**
+ * Renders a page's block sequence with the auto-alternating section
+ * backgrounds the public site uses. Shared by PublicPage-style consumers
+ * (PreviewPage, the editor's device preview) so the alternation rules live
+ * in one place instead of being copy-pasted per surface.
+ */
+export function PageBlocks({ blocks, pageId }: PageBlocksProps) {
+  let contentIndex = 0;
+  return (
+    <>
+      {blocks.map((block, index) => {
+        const isFullBleed = FULL_BLEED.has(block.type);
+        const isSelfStyled = SELF_STYLED.has(block.type);
+        let resolvedBg: SectionBackground | undefined;
+        if (!isFullBleed && !block.sectionBackground) {
+          resolvedBg = isSelfStyled ? undefined : (contentIndex % 2 === 1 ? 'muted' : 'none');
+          contentIndex++;
+        } else if (!isFullBleed) {
+          contentIndex++;
+        }
+        return (
+          <BlockRenderer
+            key={block.id || index}
+            block={block}
+            pageId={pageId}
+            index={index}
+            resolvedBackground={resolvedBg}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/src/hooks/useScrollAnimation.ts
+++ b/src/hooks/useScrollAnimation.ts
@@ -28,14 +28,16 @@ export function useScrollAnimation<T extends HTMLElement = HTMLDivElement>(
     const element = ref.current;
     if (!element) return;
 
+    // Resolve globals from the element's OWN document/window: inside the page
+    // editor's device-preview iframe the relevant viewport (and the branding
+    // data attribute) belong to the frame, not the top window. In the normal
+    // case ownerDocument IS the top document, so this changes nothing.
+    const doc = element.ownerDocument;
+    const win = doc.defaultView ?? window;
+
     // Honor reduced motion + global off switch — render immediately.
-    const reduced =
-      typeof window !== 'undefined' &&
-      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
-    const mode =
-      typeof document !== 'undefined'
-        ? document.documentElement.dataset.scrollAnimations
-        : undefined;
+    const reduced = win.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    const mode = doc.documentElement.dataset.scrollAnimations;
 
     if (reduced || mode === 'off') {
       setIsVisible(true);
@@ -46,7 +48,7 @@ export function useScrollAnimation<T extends HTMLElement = HTMLDivElement>(
       rootMargin ??
       (mode === 'eager' ? '0px 0px 200px 0px' : '0px 0px -50px 0px');
 
-    const observer = new IntersectionObserver(
+    const observer = new win.IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
           setIsVisible(true);

--- a/src/lib/__tests__/device-preview-is-a-real-viewport.guardrails.test.ts
+++ b/src/lib/__tests__/device-preview-is-a-real-viewport.guardrails.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Mobil-/surfplatteförhandsvisningen är en RIKTIG viewport — inte en smal spalt.
+ *
+ * Före 2026-08-26 krympte sideditorns previewMode bara en container
+ * (max-w-[375px]). Tailwinds md:-brytpunkter svarar på VIEWPORT-bredd, så
+ * "mobilvyn" visade desktop-layout i smal spalt: TwoColumn sida-vid-sida i
+ * stället för staplad, features-grid i tre kolumner. Fixen: mobile/tablet
+ * renderas i en läs-läges-<iframe> med äkta viewportbredd 375/768 via den
+ * publika renderarens väg (PageBlocks → BlockRenderer), medan desktop förblir
+ * den redigerbara BlockEditor-ytan.
+ *
+ * Vakterna pinnar mekaniken som gör detta sant:
+ *  1. Editorn fejkar inte längre bredd med max-w-klasser utan monterar
+ *     PreviewFrame + PageBlocks för device-lägena.
+ *  2. PreviewFrame klonar förälderns stylesheets in i ramens <head> (annars
+ *     är iframen ostylad), applicerar branding på RAMENS documentElement
+ *     (admin-föräldern har variablerna avsiktligt återställda) och blockerar
+ *     länknavigering + formulärsubmit (läs-läge — inget klick får navigera
+ *     bort portal-dokumentet).
+ *  3. useScrollAnimation läser element.ownerDocument — annars observerar
+ *     reveal-on-scroll fel viewport och blocken fastnar i opacity-0 inne i
+ *     ramen.
+ *  4. Auto-bakgrundsslingan (FULL_BLEED/SELF_STYLED) bor i PageBlocks —
+ *     PreviewPage och TemplateLivePreviewPage får inte återfå egna kopior.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = join(__dirname, '../..');
+const read = (p: string) => readFileSync(join(SRC, p), 'utf-8');
+
+describe('device-förhandsvisningen är en riktig viewport', () => {
+  it('editorn monterar PreviewFrame + PageBlocks — ingen fejkad max-w-viewport', () => {
+    const editor = read('pages/admin/PageEditorPage.tsx');
+    expect(editor).not.toContain('max-w-[375px]');
+    expect(editor).not.toContain('max-w-[768px]');
+    expect(editor).toContain('PreviewFrame');
+    expect(editor).toContain('PageBlocks');
+    // 375/768 är devicebredder, inte containerbredder
+    expect(editor).toMatch(/previewMode === 'mobile' \? 375 : 768/);
+  });
+
+  it('PreviewFrame klonar stylesheets, brandar ramens dokument och är läs-läge', () => {
+    const frame = read('components/admin/PreviewFrame.tsx');
+    // stylesheets in i ramen — både Vite-dev <style> och byggda <link>
+    expect(frame).toContain(`querySelectorAll('style, link[rel="stylesheet"]')`);
+    // branding går på RAMENS documentElement, inte förälderns
+    expect(frame).toContain('applyBrandingToDocument(branding, frame.contentDocument)');
+    // läs-läge: klick på länkar och submits stoppas i capture-fas
+    expect(frame).toContain(`closest('a[href]')`);
+    expect(frame).toMatch(/addEventListener\('submit', .*true\)/);
+    // temat speglas och hålls i synk
+    expect(frame).toContain('MutationObserver');
+  });
+
+  it('useScrollAnimation observerar elementets EGEN viewport', () => {
+    const hook = read('hooks/useScrollAnimation.ts');
+    expect(hook).toContain('element.ownerDocument');
+    expect(hook).toContain('new win.IntersectionObserver');
+  });
+
+  it('auto-bakgrundsslingan bor i PageBlocks — inga nya kopior i preview-ytorna', () => {
+    expect(read('components/public/PageBlocks.tsx')).toContain('SELF_STYLED');
+    expect(read('pages/PreviewPage.tsx')).not.toContain('SELF_STYLED');
+    expect(read('pages/admin/TemplateLivePreviewPage.tsx')).not.toContain('SELF_STYLED');
+  });
+});

--- a/src/pages/PreviewPage.tsx
+++ b/src/pages/PreviewPage.tsx
@@ -1,7 +1,7 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { Loader2, ArrowLeft, Eye } from 'lucide-react';
-import { BlockRenderer } from '@/components/public/BlockRenderer';
+import { PageBlocks } from '@/components/public/PageBlocks';
 import { PublicNavigation } from '@/components/public/PublicNavigation';
 import { PublicFooter } from '@/components/public/PublicFooter';
 import { SeoHead } from '@/components/public/SeoHead';
@@ -132,30 +132,7 @@ export default function PreviewPage() {
           </div>
         )}
         
-        {(() => {
-          const FULL_BLEED = new Set(['hero', 'parallax-section', 'announcement-bar', 'map', 'marquee', 'header', 'footer', 'popup', 'notification-toast', 'floating-cta', 'chat-launcher', 'section-divider', 'featured-carousel']);
-          const SELF_STYLED = new Set([
-            'cta', 'newsletter', 'pricing', 'form', 'booking', 'smart-booking',
-            'comparison', 'bento-grid', 'social-proof', 'badge', 'separator',
-            'kb-search', 'kb-hub', 'kb-featured', 'kb-accordion',
-            'features', 'stats', 'testimonials', 'team', 'tabs', 'accordion',
-            'timeline', 'consultant-matcher', 'quick-links', 'two-column', 'logos',
-            'table', 'countdown', 'products', 'cart', 'webinar', 'article-grid',
-          ]);
-          let contentIndex = 0;
-          return (previewData.content_json || []).map((block, index) => {
-            const isFullBleed = FULL_BLEED.has(block.type);
-            const isSelfStyled = SELF_STYLED.has(block.type);
-            let resolvedBg: import('@/types/cms').SectionBackground | undefined;
-            if (!isFullBleed && !block.sectionBackground) {
-              resolvedBg = isSelfStyled ? undefined : (contentIndex % 2 === 1 ? 'muted' : 'none');
-              contentIndex++;
-            } else if (!isFullBleed) {
-              contentIndex++;
-            }
-            return <BlockRenderer key={block.id} block={block} pageId={previewData.id} index={index} resolvedBackground={resolvedBg} />;
-          });
-        })()}
+        <PageBlocks blocks={previewData.content_json || []} pageId={previewData.id} />
       </main>
 
       <PublicFooter />

--- a/src/pages/admin/PageEditorPage.tsx
+++ b/src/pages/admin/PageEditorPage.tsx
@@ -9,6 +9,10 @@ import { Input } from '@/components/ui/input';
 import { StatusBadge } from '@/components/StatusBadge';
 import { VersionHistoryPanel } from '@/components/admin/VersionHistoryPanel';
 import { BlockEditor } from '@/components/admin/blocks/BlockEditor';
+import { PreviewFrame } from '@/components/admin/PreviewFrame';
+import { PageBlocks } from '@/components/public/PageBlocks';
+import { useBranding } from '@/providers/BrandingProvider';
+import { useDebounce } from '@/hooks/useDebounce';
 import { PageSettingsDialog } from '@/components/admin/PageSettingsDialog';
 import { SchedulePublishDialog } from '@/components/admin/SchedulePublishDialog';
 import { AeoAnalyzer } from '@/components/admin/AeoAnalyzer';
@@ -32,6 +36,7 @@ export default function PageEditorPage() {
   const { toast } = useToast();
   const { isApprover } = useAuth();
   const { data: generalSettings } = useGeneralSettings();
+  const { branding } = useBranding();
   const reviewEnabled = generalSettings?.contentReviewEnabled === true;
   
   const { data: page, isLoading, refetch } = usePage(id);
@@ -43,6 +48,7 @@ export default function PageEditorPage() {
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [previewMode, setPreviewMode] = useState<PreviewMode>('desktop');
+  const isDevicePreview = previewMode !== 'desktop';
   // Undo/Redo for blocks
   const {
     present: blocks,
@@ -56,6 +62,11 @@ export default function PageEditorPage() {
 
   // Keyboard shortcuts for undo/redo
   useUndoRedoKeyboard({ undo, redo, canUndo, canRedo });
+
+  // The device preview re-renders the full public renderer on every blocks
+  // change (e.g. undo/redo while a preview is open) — debounce so bursts
+  // collapse into one iframe re-render.
+  const previewBlocks = useDebounce(blocks, 300);
 
   const { blocker } = useUnsavedChanges({ hasChanges });
 
@@ -305,28 +316,49 @@ export default function PageEditorPage() {
           </div>
         </div>
 
-        {/* Block Editor - scrollable area */}
-        <div
-          className="flex-1 min-h-0 overflow-auto p-8 bg-background"
-          onPointerDownCapture={armDirtyTracking}
-          onKeyDownCapture={armDirtyTracking}
-        >
-          <div 
-            className={`mx-auto pb-4 transition-all duration-300 ${
-              previewMode === 'mobile' 
-                ? 'max-w-[375px] border-x border-dashed border-border' 
-                : previewMode === 'tablet' 
-                  ? 'max-w-[768px] border-x border-dashed border-border' 
-                  : 'max-w-3xl'
-            }`}
-          >
-            <BlockEditor
-              blocks={blocks}
-              onChange={handleBlocksChange}
-              canEdit={canEdit}
-            />
+        {/* Editing surface (desktop) / device preview (mobile & tablet).
+            A narrowed container can't change which md:/lg: media queries
+            match, so mobile/tablet render the PUBLIC renderer inside a real
+            iframe whose viewport IS 375/768 px. Editing stays a desktop-mode
+            activity — the frame is read-only. */}
+        {isDevicePreview ? (
+          <div className="flex-1 min-h-0 p-8 bg-muted/40 flex justify-center">
+            <PreviewFrame
+              width={previewMode === 'mobile' ? 375 : 768}
+              title={`${previewMode === 'mobile' ? 'Mobile' : 'Tablet'} preview`}
+              branding={branding}
+            >
+              <main className="min-h-screen bg-background">
+                {meta?.showTitle !== false && (
+                  <div className="max-w-4xl mx-auto px-6 pt-12">
+                    <h1
+                      className={`text-4xl md:text-5xl font-serif font-bold text-foreground ${
+                        (meta?.titleAlignment || 'left') === 'center' ? 'text-center' : 'text-left'
+                      }`}
+                    >
+                      {title}
+                    </h1>
+                  </div>
+                )}
+                <PageBlocks blocks={previewBlocks} pageId={id} />
+              </main>
+            </PreviewFrame>
           </div>
-        </div>
+        ) : (
+          <div
+            className="flex-1 min-h-0 overflow-auto p-8 bg-background"
+            onPointerDownCapture={armDirtyTracking}
+            onKeyDownCapture={armDirtyTracking}
+          >
+            <div className="mx-auto pb-4 max-w-3xl">
+              <BlockEditor
+                blocks={blocks}
+                onChange={handleBlocksChange}
+                canEdit={canEdit}
+              />
+            </div>
+          </div>
+        )}
 
         {/* Sticky Save Bar */}
         <div className="sticky-save-bar">

--- a/src/pages/admin/TemplateLivePreviewPage.tsx
+++ b/src/pages/admin/TemplateLivePreviewPage.tsx
@@ -1,8 +1,8 @@
 import { useSearchParams } from 'react-router-dom';
 import { ALL_TEMPLATES } from '@/data/templates';
-import { BlockRenderer } from '@/components/public/BlockRenderer';
+import { PageBlocks } from '@/components/public/PageBlocks';
 import { TemplateBrandingProvider } from '@/components/admin/templates/TemplateBrandingProvider';
-import { ContentBlock, SectionBackground } from '@/types/cms';
+import { ContentBlock } from '@/types/cms';
 import { cn } from '@/lib/utils';
 
 export default function TemplateLivePreviewPage() {
@@ -26,31 +26,7 @@ export default function TemplateLivePreviewPage() {
           color: isDark ? 'hsl(0 0% 100%)' : 'hsl(222 47% 11%)',
         }}
       >
-        {(() => {
-          const FULL_BLEED = new Set(['hero', 'parallax-section', 'announcement-bar', 'map', 'marquee', 'header', 'footer', 'popup', 'notification-toast', 'floating-cta', 'chat-launcher', 'section-divider', 'featured-carousel']);
-          const SELF_STYLED = new Set([
-            'cta', 'newsletter', 'pricing', 'form', 'booking', 'smart-booking',
-            'comparison', 'bento-grid', 'social-proof', 'badge', 'separator',
-            'kb-search', 'kb-hub', 'kb-featured', 'kb-accordion',
-            'features', 'stats', 'testimonials', 'team', 'tabs', 'accordion',
-            'timeline', 'consultant-matcher', 'quick-links', 'two-column', 'logos',
-            'table', 'countdown', 'products', 'cart', 'webinar', 'article-grid',
-          ]);
-          let contentIndex = 0;
-          return page?.blocks?.map((block, index) => {
-            const b = block as ContentBlock;
-            const isFullBleed = FULL_BLEED.has(b.type);
-            const isSelfStyled = SELF_STYLED.has(b.type);
-            let resolvedBg: import('@/types/cms').SectionBackground | undefined;
-            if (!isFullBleed && !b.sectionBackground) {
-              resolvedBg = isSelfStyled ? undefined : (contentIndex % 2 === 1 ? 'muted' : 'none');
-              contentIndex++;
-            } else if (!isFullBleed) {
-              contentIndex++;
-            }
-            return <BlockRenderer key={b.id || index} block={b} index={index} resolvedBackground={resolvedBg} />;
-          });
-        })()}
+        <PageBlocks blocks={(page?.blocks || []) as ContentBlock[]} />
         {(!page?.blocks || page.blocks.length === 0) && (
           <div className="flex items-center justify-center h-screen text-muted-foreground">
             No blocks on this page

--- a/src/providers/BrandingProvider.tsx
+++ b/src/providers/BrandingProvider.tsx
@@ -43,22 +43,25 @@ const GOOGLE_FONTS_MAP: Record<string, string> = {
   'Plus Jakarta Sans': 'Plus+Jakarta+Sans:wght@400;500;600;700',
 };
 
-function loadGoogleFont(fontName: string) {
+function loadGoogleFont(fontName: string, doc: Document = document) {
   const fontParam = GOOGLE_FONTS_MAP[fontName];
   if (!fontParam) return;
-  
-  const existingLink = document.querySelector(`link[data-font="${fontName}"]`);
+
+  const existingLink = doc.querySelector(`link[data-font="${fontName}"]`);
   if (existingLink) return;
-  
-  const link = document.createElement('link');
+
+  const link = doc.createElement('link');
   link.rel = 'stylesheet';
   link.href = `https://fonts.googleapis.com/css2?family=${fontParam}&display=swap`;
   link.setAttribute('data-font', fontName);
-  document.head.appendChild(link);
+  doc.head.appendChild(link);
 }
 
-function applyBrandingToDocument(branding: BrandingSettings) {
-  const root = document.documentElement;
+// Exported so preview surfaces that render into their own document (the page
+// editor's device-preview iframe) can brand that document's root — the admin
+// parent has these variables deliberately reset.
+export function applyBrandingToDocument(branding: BrandingSettings, doc: Document = document) {
+  const root = doc.documentElement;
   
   // Apply colors
   if (branding.primaryColor) {
@@ -81,11 +84,11 @@ function applyBrandingToDocument(branding: BrandingSettings) {
   
   // Apply fonts
   if (branding.headingFont) {
-    loadGoogleFont(branding.headingFont);
+    loadGoogleFont(branding.headingFont, doc);
     root.style.setProperty('--font-serif', `'${branding.headingFont}', Georgia, serif`);
   }
   if (branding.bodyFont) {
-    loadGoogleFont(branding.bodyFont);
+    loadGoogleFont(branding.bodyFont, doc);
     root.style.setProperty('--font-sans', `'${branding.bodyFont}', system-ui, sans-serif`);
   }
   
@@ -121,16 +124,17 @@ function applyBrandingToDocument(branding: BrandingSettings) {
   const scrollMode = branding.scrollAnimations || 'on';
   root.dataset.scrollAnimations = scrollMode;
 
-  // Apply favicon
-  if (branding.favicon) {
-    const existingFavicon = document.querySelector('link[rel="icon"]');
+  // Apply favicon — only meaningful on the top-level document; a preview
+  // iframe has no tab of its own.
+  if (branding.favicon && doc === document) {
+    const existingFavicon = doc.querySelector('link[rel="icon"]');
     if (existingFavicon) {
       existingFavicon.setAttribute('href', branding.favicon);
     } else {
-      const favicon = document.createElement('link');
+      const favicon = doc.createElement('link');
       favicon.rel = 'icon';
       favicon.href = branding.favicon;
-      document.head.appendChild(favicon);
+      doc.head.appendChild(favicon);
     }
   }
 }


### PR DESCRIPTION
## Problem

The page editor's mobile/tablet preview modes only narrowed a container (`max-w-[375px]`), but Tailwind's `md:`/`lg:` breakpoints respond to **viewport** width — so the "mobile" view showed desktop layout squeezed into a narrow column: TwoColumn stayed side-by-side instead of stacking, the features grid stayed multi-column, and every `md:` layout lied.

## Change

When `previewMode` is mobile/tablet, the editor now renders the page through the **public renderer path** (`PageBlocks` → `BlockRenderer` over the current, debounced blocks state — not the saved version) inside a **read-only `<iframe>` with a genuine 375/768 px viewport**. Desktop remains the editable `BlockEditor` surface. No editing/DnD crosses the frame boundary.

- **`PreviewFrame`** (new, `src/components/admin/PreviewFrame.tsx`): React-portals children into the frame's `<body>` (contexts — QueryClient, Router, Branding — keep working since the children stay in the parent React tree). Clones the parent's stylesheets (Vite dev `<style>` + built `<link rel="stylesheet">`) into the frame's `<head>`, mirrors the theme class (`dark`) with a MutationObserver, applies branding CSS variables to the **frame's** `documentElement` (the admin parent deliberately resets them), and blocks link navigation + form submits in capture phase.
- **`BrandingProvider`**: `applyBrandingToDocument` / `loadGoogleFont` now take a target `Document` (default: top document) and `applyBrandingToDocument` is exported; favicon writes stay top-document-only.
- **`useScrollAnimation`**: resolves `document`/`window`/`IntersectionObserver` from `element.ownerDocument`, so reveal-on-scroll observes the frame's own viewport instead of leaving blocks stuck at `opacity-0`. No-op in the normal case (ownerDocument *is* the top document).
- **`PageBlocks`** (new, `src/components/public/PageBlocks.tsx`): the FULL_BLEED/SELF_STYLED auto-background alternation loop extracted from its copy-pasted twins — `PreviewPage` and `TemplateLivePreviewPage` now use it, and the editor preview is not a fourth copy. (`PublicPage` keeps its variant with per-block try/catch.)
- **Guardrail test** (`device-preview-is-a-real-viewport.guardrails.test.ts`) pins the mechanics: real device widths (no fake `max-w` viewport), stylesheet cloning, frame-side branding, the read-only surface, ownerDocument-based scroll animation, and the single background loop.

## Verification

- `TwoColumnBlock` columns come from `md:grid-cols-*` (min-width 768 px) ⇒ single column / stacked in the 375 px frame; `FeaturesBlock` is base 1 column with `sm:`/`lg:` steps ⇒ single column at 375 px.
- `npx tsc -p tsconfig.app.json` — clean.
- `npx vitest run` — 254 files / 3336 tests passed (2 files skipped: live-DB probes).
- `eslint` on touched files — 0 errors (only pre-existing warning classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKjXidfkisgNTZG1AGPgN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKjXidfkisgNTZG1AGPgN9)_