### PR TITLE
fix(css): overflow-x clip — hidden dödade headerns sticky på mobil

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -155,14 +155,18 @@
   html {
     scroll-behavior: smooth;
     /* Mobile safety net: prevent rogue blocks (wide tables, marquees, full-bleed images)
-       from creating horizontal page scroll. Internal overflow-x:auto containers still scroll. */
-    overflow-x: hidden;
+       from creating horizontal page scroll. Internal overflow-x:auto containers still scroll.
+       MUST be `clip`, not `hidden`: overflow-x:hidden turns body into a scroll
+       container, which silently kills every position:sticky descendant — the
+       public header scrolled away on mobile and hero text rode up over it
+       (Restagård 2026-08-27). `clip` clips without creating a scroll container. */
+    overflow-x: clip;
   }
 
   body {
     @apply bg-background text-foreground font-sans antialiased;
     font-family: var(--font-sans);
-    overflow-x: hidden;
+    overflow-x: clip;
     /* Avoid layout shift caused by horizontal scrollbar on desktop */
     max-width: 100vw;
   }

--- a/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
+++ b/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
@@ -115,3 +115,16 @@ describe('formulärets kort äger sin yta', () => {
     }
   });
 });
+
+describe('skyddsnätet får inte döda stickyn', () => {
+  // overflow-x: hidden på html/body gör body till scroll-container och bryter
+  // varje position:sticky-ättling — headern scrollade bort på mobil och
+  // herotexten red upp över den (Restagård 2026-08-27). `clip` klipper
+  // utan scroll-container; skyddsnätet mot horisontellt spill består.
+  it('html/body klipper med clip, aldrig hidden', () => {
+    const css = readFileSync(join(__dirname, '../../index.css'), 'utf-8');
+    const base = css.slice(css.indexOf('html {'), css.indexOf('h1, h2'));
+    expect(base).toContain('overflow-x: clip');
+    expect(base, 'overflow-x: hidden på html/body dödar position:sticky — använd clip').not.toContain('overflow-x: hidden');
+  });
+});


### PR DESCRIPTION
html/body hade overflow-x: hidden som mobilskyddsnät — det gör body till scroll-container och bryter position:sticky, så headern scrollade bort och herotexten red över den. clip klipper utan scroll-container; båda egenskaperna verifierade i runtime på liven. Pinne + negativtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)