### PR TITLE
fix(chat): LiveAgentIndicator på ui_text-rälsen + bg-success för pulsprick

### DIFF
--- a/src/components/chat/LiveAgentIndicator.tsx
+++ b/src/components/chat/LiveAgentIndicator.tsx
@@ -1,4 +1,5 @@
 import { type SupportChannel, channelMeta } from '@/lib/support-channels';
+import { useUiText } from '@/lib/ui-text';
 import { cn } from '@/lib/utils';
 
 interface LiveAgentIndicatorProps {
@@ -8,20 +9,26 @@ interface LiveAgentIndicatorProps {
 }
 
 export function LiveAgentIndicator({ className, channel = 'web', agentName }: LiveAgentIndicatorProps) {
+  const t = useUiText();
   const meta = channelMeta[channel];
   const Icon = meta.icon;
 
-  const copy = (() => {
-    const who = agentName ? `with ${agentName}` : 'with a teammate';
+  const template = (() => {
     switch (channel) {
-      case 'telegram': return `You're now connected ${who} on Telegram`;
-      case 'sms':      return `${agentName ?? 'A teammate'} is replying by SMS`;
-      case 'voice':    return `${agentName ?? 'A teammate'} is on the line`;
-      case 'voicemail':return `${agentName ?? 'A teammate'} will follow up on your voicemail`;
+      case 'telegram': return t('chat.live.telegram', "You're now connected with {name} on Telegram");
+      case 'sms':      return t('chat.live.sms', '{name} is replying by SMS');
+      case 'voice':    return t('chat.live.voice', '{name} is on the line');
+      case 'voicemail':return t('chat.live.voicemail', '{name} will follow up on your voicemail');
       case 'web':
-      default:         return `You are now chatting ${who}`;
+      default:         return t('chat.live.web', 'You are now chatting with {name}');
     }
   })();
+
+  const filled = template.replace('{name}', agentName ?? t('chat.live.teammate', 'a teammate'));
+  // The teammate fallback is lowercase ("a teammate") so it reads right
+  // mid-sentence; when a template leads with {name} the sentence still needs
+  // its capital. No-op for strings that already start uppercase.
+  const copy = filled.charAt(0).toUpperCase() + filled.slice(1);
 
   return (
     <div className={cn(
@@ -31,7 +38,7 @@ export function LiveAgentIndicator({ className, channel = 'web', agentName }: Li
     )}>
       <div className="relative">
         <Icon className={cn('h-4 w-4', meta.color)} />
-        <span className="absolute -top-0.5 -right-0.5 h-2 w-2 bg-green-500 rounded-full animate-pulse" />
+        <span className="absolute -top-0.5 -right-0.5 h-2 w-2 bg-success rounded-full animate-pulse" />
       </div>
       <span className={cn('text-sm font-medium', meta.color)}>
         {copy}

--- a/src/lib/__tests__/status-token-adoption.guardrails.test.ts
+++ b/src/lib/__tests__/status-token-adoption.guardrails.test.ts
@@ -70,7 +70,7 @@ describe('status-tokens: populationen krymper', () => {
   // Mätt 2026-08-27 efter svepet (85 mönsterersättningar + besökarytan till
   // noll). FÖREKOMSTER, inte rader — flera klasser per rad räknas var för sig.
   // Får SÄNKAS när fler konverteras — aldrig höjas.
-  const BASELINE = 1118;
+  const BASELINE = 1117;
 
   it(`ratchet: max ${BASELINE} råa statusfärger i src`, () => {
     const { count } = countRaw(SRC);


### PR DESCRIPTION
## Vad

`src/components/chat/LiveAgentIndicator.tsx` hade fem hårdkodade engelska besökarsträngar (web/telegram/sms/voice/voicemail) som visades oöversatta på svenska sajter ("You are now chatting with a teammate", observerat på optic 2026-08-27).

## Ändringar

- **ui_text-rälsen**: alla fem kanalsträngar går nu via `useUiText` (samma mönster som `shop.*` i `ShopPage.tsx`, #304), med `{name}`-platshållare som fylls vid render:
  - `chat.live.web` — `You are now chatting with {name}`
  - `chat.live.telegram` — `You're now connected with {name} on Telegram`
  - `chat.live.sms` — `{name} is replying by SMS`
  - `chat.live.voice` — `{name} is on the line`
  - `chat.live.voicemail` — `{name} will follow up on your voicemail`
  - `chat.live.teammate` — `a teammate` (fallbacknamn när `agentName` saknas; renderad sträng versaliseras i första positionen så "a teammate is replying…" → "A teammate is replying…" och sv. "en kollega" → "En kollega")
- **Statustoken**: pulsprickens `bg-green-500` → `bg-success` (rälsen finns redan i `index.css`/`tailwind.config.ts`); ratchet-`BASELINE` i `status-token-adoption.guardrails` sänkt 1118 → 1117 (verifierad räkning: exakt 1117 träffar i `src`).

## Kvarstår (utanför repo:t)

Svenska värden för `chat.live.*` behöver sättas på optic via `manage_site_settings` (get `ui_text` → merge → update; handlern ersätter hela värdet, så merge sker klientside). Kunde inte köras från den här sessionen — `OPTIC_MCP_KEY`/`.env.local` finns inte i miljön. Föreslagen payload finns i sessionen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbgcV1YeBDnz23Ft5XyhCw

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbgcV1YeBDnz23Ft5XyhCw)_