### PR TITLE
fix(blocks): formulärets kort äger sin yta

### DIFF
--- a/src/components/public/blocks/FormBlock.tsx
+++ b/src/components/public/blocks/FormBlock.tsx
@@ -535,15 +535,13 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
 
   // Default variant
   return (
-    {/* Kortet ÄGER sin yta (bg-card) — det tonade sektionsbandet bakom var
-        1104 px brett kring ett 640 px kort och lästes som "bakgrund som går
-        utanför formuläret" (Magnus, optic /contact 2026-08-27, verifierat i
-        levande computed-kedja). #287-svepet strippade padding men lämnade
-        färg medvetet; det här är färgens tur: en målad sektion utan radie
-        runt ett kort med egen yta är ingen panel — den är ett band utan
-        ägare. Sektionsbakgrund väljs i så fall via sectionBackground-ratten,
-        inte hårdkodas här. */}
-    <section>
+    <section
+      /* Kortet ÄGER sin yta (bg-card) — det tonade sektionsbandet bakom var
+         1104 px brett kring ett 640 px kort och lästes som "bakgrund som går
+         utanför formuläret" (optic 2026-08-27, verifierad computed-kedja).
+         En målad sektion utan radie runt ett kort med egen yta är ett band
+         utan ägare; sektionsbakgrund är sectionBackground-rattens jobb. */
+    >
       <div className="container max-w-2xl mx-auto px-4">
         {data.title && (
           <h2 className="text-3xl font-serif font-semibold text-center mb-3">{data.title}</h2>

--- a/src/components/public/blocks/FormBlock.tsx
+++ b/src/components/public/blocks/FormBlock.tsx
@@ -535,7 +535,15 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
 
   // Default variant
   return (
-    <section className="bg-muted/30">
+    {/* Kortet ÄGER sin yta (bg-card) — det tonade sektionsbandet bakom var
+        1104 px brett kring ett 640 px kort och lästes som "bakgrund som går
+        utanför formuläret" (Magnus, optic /contact 2026-08-27, verifierat i
+        levande computed-kedja). #287-svepet strippade padding men lämnade
+        färg medvetet; det här är färgens tur: en målad sektion utan radie
+        runt ett kort med egen yta är ingen panel — den är ett band utan
+        ägare. Sektionsbakgrund väljs i så fall via sectionBackground-ratten,
+        inte hårdkodas här. */}
+    <section>
       <div className="container max-w-2xl mx-auto px-4">
         {data.title && (
           <h2 className="text-3xl font-serif font-semibold text-center mb-3">{data.title}</h2>

--- a/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
+++ b/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
@@ -102,3 +102,19 @@ describe('transparent header är ett överlägg', () => {
     expect(sticky).toContain("backgroundStyle: 'blur'");
   });
 });
+
+describe('formulärets kort äger sin yta', () => {
+  /**
+   * FormBlock bar en hårdkodad bg-muted/30 på sin innersektion — ett 1104px
+   * tonat band bakom 640px-kortet, läst som "bakgrund utanför formuläret"
+   * (optic 2026-08-27, verifierad computed-kedja). Kortet (bg-card) är
+   * formulärets yta; sektionsbakgrund är sectionBackground-rattens jobb.
+   */
+  it('FormBlock målar aldrig sina egna sektioner', () => {
+    const src = readFileSync(
+      join(__dirname, '../../components/public/blocks/FormBlock.tsx'), 'utf-8');
+    for (const m of src.matchAll(SECTION_TAG)) {
+      expect(m[0], `målad sektion i FormBlock: ${m[0].slice(0, 80)}`).not.toMatch(/className="[^"]*bg-/);
+    }
+  });
+});


### PR DESCRIPTION
Magnus förtydligande: FORM-blocket, inte contact. Verifierat i webbläsaren (computed-kedja på optic): FormBlocks innersektion bar hårdkodad `bg-muted/30` — 1104 px band bakom 640 px-kortet. Bandet fällt; kortet (`bg-card`) är formulärets yta, sektionsbakgrund väljs via `sectionBackground`-ratten. Pinnat: FormBlock målar aldrig sina sektioner.