### PR TITLE
fix(hero): innehållet får säkerhetspadding — red över overlay-headern på mobil

### DIFF
--- a/src/components/public/blocks/HeroBlock.tsx
+++ b/src/components/public/blocks/HeroBlock.tsx
@@ -477,7 +477,13 @@ export function HeroBlock({ data }: HeroBlockProps) {
       <div className={cn(
         "relative container mx-auto max-w-3xl z-10 flex flex-col",
         textAlignmentClasses[textAlignment] ?? textAlignmentClasses.center,
-        heightMode === 'auto' && "py-0"
+        heightMode === 'auto' && "py-0",
+        /* Centrerat innehåll i viewport-höjd har ingen egen kant: är innehållet
+           högre än sektionen svämmar det över mot y=0 och krockar med en
+           overlay-header (optic mobil, 2026-08-27). 6 rem > headerns 4 rem;
+           när innehållet får plats ändrar paddingen inget — centreringen
+           består. top/bottom-lägena bär redan 8 rem sektionspadding. */
+        heightMode !== 'auto' && contentAlignment === 'center' && "py-24"
       )}>
         {data.eyebrow && (
           <p className={cn(

--- a/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
+++ b/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
@@ -128,3 +128,14 @@ describe('skyddsnätet får inte döda stickyn', () => {
     expect(base, 'overflow-x: hidden på html/body dödar position:sticky — använd clip').not.toContain('overflow-x: hidden');
   });
 });
+
+describe('heron krockar inte med overlay-headern', () => {
+  // Centrerat innehåll i viewport-höjd utan egen kantpadding svämmar över mot
+  // y=0 när det är högre än sektionen — och ligger då ovanpå en transparent
+  // overlay-header (optic mobil 2026-08-27). Innehållscontainern MÅSTE bära
+  // säkerhetspadding (> headerns 4 rem) i centrerat icke-auto-läge.
+  it('innehållscontainern bär py-24 i centrerat viewport-läge', () => {
+    const src = readFileSync(join(__dirname, '../../components/public/blocks/HeroBlock.tsx'), 'utf-8');
+    expect(src).toMatch(/heightMode !== 'auto' && contentAlignment === 'center' && "py-2[4-9]"/);
+  });
+});


### PR DESCRIPTION
Centrerat viewport-höjd-innehåll utan egen kantpadding svämmar över mot y=0 → rubriken ovanpå transparent header (optic mobil). py-24 på containern i centrerat icke-auto-läge, runtime-bevisat på liven, pinnat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)