### PR TITLE
revert(blocks): contact-korten var rätt som de var

### DIFF
--- a/src/components/public/blocks/ContactBlock.tsx
+++ b/src/components/public/blocks/ContactBlock.tsx
@@ -7,19 +7,17 @@ interface ContactBlockProps {
 
 export function ContactBlock({ data }: ContactBlockProps) {
   return (
-    <section>
-      {/* Korten är KOLUMNERNAS, inte sektionens. Den breda tonade panelen
-          (#287 gav den radie, ursprunget var ett kantlöst band) lästes på
-          optic som 'formulärets bakgrund som går utanför formuläret' — på
-          /contact ligger blocket direkt under ett FormBlock. Gles tvåkolumns-
-          info i ett ~1150px-kort är fel form; två innehållsnära kort är rätt.
-          Sektionen är ren — renderaren äger skalet. */}
+    <section
+      /* Målad sektion = PANEL (cta-doktrinen #278): paddingen är INVÄNDIG och
+         står kvar; radien är systemets panelradie. Renderarens wrapper ger
+         layoutrytmen utanför. */
+      className="py-16 px-6 bg-muted/30 rounded-[var(--radius-block,1rem)]">
       <div className="container mx-auto max-w-6xl">
         {data.title && (
           <h2 className="font-serif text-3xl font-bold mb-8 text-center">{data.title}</h2>
         )}
-        <div className="grid md:grid-cols-2 gap-8 items-start">
-          <div className="space-y-4 rounded-[var(--radius-block,1rem)] bg-muted/30 p-6 md:p-8">
+        <div className="grid md:grid-cols-2 gap-8">
+          <div className="space-y-4">
             {data.phone && (
               <div className="flex items-center gap-3">
                 <Phone className="h-5 w-5 text-accent-foreground" />
@@ -44,7 +42,7 @@ export function ContactBlock({ data }: ContactBlockProps) {
             )}
           </div>
           {data.hours && data.hours.length > 0 && (
-            <div className="rounded-[var(--radius-block,1rem)] bg-muted/30 p-6 md:p-8">
+            <div>
               <div className="flex items-center gap-2 mb-4">
                 <Clock className="h-5 w-5 text-accent-foreground" />
                 <span className="font-medium">Opening Hours</span>

--- a/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
+++ b/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
@@ -31,10 +31,7 @@ const FULL_BLEED = new Set([
  * MÅSTE sektionen bära färg + systemets panelradie (cta-doktrinen #278).
  * Svepet 2026-08-26 tömde dubbelskalslistan: 26 lagerskal strippade (endast
  * padding, struktur orörd), Contact omklassad till panel, CTA var redan panel. */
-// Contact lämnade listan 2026-08-26: dess breda sektionspanel lästes som
-// formulärets utrunna bakgrund — korten flyttade IN till kolumnerna (divar,
-// inte sektioner; zero-populationen ser dem inte och ska inte se dem).
-const PANEL_SECTIONS = new Set(['CTABlock']);
+const PANEL_SECTIONS = new Set(['CTABlock', 'ContactBlock']);
 
 // Multiline-medveten: #287-svepets skanner läste bara enradiga
 // <section className="…"> — TwoColumn (attribut på egen rad) och ChatBlock


### PR DESCRIPTION
Magnus förtydligade: observationen gällde FORM-blocket, inte contact — contact var bra. Ren revert av #297: sektionspanelen tillbaka, ContactBlock åter i PANEL_SECTIONS.