### PR TITLE
fix(blog): publik blogg läsbar för anon på färska instanser — utan e-postläckan

### DIFF
--- a/src/components/admin/blog/BlogPostsTab.tsx
+++ b/src/components/admin/blog/BlogPostsTab.tsx
@@ -114,7 +114,7 @@ export default function BlogPostsTab() {
                       <><span>•</span><span>{post.categories.map(c => c.name).join(", ")}</span></>
                     )}
                     {post.author && (
-                      <><span>•</span><span>{post.author.full_name || post.author.email}</span></>
+                      <><span>•</span><span>{post.author.full_name || "Unnamed"}</span></>
                     )}
                     <span>•</span>
                     <span>{formatDistanceToNow(new Date(post.updated_at), { addSuffix: true })}</span>

--- a/src/components/public/AuthorCard.tsx
+++ b/src/components/public/AuthorCard.tsx
@@ -24,7 +24,7 @@ export function AuthorCard({ author, variant = "card", showBio = true }: AuthorC
           <AvatarFallback>{initials}</AvatarFallback>
         </Avatar>
         <div>
-          <p className="font-medium">{author.full_name || author.email}</p>
+          <p className="font-medium">{author.full_name || author.title || "Author"}</p>
           {author.title && (
             <p className="text-sm text-muted-foreground">{author.title}</p>
           )}
@@ -42,7 +42,7 @@ export function AuthorCard({ author, variant = "card", showBio = true }: AuthorC
             <AvatarFallback className="text-lg">{initials}</AvatarFallback>
           </Avatar>
           <div className="flex-1 min-w-0">
-            <p className="font-semibold text-lg">{author.full_name || author.email}</p>
+            <p className="font-semibold text-lg">{author.full_name || author.title || "Author"}</p>
             {author.title && (
               <p className="text-sm text-muted-foreground mb-2">{author.title}</p>
             )}

--- a/src/hooks/useBlogPosts.ts
+++ b/src/hooks/useBlogPosts.ts
@@ -87,7 +87,7 @@ export function useBlogPosts(options: UseBlogPostsOptions = {}) {
         .from('blog_posts')
         .select(`
           *,
-          author:profiles!blog_posts_author_id_fkey(id, email, full_name, avatar_url, bio, title),
+          author:profiles!blog_posts_author_id_fkey(id, full_name, avatar_url, bio, title),
           categories:blog_post_categories(category:blog_categories(*)),
           tags:blog_post_tags(tag:blog_tags(*))
         `, { count: 'exact' })
@@ -176,8 +176,8 @@ export function useBlogPost(slugOrId: string | undefined) {
         .from('blog_posts')
         .select(`
           *,
-          author:profiles!blog_posts_author_id_fkey(id, email, full_name, avatar_url, bio, title),
-          reviewer:profiles!blog_posts_reviewer_id_fkey(id, email, full_name, avatar_url, bio, title),
+          author:profiles!blog_posts_author_id_fkey(id, full_name, avatar_url, bio, title),
+          reviewer:profiles!blog_posts_reviewer_id_fkey(id, full_name, avatar_url, bio, title),
           categories:blog_post_categories(category:blog_categories(*)),
           tags:blog_post_tags(tag:blog_tags(*))
         `);
@@ -587,17 +587,19 @@ export function useAuthors(publicOnly = false) {
   return useQuery({
     queryKey: ['authors', { publicOnly }],
     queryFn: async () => {
-      let query = supabase
-        .from('profiles')
-        .select('*')
-        .order('full_name');
-      
-      // Only filter by show_as_author for public-facing contexts
-      if (publicOnly) {
-        query = query.eq('show_as_author', true);
-      }
-      
-      const { data, error } = await query;
+      /* Anon har kolumnbegränsad SELECT på profiles (aldrig e-post) —
+         publika vägen får bara be om det den får läsa, annars 401:ar
+         PostgREST hela frågan (fresh-install-klassen, Restagård 2026-08-27). */
+      const { data, error } = publicOnly
+        ? await supabase
+            .from('profiles')
+            .select('id, full_name, avatar_url, bio, title, show_as_author')
+            .eq('show_as_author', true)
+            .order('full_name')
+        : await supabase
+            .from('profiles')
+            .select('*')
+            .order('full_name');
       
       if (error) throw error;
       return data;

--- a/src/pages/BlogAuthorPage.tsx
+++ b/src/pages/BlogAuthorPage.tsx
@@ -31,7 +31,7 @@ function useAuthorBySlug(slug: string | undefined) {
       if (slug && uuidRe.test(slug)) {
         const { data } = await supabase
           .from('profiles')
-          .select('id, full_name, email, avatar_url, bio, title, show_as_author')
+          .select('id, full_name, avatar_url, bio, title, show_as_author')
           .eq('id', slug)
           .maybeSingle();
         if (data) return data as AuthorProfile;
@@ -39,7 +39,7 @@ function useAuthorBySlug(slug: string | undefined) {
       // Otherwise fetch candidates and match slugified full_name
       const { data, error } = await supabase
         .from('profiles')
-        .select('id, full_name, email, avatar_url, bio, title, show_as_author')
+        .select('id, full_name, avatar_url, bio, title, show_as_author')
         .not('full_name', 'is', null);
       if (error) throw error;
       const match = (data ?? []).find(
@@ -74,7 +74,7 @@ export default function BlogAuthorPage() {
 
   const initials = useMemo(
     () =>
-      (author?.full_name || author?.email || '?')
+      (author?.full_name || '?')
         .split(' ')
         .map((s) => s[0])
         .join('')
@@ -99,7 +99,7 @@ export default function BlogAuthorPage() {
 
   if (!author) return <NotFound />;
 
-  const displayName = author.full_name || author.email;
+  const displayName = author.full_name || author.title || 'Author';
   const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
   const canonicalUrl = `${baseUrl}/blog/author/${slug}`;
 

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -140,7 +140,7 @@ export default function BlogPostPage() {
             {post.author && (
               <div className="flex items-center gap-2">
                 <User className="h-4 w-4" />
-                <span>{post.author.full_name || post.author.email}</span>
+                <span>{post.author.full_name || "Author"}</span>
               </div>
             )}
             <div className="flex items-center gap-2">
@@ -222,7 +222,7 @@ export default function BlogPostPage() {
                   }`}
                   className="text-sm text-primary hover:underline"
                 >
-                  View all posts by {post.author.full_name || post.author.email} →
+                  View all posts by {post.author.full_name || "Author"} →
                 </Link>
               </div>
             </div>

--- a/src/pages/admin/BlogPostEditorPage.tsx
+++ b/src/pages/admin/BlogPostEditorPage.tsx
@@ -336,7 +336,7 @@ export default function BlogPostEditorPage() {
                         <SelectContent>
                           {authors?.map((author) => (
                             <SelectItem key={author.id} value={author.id}>
-                              {author.full_name || author.email}
+                              {author.full_name || "Unnamed"}
                             </SelectItem>
                           ))}
                         </SelectContent>
@@ -359,7 +359,7 @@ export default function BlogPostEditorPage() {
                             <SelectItem value="none">None</SelectItem>
                             {authors?.map((author) => (
                               <SelectItem key={author.id} value={author.id}>
-                                {author.full_name || author.email}
+                                {author.full_name || "Unnamed"}
                               </SelectItem>
                             ))}
                           </SelectContent>

--- a/src/pages/admin/BlogPostsPage.tsx
+++ b/src/pages/admin/BlogPostsPage.tsx
@@ -182,7 +182,7 @@ export default function BlogPostsPage() {
                       {post.author && (
                         <>
                           <span>•</span>
-                          <span>{post.author.full_name || post.author.email}</span>
+                          <span>{post.author.full_name || "Unnamed"}</span>
                         </>
                       )}
                       

--- a/supabase/migrations/20260828190000_f5f20801-public-blog-anon-read.sql
+++ b/supabase/migrations/20260828190000_f5f20801-public-blog-anon-read.sql
@@ -1,0 +1,36 @@
+-- Publik blogg för anon — fresh-install-klassen (Restagård 2026-08-27).
+-- Besökarfrågan embeddar author:profiles + kategorier/taggar. På en färsk
+-- instans saknar anon både grant på profiles och SELECT-policyer på
+-- taxonomitabellerna → PostgREST 401:ar HELA frågan och publika bloggen
+-- visar "No posts yet" trots publicerade inlägg. Äldre instanser har i
+-- stället en BRED profiles-grant (e-post läsbar för anon) — båda felen
+-- normaliseras här till samma sluttillstånd:
+--   profiles: anon läser ENDAST id/full_name/avatar_url/bio/title/
+--   show_as_author, och bara rader med show_as_author = true.
+--   Taxonomin (kategorier/taggar/kopplingar): öppen läsning — publik metadata.
+-- Frontend är samtidigt ändrad att aldrig BE om e-post på publika vägar
+-- (kolumnbegränsad grant 401:ar annars frågor som begär fel kolumner).
+
+REVOKE SELECT ON public.profiles FROM anon;
+GRANT SELECT (id, full_name, avatar_url, bio, title, show_as_author)
+  ON public.profiles TO anon;
+
+DROP POLICY IF EXISTS "Public can view author profiles" ON public.profiles;
+CREATE POLICY "Public can view author profiles" ON public.profiles
+  FOR SELECT TO anon USING (show_as_author = true);
+
+DROP POLICY IF EXISTS "Public can view blog categories" ON public.blog_categories;
+CREATE POLICY "Public can view blog categories" ON public.blog_categories
+  FOR SELECT TO anon USING (true);
+
+DROP POLICY IF EXISTS "Public can view blog tags" ON public.blog_tags;
+CREATE POLICY "Public can view blog tags" ON public.blog_tags
+  FOR SELECT TO anon USING (true);
+
+DROP POLICY IF EXISTS "Public can view blog post categories" ON public.blog_post_categories;
+CREATE POLICY "Public can view blog post categories" ON public.blog_post_categories
+  FOR SELECT TO anon USING (true);
+
+DROP POLICY IF EXISTS "Public can view blog post tags" ON public.blog_post_tags;
+CREATE POLICY "Public can view blog post tags" ON public.blog_post_tags
+  FOR SELECT TO anon USING (true);

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260828170000",
-      "migrations_count": 521,
+      "migration_head": "20260828190000",
+      "migrations_count": 522,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2089,6 +2089,10 @@
         {
           "version": "20260828170000",
           "name": "mailet-ar-sajtinnehall"
+        },
+        {
+          "version": "20260828190000",
+          "name": "f5f20801-public-blog-anon-read"
         }
       ]
     },


### PR DESCRIPTION
Fresh-install: anon saknar profiles-grant → embed-frågan 401:ar → tom publik blogg. Gamla instanser: bred grant = författar-e-post läsbar för anon. Migration normaliserar (kolumnbegränsad grant + policyer), frontend slutar be om e-post publikt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)