### PR TITLE
fix(header): sticky-ratten ignoreras aldrig

### DIFF
--- a/src/components/public/PublicNavigation.tsx
+++ b/src/components/public/PublicNavigation.tsx
@@ -109,11 +109,18 @@ export function PublicNavigation() {
     // över innehållet — heron fortsätter upp bakom den — och scrollar bort
     // med sidan (parad med en hero, som mönstret alltid används). Vill man ha
     // följ-med-vid-scroll är det blur/solid + sticky som är valet.
+    // Båda rattarna talar sanning: transparent är alltid ett ÖVERLÄGG (heron
+    // fortsätter upp bakom), och sticky-ratten avgör om överlägget FÖLJER MED
+    // (fixed) eller scrollar bort (absolute). Preset-matrisen valde detta
+    // långt före oss: clean = transparent + sticky:false, sticky-varianten =
+    // blur + sticky:true. En manuell kombination transparent+sticky är
+    // författarens uttryckliga val av två rattar — den ignoreras inte tyst.
     const isOverlay = style === 'transparent';
+    const overlayFollows = headerSettings.stickyHeader !== false;
     const baseClasses = cn(
       "z-50",
       isOverlay
-        ? "absolute top-0 left-0 right-0"
+        ? (overlayFollows ? "fixed top-0 left-0 right-0" : "absolute top-0 left-0 right-0")
         : headerSettings.stickyHeader !== false && "sticky top-0",
       showBorder && "border-b",
       shadowClasses[shadow]

--- a/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
+++ b/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
@@ -81,10 +81,21 @@ describe('transparent header är ett överlägg', () => {
    * transparent = absolut över innehållet, scrollar bort med sidan;
    * följ-med-vid-scroll är blur/solid + sticky.
    */
-  it('transparent positionerar absolut och ärver aldrig sticky-flödet', () => {
+  it('transparent är alltid överlägg — och sticky-ratten väljer fixed/absolute, aldrig ignorerad', () => {
     const src = readFileSync(
       join(__dirname, '../../components/public/PublicNavigation.tsx'), 'utf-8');
     expect(src).toMatch(/isOverlay\s*=\s*style === 'transparent'/);
-    expect(src).toMatch(/isOverlay[\s\S]{0,80}absolute top-0 left-0 right-0/);
+    expect(src).toMatch(/overlayFollows \? "fixed top-0 left-0 right-0" : "absolute top-0 left-0 right-0"/);
+  });
+
+  it('preset-matrisen förblir koherent: clean=transparent+ej sticky, sticky=blur+sticky', () => {
+    const presets = readFileSync(
+      join(__dirname, '../../hooks/useGlobalBlocks.ts'), 'utf-8');
+    const clean = presets.match(/clean: \{[\s\S]*?\}/)?.[0] ?? '';
+    const sticky = presets.match(/sticky: \{[\s\S]*?\}/)?.[0] ?? '';
+    expect(clean).toContain('stickyHeader: false');
+    expect(clean).toContain("backgroundStyle: 'transparent'");
+    expect(sticky).toContain('stickyHeader: true');
+    expect(sticky).toContain("backgroundStyle: 'blur'");
   });
 });


### PR DESCRIPTION
Magnus fråga 'ska varianterna vara sticky?' — mätningen: **preset-matrisen är redan koherent** (clean=transparent+ej sticky · sticky=blur+sticky · mega=solid+sticky), och den valde #295:s kontrakt före oss. Kvarvarande kant: #295 ignorerade sticky-ratten tyst vid manuell transparent+sticky. Nu: överlägget väljer **fixed** (följer med) eller **absolute** (scrollar bort) på ratten — båda rattarna talar sanning. Preset-matrisen pinnad.