### PR TITLE
feat(branding): primären är per-tema med luminans-härledd text

### DIFF
--- a/src/components/admin/PreviewFrame.tsx
+++ b/src/components/admin/PreviewFrame.tsx
@@ -56,6 +56,9 @@ export function PreviewFrame({ width, title, branding, children }: PreviewFrameP
 
     const syncRootClass = () => {
       doc.documentElement.className = document.documentElement.className;
+      // Per-tema-primären läses ur dokumentklassen — när temat flippar måste
+      // ramen brandas om, inte bara byta klass.
+      if (branding) applyBrandingToDocument(branding, doc);
     };
     syncRootClass();
     const themeObserver = new MutationObserver(syncRootClass);

--- a/src/hooks/useSiteSettings.tsx
+++ b/src/hooks/useSiteSettings.tsx
@@ -85,6 +85,17 @@ export interface BrandingSettings {
   
   // Colors (HSL format)
   primaryColor?: string;
+  /**
+   * Optional dark-theme override for primary. The design system was born with
+   * TWO primaries (index.css: deep 220 100% 26% light / lifted 210 60% 60%
+   * dark) but branding used to flatten both to one value — the unsatisfiable
+   * contrast loop Magnus hit when locking optic to dark (2026-08-26): links on
+   * dark want a light primary, which then fails as a surface under the theme's
+   * near-black foreground. Unset = primaryColor is used in both themes, with
+   * the foreground auto-derived per theme (see applyBrandingToDocument).
+   * Naming follows the logoDark convention.
+   */
+  primaryColorDark?: string;
   secondaryColor?: string;
   accentColor?: string;
   

--- a/src/lib/__tests__/primary-per-theme-derived-fg.guardrails.test.ts
+++ b/src/lib/__tests__/primary-per-theme-derived-fg.guardrails.test.ts
@@ -1,0 +1,47 @@
+/**
+ * En token, många kontrastpartners — löst med två värden och en regel.
+ *
+ * Systemet föddes med TVÅ primärer (index.css: djup ljus-tema, lyft mörk-tema)
+ * men BrandingProvider plattade till båda med ETT inline-värde och rörde
+ * aldrig --primary-foreground. Magnus olösliga loop vid dark-låset på optic:
+ * länk-på-mörkt vill ha ljus primär, som då failar som yta under temats
+ * nära-svarta text. (1) primaryColorDark (logoDark-konventionen) + (2)
+ * luminans-härledd foreground — mönstret som SECONDARY haft sedan födseln
+ * och primary aldrig fick (adoptionsklassen, femte fyndet).
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PROVIDER = readFileSync(join(__dirname, '../../providers/BrandingProvider.tsx'), 'utf-8');
+const FRAME = readFileSync(join(__dirname, '../../components/admin/PreviewFrame.tsx'), 'utf-8');
+const TYPES = readFileSync(join(__dirname, '../../hooks/useSiteSettings.tsx'), 'utf-8');
+
+describe('primären är per-tema med härledd text', () => {
+  it('dokumentet bär temat — per-tema-värdet läses ur dess klass, aldrig ur modulstate', () => {
+    expect(PROVIDER).toMatch(/isDark = root\.classList\.contains\('dark'\)/);
+    expect(PROVIDER).toMatch(/isDark && branding\.primaryColorDark\) \|\| branding\.primaryColor/);
+  });
+
+  it('primärens foreground HÄRLEDS — svart-på-mörkblå kan inte längre författas', () => {
+    expect(PROVIDER).toMatch(/setProperty\('--primary-foreground', contrastForeground\(effectivePrimary\)\)/);
+  });
+
+  it('en härledningsregel, två brukare — secondary behåller exakt sin födelseregel (tröskel 40)', () => {
+    expect(PROVIDER).toMatch(/lightness < 40 \? '0 0% 98%' : '0 0% 9%'/);
+    expect(PROVIDER).toMatch(/contrastForeground\(branding\.secondaryColor\)/);
+  });
+
+  it('temaflipp brandar OM — providern reagerar på resolvedTheme, ramen i sin klass-synk', () => {
+    expect(PROVIDER).toMatch(/\[branding[^\]]*resolvedTheme\]/);
+    expect(FRAME).toMatch(/syncRootClass[\s\S]{0,300}applyBrandingToDocument\(branding, doc\)/);
+  });
+
+  it('admin-nollställningen släpper den härledda foregrounden', () => {
+    expect(PROVIDER).toMatch(/removeProperty\('--primary-foreground'\)/);
+  });
+
+  it('typen följer logoDark-konventionen', () => {
+    expect(TYPES).toContain('primaryColorDark?: string');
+  });
+});

--- a/src/pages/admin/BrandingSettingsPage.tsx
+++ b/src/pages/admin/BrandingSettingsPage.tsx
@@ -706,9 +706,38 @@ export function BrandingSettingsContent({ embedded = false }: { embedded?: boole
                         <p className="text-xs text-muted-foreground">Buttons, links, footer</p>
                       </div>
                     </div>
-                    {/* Contrast: white text on primary background */}
-                    <div className="text-xs text-muted-foreground">vs white text</div>
-                    <ContrastBadge ratio={getContrastRatio(settings.primaryColor || '220 100% 26%', '0 0% 100%')} />
+                    {/* Kontrasten mäts mot den text primären FAKTISKT får:
+                        foregrounden härleds numera ur färgens ljushet (ljus
+                        primär → mörk text, mörk → ljus). En badge mot alltid-
+                        vitt dömde ljusa primärer fel. */}
+                    <div className="text-xs text-muted-foreground">vs auto text</div>
+                    <ContrastBadge ratio={getContrastRatio(
+                      settings.primaryColor || '220 100% 26%',
+                      parseFloat((settings.primaryColor || '220 100% 26%').split(/\s+/)[2] || '50') < 40 ? '0 0% 98%' : '0 0% 9%'
+                    )} />
+
+                    <div className="pt-2 space-y-2 border-t">
+                      <Label className="text-xs">Primary — dark theme (optional)</Label>
+                      <div className="flex items-center gap-3">
+                        <input
+                          type="color"
+                          value={hslToHex(settings.primaryColorDark || settings.primaryColor || '210 60% 60%')}
+                          onChange={(e) => updateField('primaryColorDark', hexToHsl(e.target.value))}
+                          className="h-9 w-9 rounded-lg border cursor-pointer"
+                        />
+                        <p className="text-xs text-muted-foreground flex-1">
+                          Used when the site renders dark. A deep brand blue that
+                          works in light theme often needs a lifted variant here —
+                          text color adapts automatically to whichever is active.
+                        </p>
+                      </div>
+                      {settings.primaryColorDark && (
+                        <ContrastBadge ratio={getContrastRatio(
+                          settings.primaryColorDark,
+                          parseFloat(settings.primaryColorDark.split(/\s+/)[2] || '50') < 40 ? '0 0% 98%' : '0 0% 9%'
+                        )} />
+                      )}
+                    </div>
                   </div>
                   
                   <div className="space-y-3">

--- a/src/providers/BrandingProvider.tsx
+++ b/src/providers/BrandingProvider.tsx
@@ -63,20 +63,29 @@ function loadGoogleFont(fontName: string, doc: Document = document) {
 export function applyBrandingToDocument(branding: BrandingSettings, doc: Document = document) {
   const root = doc.documentElement;
   
+  // The document CARRIES its theme (next-themes stamps `dark` on <html>, and
+  // PreviewFrame mirrors it into its own root) — so per-theme brand values
+  // resolve from the doc we are painting, never from module state. Same rule
+  // as useScrollAnimation's ownerDocument resolution.
+  const isDark = root.classList.contains('dark');
+
+  // House pattern promoted from secondary (it had this since birth; primary
+  // never got it — the adoption class again): a brand surface derives its own
+  // text color from its lightness, so black-on-dark-blue cannot be authored.
+  const contrastForeground = (hsl: string): string => {
+    const lightness = parseFloat(hsl.split(/\s+/)[2] || '50');
+    return lightness < 40 ? '0 0% 98%' : '0 0% 9%';
+  };
+
   // Apply colors
-  if (branding.primaryColor) {
-    root.style.setProperty('--primary', branding.primaryColor);
+  const effectivePrimary = (isDark && branding.primaryColorDark) || branding.primaryColor;
+  if (effectivePrimary) {
+    root.style.setProperty('--primary', effectivePrimary);
+    root.style.setProperty('--primary-foreground', contrastForeground(effectivePrimary));
   }
   if (branding.secondaryColor) {
     root.style.setProperty('--secondary', branding.secondaryColor);
-    // Auto-derive contrasting foreground for secondary
-    const parts = branding.secondaryColor.split(/\s+/);
-    const lightness = parseFloat(parts[2] || '50');
-    if (lightness < 40) {
-      root.style.setProperty('--secondary-foreground', '0 0% 98%');
-    } else {
-      root.style.setProperty('--secondary-foreground', '0 0% 9%');
-    }
+    root.style.setProperty('--secondary-foreground', contrastForeground(branding.secondaryColor));
   }
   if (branding.accentColor) {
     root.style.setProperty('--accent', branding.accentColor);
@@ -152,6 +161,7 @@ function resetBrandingToDefaults() {
   root.style.removeProperty('--accent');
   root.style.removeProperty('--font-serif');
   root.style.removeProperty('--font-sans');
+  root.style.removeProperty('--primary-foreground');
   root.style.removeProperty('--radius');
   root.style.removeProperty('--radius-block');
 }
@@ -161,7 +171,7 @@ interface BrandingProviderProps {
 }
 
 export function BrandingProvider({ children }: BrandingProviderProps) {
-  const { setTheme } = useTheme();
+  const { setTheme, resolvedTheme } = useTheme();
   const [pathname, setPathname] = useState(window.location.pathname);
   const themeSetRef = useRef(false);
   
@@ -211,6 +221,8 @@ export function BrandingProvider({ children }: BrandingProviderProps) {
 
   useEffect(() => {
     if (branding && !isAdminRoute) {
+      // resolvedTheme i deps: per-tema-primären måste appliceras OM när temat
+      // flippar — dokumentklassen är sanningen appliceringen läser.
       applyBrandingToDocument(branding);
       themeSetRef.current = false;
       
@@ -244,7 +256,7 @@ export function BrandingProvider({ children }: BrandingProviderProps) {
       resetBrandingToDefaults();
       themeSetRef.current = true;
     }
-  }, [branding, setTheme, isAdminRoute]);
+  }, [branding, setTheme, isAdminRoute, resolvedTheme]);
 
   return (
     <BrandingContext.Provider value={{ branding: branding || null, isLoading }}>


### PR DESCRIPTION
Beslut Magnus (1+2), produktionsmotiverat av optic-lanseringen.

**Roten:** systemet föddes med två primärer; providern plattade till båda och rörde aldrig foregrounden → den olösliga kontrastloopen vid dark-lås.

**(1)** `primaryColorDark` (logoDark-konventionen) med UI-väljare · **(2)** luminans-härledd foreground — mönstret secondary haft sedan födseln (adoptionsklassen, femte fyndet). Dokumentklassen är sanningen (fungerar i PreviewFrame gratis); temaflipp re-brandar; ärlig kontrastbadge (mot auto-text, inte alltid-vitt); reset städat. 6 guardrail-pinnar · full svit grön.