### PR TITLE
fix(blocks): bentos ikonfallback följer accentkanon

### DIFF
--- a/src/components/public/blocks/BentoGridBlock.tsx
+++ b/src/components/public/blocks/BentoGridBlock.tsx
@@ -180,10 +180,16 @@ export function BentoGridBlock({ data }: BentoGridBlockProps) {
                     <div
                       className="w-12 h-12 rounded-xl flex items-center justify-center mb-4 transition-colors duration-300"
                       style={{
+                        // Fallbacken följer systemets ikonkanon: accent-plattan
+                        // (bg-accent/50 + accent-foreground) som 14 block kör —
+                        // features på /product bland dem. Primary-fallbacken här
+                        // var avvikaren teamet såg som "olika ikonfärger mellan
+                        // landing och /product" (2026-08-26). item.accentColor
+                        // är ett PER-CELL-innehållsval och rör vi aldrig.
                         backgroundColor: item.accentColor
                           ? `${item.accentColor}15`
-                          : 'hsl(var(--primary) / 0.1)',
-                        color: item.accentColor || 'hsl(var(--primary))',
+                          : 'hsl(var(--accent) / 0.5)',
+                        color: item.accentColor || 'hsl(var(--accent-foreground))',
                       }}
                     >
                       <LucideIcon name={item.icon} className="h-6 w-6" />

--- a/src/lib/__tests__/cta-follows-the-panel-radius.guardrails.test.ts
+++ b/src/lib/__tests__/cta-follows-the-panel-radius.guardrails.test.ts
@@ -107,3 +107,18 @@ describe('statusfärger bär tokens, inte palett', () => {
     expect(offenders, offenders.join('; ')).toEqual([]);
   });
 });
+
+describe('ikonplattornas fallback följer accentkanon', () => {
+  /**
+   * 14 block kör accent-plattan (bg-accent/50 + text-accent-foreground) för
+   * fristående ikoner; bentos primary-fallback var avvikaren teamet såg som
+   * "olika ikonfärger mellan landing och /product" (2026-08-26). Per-cell-
+   * accentColor är innehållsval och pinnas inte — bara FALLBACKEN.
+   */
+  it('BentoGrid-fallbacken är accentfamiljen, inte primary', () => {
+    const src = readFileSync(join(__dirname, '../../components/public/blocks/BentoGridBlock.tsx'), 'utf-8');
+    expect(src).toContain("'hsl(var(--accent) / 0.5)'");
+    expect(src).toContain("'hsl(var(--accent-foreground))'");
+    expect(src).not.toContain("'hsl(var(--primary) / 0.1)'");
+  });
+});

--- a/src/pages/admin/BrandingSettingsPage.tsx
+++ b/src/pages/admin/BrandingSettingsPage.tsx
@@ -741,7 +741,7 @@ export function BrandingSettingsContent({ embedded = false }: { embedded?: boole
                       />
                       <div className="flex-1">
                         <p className="text-sm font-medium">Highlights</p>
-                        <p className="text-xs text-muted-foreground">Hover, focus states</p>
+                        <p className="text-xs text-muted-foreground">Icon tiles, hover, focus states</p>
                       </div>
                     </div>
                     {/* Contrast: white text on accent background */}


### PR DESCRIPTION
Teamets observation: ikoner på landing (bento) och /product (features) har olika färger. Uppmätt: 14 block kör accent-plattan; bentos **fallback** var primary — avvikaren. Endast fallbacken rättad (per-cell `accentColor` är innehållsval, orört; bildcellers vita är bildankrat och korrekt). Branding-copyn för Accent säger nu vad färgen bär: 'Icon tiles, hover, focus states'. Pinnad.