### PR TITLE
fix(header): transparent är ett överlägg

### DIFF
--- a/src/components/admin/blocks/HeaderBlockEditor.tsx
+++ b/src/components/admin/blocks/HeaderBlockEditor.tsx
@@ -533,7 +533,7 @@ export function HeaderBlockEditor({ data, onChange }: HeaderBlockEditorProps) {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="solid">Solid background</SelectItem>
-                  <SelectItem value="transparent">Transparent</SelectItem>
+                  <SelectItem value="transparent">Transparent (overlays the hero)</SelectItem>
                   <SelectItem value="blur">Blur (glass effect)</SelectItem>
                 </SelectContent>
               </Select>

--- a/src/components/public/PublicNavigation.tsx
+++ b/src/components/public/PublicNavigation.tsx
@@ -101,13 +101,24 @@ export function PublicNavigation() {
       lg: 'shadow-lg',
     };
     
+    // Transparent är ett ÖVERLÄGG, inte en färg. bg-transparent i normalt
+    // dokumentflöde tar bara bort färgen men behåller PLATSEN — headern blev
+    // ett sidbakgrundsfärgat band OVANFÖR heron i stället för att sväva över
+    // den (uppmätt på optic 2026-08-26; redigeraren lovar 'Minimalist
+    // transparent header'). Kontraktet nu: transparent = absolut positionerad
+    // över innehållet — heron fortsätter upp bakom den — och scrollar bort
+    // med sidan (parad med en hero, som mönstret alltid används). Vill man ha
+    // följ-med-vid-scroll är det blur/solid + sticky som är valet.
+    const isOverlay = style === 'transparent';
     const baseClasses = cn(
       "z-50",
-      headerSettings.stickyHeader !== false && "sticky top-0",
+      isOverlay
+        ? "absolute top-0 left-0 right-0"
+        : headerSettings.stickyHeader !== false && "sticky top-0",
       showBorder && "border-b",
       shadowClasses[shadow]
     );
-    
+
     switch (style) {
       case 'transparent':
         return cn(baseClasses, "bg-transparent");

--- a/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
+++ b/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
@@ -73,3 +73,18 @@ describe('renderaren äger skalet', () => {
     }
   });
 });
+
+describe('transparent header är ett överlägg', () => {
+  /**
+   * bg-transparent i dokumentflödet tar bort färgen men inte PLATSEN —
+   * headern blev ett band ovanför heron (optic 2026-08-26). Kontraktet:
+   * transparent = absolut över innehållet, scrollar bort med sidan;
+   * följ-med-vid-scroll är blur/solid + sticky.
+   */
+  it('transparent positionerar absolut och ärver aldrig sticky-flödet', () => {
+    const src = readFileSync(
+      join(__dirname, '../../components/public/PublicNavigation.tsx'), 'utf-8');
+    expect(src).toMatch(/isOverlay\s*=\s*style === 'transparent'/);
+    expect(src).toMatch(/isOverlay[\s\S]{0,80}absolute top-0 left-0 right-0/);
+  });
+});


### PR DESCRIPTION
Optic: 'transparent renderar inte som den skall'. Uppmätt: `bg-transparent` i dokumentflödet tar bort färgen men inte platsen — ett sidbakgrundsband ovanför heron, medan redigeraren lovar 'Minimalist transparent header'. Kontraktet nu: **transparent = absolut överlägg** (heron fortsätter upp bakom), scrollar bort med sidan; följ-med är blur/solid+sticky. Copy uppdaterad ('overlays the hero'), pinnat.