### PR TITLE
fix(admin): bygg-intentionen pekar på FlowChat, inte statuscockpiten

### DIFF
--- a/src/components/admin/EmptyDashboard.tsx
+++ b/src/components/admin/EmptyDashboard.tsx
@@ -44,7 +44,12 @@ export function EmptyDashboard() {
                 Describe your vision — or paste a URL to clone your current website.
               </p>
               <Button asChild className="w-full gap-2">
-                <Link to="/admin/flowpilot">
+                <Link
+                  to="/admin/flowchat"
+                  /* Bygg-intentionen är en KONVERSATION — den hör hemma i
+                     FlowChat. /admin/flowpilot är numera statuscockpiten
+                     (briefings, autonomy loop) utan chattyta. */
+                >
                   Start with FlowPilot
                   <ArrowRight className="h-4 w-4" />
                 </Link>

--- a/src/pages/admin/TemplateGalleryPage.tsx
+++ b/src/pages/admin/TemplateGalleryPage.tsx
@@ -125,7 +125,11 @@ export default function TemplateGalleryPage() {
                   Can't find what you're looking for?
                 </p>
                 <Button variant="outline" asChild>
-                  <Link to="/admin/flowpilot">
+                  <Link
+                    to="/admin/flowchat"
+                    /* Bygg-intentionen är en konversation → FlowChat;
+                       /admin/flowpilot är statuscockpiten utan chatt. */
+                  >
                     <Bot className="h-4 w-4 mr-2" />
                     Let FlowPilot build it for you
                     <ArrowRight className="h-4 w-4 ml-2" />


### PR DESCRIPTION
Nyinstallens 'Start with FlowPilot' och templategalleriets 'Let FlowPilot build it for you' landade på /admin/flowpilot som inte längre har någon chatt — konversationsytan är FlowChat. Statuslänkar orörda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)