### PR TITLE
fix(blocks): okänt ikonnamn faller till Sparkles på accent-plattan — aldrig ett hål

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -574,6 +574,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -590,6 +591,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -606,6 +608,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -622,6 +625,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -638,6 +642,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -654,6 +659,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -670,6 +676,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -686,6 +693,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -702,6 +710,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -718,6 +727,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -734,6 +744,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -750,6 +761,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -766,6 +778,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -782,6 +795,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -798,6 +812,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -814,6 +829,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -830,6 +846,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -863,6 +880,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -896,6 +914,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -928,6 +947,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -944,6 +964,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -960,6 +981,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -976,6 +998,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -574,7 +574,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -591,7 +590,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -608,7 +606,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -625,7 +622,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -642,7 +638,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -659,7 +654,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -676,7 +670,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -693,7 +686,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -710,7 +702,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -727,7 +718,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -744,7 +734,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -761,7 +750,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -778,7 +766,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -795,7 +782,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -812,7 +798,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -829,7 +814,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -846,7 +830,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -880,7 +863,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -914,7 +896,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -947,7 +928,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -964,7 +944,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -981,7 +960,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -998,7 +976,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/components/admin/blocks/FeaturesBlockEditor.tsx
+++ b/src/components/admin/blocks/FeaturesBlockEditor.tsx
@@ -157,8 +157,7 @@ export function FeaturesBlockEditor({ data, onChange, isEditing }: FeaturesBlock
     );
 
     const renderIcon = (iconName: string) => {
-      const LucideIcon = icons[iconName as keyof typeof icons];
-      if (!LucideIcon) return null;
+      const LucideIcon = icons[iconName as keyof typeof icons] ?? icons.Sparkles;
       if (iconStyle === 'none') return <LucideIcon className="h-7 w-7 text-accent-foreground" />;
       return (
         <div className={cn(

--- a/src/components/admin/blocks/StatsBlockEditor.tsx
+++ b/src/components/admin/blocks/StatsBlockEditor.tsx
@@ -153,7 +153,7 @@ export function StatsBlockEditor({ data, onChange, canEdit }: StatsBlockEditorPr
           stats.length <= 2 ? 'grid-cols-2' : stats.length === 3 ? 'grid-cols-3' : 'grid-cols-4'
         )}>
           {stats.map((stat, index) => {
-            const StatIcon = stat.icon ? icons[stat.icon as keyof typeof icons] : null;
+            const StatIcon = stat.icon ? icons[stat.icon as keyof typeof icons] ?? icons.Sparkles : null;
             return (
               <div key={index} className="text-center p-4 bg-card rounded-xl border">
                 {StatIcon && (

--- a/src/components/public/blocks/BentoGridBlock.tsx
+++ b/src/components/public/blocks/BentoGridBlock.tsx
@@ -54,8 +54,7 @@ function getGapClass(gap?: string): string {
 }
 
 function LucideIcon({ name, className }: { name: string; className?: string }) {
-  const IconComponent = icons[name as keyof typeof icons];
-  if (!IconComponent) return null;
+  const IconComponent = icons[name as keyof typeof icons] ?? icons.Sparkles;
   return <IconComponent className={className} />;
 }
 

--- a/src/components/public/blocks/FeaturesBlock.tsx
+++ b/src/components/public/blocks/FeaturesBlock.tsx
@@ -15,9 +15,10 @@ function FeatureIcon({
   iconName: string; 
   iconStyle: 'circle' | 'square' | 'none';
 }) {
-  const LucideIcon = icons[iconName as keyof typeof icons];
-  
-  if (!LucideIcon) return null;
+  // AI-composers hittar på ikonnamn som inte finns i lucides register
+  // ("Sheep", "Cow" — Restagård 2026-08-27); ett okänt namn ska ge
+  // fallback-glyfen på accent-plattan, aldrig ett hål i kortet.
+  const LucideIcon = icons[iconName as keyof typeof icons] ?? icons.Sparkles;
 
   const baseClasses = "h-6 w-6 text-accent-foreground";
   

--- a/src/components/public/blocks/LinkGridBlock.tsx
+++ b/src/components/public/blocks/LinkGridBlock.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { LinkGridBlockData } from '@/types/cms';
-import { ArrowRight, icons, LucideIcon } from 'lucide-react';
+import { ArrowRight, icons } from 'lucide-react';
 
 interface LinkGridBlockProps {
   data: LinkGridBlockData;
@@ -9,13 +9,8 @@ interface LinkGridBlockProps {
 function renderIcon(iconName: string, className?: string) {
   if (!iconName) return <ArrowRight className={className} />;
   
-  const LucideIconComponent = icons[iconName as keyof typeof icons] as LucideIcon | undefined;
-  
-  if (LucideIconComponent) {
-    return <LucideIconComponent className={className} />;
-  }
-  
-  return <ArrowRight className={className} />;
+  const LucideIconComponent = icons[iconName as keyof typeof icons] ?? ArrowRight;
+  return <LucideIconComponent className={className} />;
 }
 
 export function LinkGridBlock({ data }: LinkGridBlockProps) {

--- a/src/components/public/blocks/StatsBlock.tsx
+++ b/src/components/public/blocks/StatsBlock.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { StatsBlockData, StatsAnimationStyle } from '@/types/cms';
-import { icons, LucideIcon } from 'lucide-react';
+import { icons } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { usePlatformFormat } from '@/hooks/usePlatformFormat';
 
@@ -244,8 +244,8 @@ export function StatsBlock({ data }: StatsBlockProps) {
 
   const getIcon = (iconName?: string) => {
     if (!iconName) return null;
-    const Icon = icons[iconName as keyof typeof icons] as LucideIcon | undefined;
-    return Icon ? <Icon className="h-6 w-6" /> : null;
+    const Icon = icons[iconName as keyof typeof icons] ?? icons.Sparkles;
+    return <Icon className="h-6 w-6" />;
   };
 
   const gridCols = {

--- a/src/components/public/blocks/TimelineBlock.tsx
+++ b/src/components/public/blocks/TimelineBlock.tsx
@@ -22,11 +22,7 @@ interface TimelineBlockProps {
 }
 
 function StepIcon({ iconName, className }: { iconName: string; className?: string }) {
-  const IconComponent = icons[iconName as keyof typeof icons];
-  if (!IconComponent) {
-    const FallbackIcon = icons['Circle'];
-    return <FallbackIcon className={className} />;
-  }
+  const IconComponent = icons[iconName as keyof typeof icons] ?? icons.Circle;
   return <IconComponent className={className} />;
 }
 

--- a/src/lib/__tests__/template-icons.guardrails.test.ts
+++ b/src/lib/__tests__/template-icons.guardrails.test.ts
@@ -49,6 +49,31 @@ describe('template icon names', () => {
     expect('FileSignature' in icons, 'the alias is now a registry key too').toBe(false);
   });
 
+  it('every dynamic registry lookup in a public block coalesces to a fallback icon', () => {
+    // The other half of the trap: even with the template test above, icon
+    // names arrive from AI composers at runtime (migrate_url compose invented
+    // "Sheep"/"Sausage"/"Cow" on Restagård, 2026-08-27) — no static check can
+    // catch those. So the lookup itself must never render nothing: a bare
+    // `icons[name]` that resolves to undefined leaves a hole where the icon
+    // should be. Convention: every bracket lookup on the lucide registry in a
+    // public block coalesces (`?? icons.Sparkles`, `?? ArrowRight`, …) in the
+    // same statement. Write fallbacks as dot access (`icons.Sparkles`), which
+    // this scan deliberately ignores.
+    const blockDir = join(root, 'src/components/public/blocks');
+    const bad: string[] = [];
+    for (const file of readdirSync(blockDir).filter((f) => f.endsWith('.tsx'))) {
+      const src = readFileSync(join(blockDir, file), 'utf8');
+      for (const m of src.matchAll(/icons\[[^\]]+\][^;]*/g)) {
+        if (!m[0].includes('??')) bad.push(`${file}: ${m[0].trim().split('\n')[0]}`);
+      }
+    }
+    expect(
+      bad,
+      'these lucide registry lookups have no `??` fallback in the same statement — ' +
+        `an AI-invented icon name renders a hole instead of a glyph:\n${bad.join('\n')}`,
+    ).toEqual([]);
+  });
+
   it('blocks with their own icon map only receive names that map exists for', () => {
     // BadgeBlock and SocialProofBlock keep small curated maps keyed by
     // lowercase names, so a lucide-valid name is not automatically safe there.


### PR DESCRIPTION
## Problemet

AI-composern (migrate_url compose) hittar på lucide-namn som inte finns i registret — `'Sheep'`/`'Sausage'`/`'Cow'` live på Restagård 2026-08-27. `FeatureIcon` i `FeaturesBlock` gjorde ett naket `icons[iconName]`-uppslag och returnerade `null` vid miss: korten stod utan ikon. Inget fel, ingen varning — bara ett hål.

Detta är runtime-halvan av fällan som `template-icons.guardrails.test.ts` täcker statiskt: templatens namn kan lintas, composerns påhitt kan inte.

## Ändringar

Alla dynamiska registeruppslag i `src/components/public/blocks/` koalescerar nu till en fallback-glyf i samma sats:

| Block | Före | Efter |
|---|---|---|
| `FeaturesBlock` | `null` → hål i kortet | `?? icons.Sparkles` (på befintlig accent-platta: `bg-accent/50` + `text-accent-foreground`) |
| `BentoGridBlock` | `null` → tom accent-platta (färgkanon fixades i #293, glyfen saknades) | `?? icons.Sparkles` |
| `StatsBlock` | `null` vid okänt namn | `?? icons.Sparkles` (inget ikonnamn alls renderar fortsatt inget — det är ett legitimt val) |
| `LinkGridBlock` | hade redan `ArrowRight`-fallback | normaliserad till `?? ArrowRight` |
| `TimelineBlock` | hade redan `Circle`-fallback | normaliserad till `?? icons.Circle` |

Editor-previews följer med så preview speglar publikt (konventionen `isEditing=false` ≈ public): `FeaturesBlockEditor` och `StatsBlockEditor` får samma koalescering.

## Pinnen

Nytt test i `template-icons.guardrails.test.ts`: skannar `src/components/public/blocks/*.tsx` och fäller varje `icons[...]`-uppslag som saknar `??` i samma sats. Konvention: fallbacks skrivs som dot access (`icons.Sparkles`) så skannern medvetet ignorerar dem. Verifierat icke-vakuöst — den hittar alla 5 uppslag idag.

## Verifiering

- `npx vitest run` — 3352 passed, 5 skipped
- `npx tsc --noEmit` — rent
- `npx eslint` på berörda filer — endast pre-existerande fynd på orörda rader

Andra commiten återställer `package-lock.json` (npm-versionsbrus från installationen, ingen beroendeändring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJSNab6NinrCCWHbUQPStv

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJSNab6NinrCCWHbUQPStv)_