### PR TITLE
fix(nav): overlay-offset för sidor utan hero — /chat låg under headern

### DIFF
--- a/src/components/public/PublicNavigation.tsx
+++ b/src/components/public/PublicNavigation.tsx
@@ -85,6 +85,23 @@ export function PublicNavigation() {
     staleTime: 1000 * 60 * 5,
   });
 
+  // Overlay-headern tar ingen plats i flödet — sidor UTAN hero börjar annars
+  // på y=0 under den (chatten på /chat låg under nav-länkarna, autoversio
+  // 2026-08-28). Headern annonserar sin uppmätta höjd som CSS-variabel;
+  // hero-lösa sidor konsumerar den som padding-top. Icke-overlay: variabeln
+  // tas bort → 0 → ingen effekt.
+  const overlayStyle = headerSettings.backgroundStyle || 'solid';
+  const headerIsOverlay = overlayStyle === 'transparent';
+  const headerRef = useRef<HTMLElement>(null);
+  useEffect(() => {
+    const root = document.documentElement;
+    if (!headerIsOverlay) { root.style.removeProperty('--overlay-header-offset'); return; }
+    const set = () => root.style.setProperty('--overlay-header-offset', `${headerRef.current?.offsetHeight ?? 64}px`);
+    set();
+    window.addEventListener('resize', set);
+    return () => { window.removeEventListener('resize', set); root.style.removeProperty('--overlay-header-offset'); };
+  }, [headerIsOverlay]);
+
   // Custom nav items from header settings
   const customNavItems = (headerSettings.customNavItems || []).filter(item => item.enabled);
 
@@ -289,7 +306,7 @@ export function PublicNavigation() {
   return (
     <>
     <SandboxBanner />
-    <header className={getBackgroundClasses()}>
+    <header ref={headerRef} className={getBackgroundClasses()}>
       {/* Mega Menu Dropdowns - Rendered at header level for full width */}
       {isMegaMenuVariant && customNavItems.map((item) => (
         item.children && item.children.length > 0 && (

--- a/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
+++ b/src/lib/__tests__/renderer-owns-the-shell.guardrails.test.ts
@@ -152,3 +152,32 @@ describe('heroens bildfält ljuger inte', () => {
       'nya nakna data.backgroundImage-läsningar — gå via heroImage-aliaset').toBe(1);
   });
 });
+
+describe('overlay-headern annonserar sin höjd — hero-lösa sidor konsumerar den', () => {
+  // Overlay tar ingen flödeshöjd: /chat låg under nav-länkarna (autoversio
+  // 2026-08-28). Headern sätter --overlay-header-offset (uppmätt, tas bort i
+  // icke-overlay); varje PublicNavigation-sida utan hero-garanti bär
+  // pt-[var(--overlay-header-offset,0px)] på sin main. Population: ALLA
+  // src/pages-filer som importerar PublicNavigation, utom PublicPage som
+  // villkorar på förstablockets typ.
+  const PAD = 'pt-[var(--overlay-header-offset,0px)]';
+  it('headern sätter variabeln i overlay-läge', () => {
+    const nav = readFileSync(join(__dirname, '../../components/public/PublicNavigation.tsx'), 'utf-8');
+    expect(nav).toContain("setProperty('--overlay-header-offset'");
+    expect(nav).toContain("removeProperty('--overlay-header-offset')");
+  });
+  it('varje PublicNavigation-sida konsumerar offset', () => {
+    const dir = join(__dirname, '../../pages');
+    const offenders: string[] = [];
+    for (const f of readdirSync(dir).filter((x) => x.endsWith('.tsx'))) {
+      const src = readFileSync(join(dir, f), 'utf-8');
+      if (!src.includes('PublicNavigation')) continue;
+      if (f === 'PublicPage.tsx') {
+        if (!src.includes(PAD)) offenders.push(f + ' (villkorade offseten saknas)');
+        continue;
+      }
+      if (src.includes('<main className="') && !src.includes(PAD)) offenders.push(f);
+    }
+    expect(offenders, `sidor utan overlay-offset: ${offenders.join(', ')}`).toEqual([]);
+  });
+});

--- a/src/pages/BlogArchivePage.tsx
+++ b/src/pages/BlogArchivePage.tsx
@@ -77,7 +77,7 @@ export default function BlogArchivePage() {
       
       <PublicNavigation />
       
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         <div className="container mx-auto px-4 py-12">
           {/* Header */}
           <div className={archiveTitle

--- a/src/pages/BlogAuthorPage.tsx
+++ b/src/pages/BlogAuthorPage.tsx
@@ -87,7 +87,7 @@ export default function BlogAuthorPage() {
     return (
       <>
         <PublicNavigation />
-        <main className="min-h-screen bg-background">
+        <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
           <div className="container mx-auto px-4 py-12">
             <p className="text-center text-muted-foreground">Loading author…</p>
           </div>
@@ -112,7 +112,7 @@ export default function BlogAuthorPage() {
         ogImage={author.avatar_url || undefined}
       />
       <PublicNavigation />
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         <section className="container mx-auto px-4 py-12 max-w-4xl">
           <div className="flex items-start gap-6 mb-10">
             <Avatar className="h-24 w-24">

--- a/src/pages/BlogCategoryPage.tsx
+++ b/src/pages/BlogCategoryPage.tsx
@@ -39,7 +39,7 @@ export default function BlogCategoryPage() {
     return (
       <>
         <PublicNavigation />
-        <main className="min-h-screen bg-background">
+        <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
           <div className="container mx-auto px-4 py-12">
             <p className="text-center text-muted-foreground">Loading...</p>
           </div>
@@ -67,7 +67,7 @@ export default function BlogCategoryPage() {
       
       <PublicNavigation />
       
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         <div className="container mx-auto px-4 py-12">
           {/* Breadcrumb */}
           <nav className="mb-6">

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -45,7 +45,7 @@ export default function BlogPostPage() {
     return (
       <>
         <PublicNavigation />
-        <main className="min-h-screen bg-background">
+        <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
           <div className="container mx-auto px-4 py-12">
             <p className="text-center text-muted-foreground">Loading article...</p>
           </div>
@@ -104,7 +104,7 @@ export default function BlogPostPage() {
       
       <PublicNavigation />
       
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         <article className="container mx-auto px-4 py-8 max-w-4xl">
           {/* Breadcrumb */}
           <nav className="mb-6">

--- a/src/pages/BlogTagPage.tsx
+++ b/src/pages/BlogTagPage.tsx
@@ -37,7 +37,7 @@ export default function BlogTagPage() {
     return (
       <>
         <PublicNavigation />
-        <main className="min-h-screen bg-background">
+        <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
           <div className="container mx-auto px-4 py-12">
             <p className="text-center text-muted-foreground">Loading...</p>
           </div>
@@ -64,7 +64,7 @@ export default function BlogTagPage() {
       
       <PublicNavigation />
       
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         <div className="container mx-auto px-4 py-12">
           {/* Breadcrumb */}
           <nav className="mb-6">

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -20,7 +20,7 @@ export default function CartPage() {
       <>
         <Helmet><title>{'Cart'}</title></Helmet>
         <PublicNavigation />
-        <main className="min-h-screen bg-background flex items-center justify-center p-4">
+        <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background flex items-center justify-center p-4">
           <div className="text-center space-y-4">
             <ShoppingBag className="h-16 w-16 mx-auto text-muted-foreground/30" />
             <h1 className="text-2xl font-bold">Your cart is empty</h1>
@@ -43,7 +43,7 @@ export default function CartPage() {
       <Helmet><title>{`Cart (${totalItems})`}</title></Helmet>
       <PublicNavigation />
 
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         <div className="container mx-auto px-6 py-8 max-w-5xl">
           <h1 className="text-3xl font-serif font-bold tracking-tight mb-8">Your Cart</h1>
 

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -113,7 +113,7 @@ export default function ChatPage() {
         </div>
       )}
 
-      <main className="flex-1 flex min-h-0">
+      <main className="pt-[var(--overlay-header-offset,0px)] flex-1 flex min-h-0">
         {/* Main chat area */}
         <div className="flex-1 flex flex-col min-h-0 min-w-0">
           <ChatConversation

--- a/src/pages/DocsArticlePage.tsx
+++ b/src/pages/DocsArticlePage.tsx
@@ -76,7 +76,7 @@ export default function DocsArticlePage() {
 
       {!embed && <PublicNavigation />}
 
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         <div className="container mx-auto px-4 py-8 lg:py-12 max-w-7xl">
           <div className="grid grid-cols-12 gap-8">
             <aside className="col-span-12 lg:col-span-3 hidden lg:block sticky top-20 self-start">

--- a/src/pages/DocsCategoryPage.tsx
+++ b/src/pages/DocsCategoryPage.tsx
@@ -51,7 +51,7 @@ export default function DocsCategoryPage() {
 
       {!embed && <PublicNavigation />}
 
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         <div className="container mx-auto px-4 py-8 lg:py-12 max-w-7xl">
           <div className="grid grid-cols-12 gap-8">
             <aside className="col-span-12 lg:col-span-3 hidden lg:block sticky top-20 self-start">

--- a/src/pages/DocsLandingPage.tsx
+++ b/src/pages/DocsLandingPage.tsx
@@ -54,7 +54,7 @@ export default function DocsLandingPage() {
 
       {!embed && <PublicNavigation />}
 
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         <div className="container mx-auto px-4 py-8 lg:py-12 max-w-7xl">
           <div className="grid grid-cols-12 gap-8">
             {/* Sidebar */}

--- a/src/pages/JobsPage.tsx
+++ b/src/pages/JobsPage.tsx
@@ -39,7 +39,7 @@ export default function JobsPage() {
         <meta name="description" content="Browse our open positions and apply to join the team." />
       </Helmet>
       <PublicNavigation />
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         <section className="border-b border-border bg-muted/30">
           <div className="container mx-auto max-w-5xl px-4 py-16 md:py-24">
 

--- a/src/pages/KbArticlePage.tsx
+++ b/src/pages/KbArticlePage.tsx
@@ -37,7 +37,7 @@ export default function KbArticlePage() {
     return (
       <>
         <PublicNavigation />
-        <main className="min-h-screen bg-background">
+        <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
           <div className="container mx-auto px-4 py-12">
             <p className="text-center text-muted-foreground">Loading article…</p>
           </div>
@@ -63,7 +63,7 @@ export default function KbArticlePage() {
         canonicalUrl={`${baseUrl}/kb/${article.slug}`}
       />
       <PublicNavigation />
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         <article className="container mx-auto max-w-3xl px-4 py-12 md:py-16">
           <Link
             to="/kb"

--- a/src/pages/KbLandingPage.tsx
+++ b/src/pages/KbLandingPage.tsx
@@ -20,7 +20,7 @@ export default function KbLandingPage() {
     <>
       <SeoHead title="Knowledge Base" description="Browse questions and answers." />
       <PublicNavigation />
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         <KbHubBlock data={{}} />
       </main>
       <PublicFooter />

--- a/src/pages/KnowledgeBasePage.tsx
+++ b/src/pages/KnowledgeBasePage.tsx
@@ -93,7 +93,7 @@ export default function KnowledgeBasePage() {
       />
       <PublicNavigation />
       
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         {/* Hero Section */}
         <section className="bg-gradient-to-b from-primary/5 to-background py-16 md:py-24">
           <div className="container max-w-4xl mx-auto px-4 text-center">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -43,7 +43,7 @@ const NotFoundBody = ({ routeError }: { routeError?: unknown }) => {
         <meta name="robots" content="noindex" />
       </Helmet>
       <PublicNavigation />
-      <main className="min-h-[60vh] bg-background flex items-center justify-center px-4 py-16">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-[60vh] bg-background flex items-center justify-center px-4 py-16">
         <div className="text-center max-w-lg space-y-6">
           <div className="mx-auto w-16 h-16 rounded-full bg-muted flex items-center justify-center">
             <AlertTriangle className="h-8 w-8 text-muted-foreground" />

--- a/src/pages/OrderTrackingPage.tsx
+++ b/src/pages/OrderTrackingPage.tsx
@@ -140,7 +140,7 @@ export default function OrderTrackingPage() {
 
       <PublicNavigation />
 
-      <main className="min-h-screen bg-background py-12 px-4">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background py-12 px-4">
         <div className="max-w-3xl mx-auto space-y-8">
           <div className="text-center space-y-2">
             <h1 className="text-3xl md:text-4xl font-serif font-bold">Track your order</h1>

--- a/src/pages/PreviewPage.tsx
+++ b/src/pages/PreviewPage.tsx
@@ -119,7 +119,7 @@ export default function PreviewPage() {
 
       <PublicNavigation />
       
-      <main className="min-h-screen">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen">
         {showTitle && (
           <div className="max-w-4xl mx-auto px-6 pt-12">
             <h1 

--- a/src/pages/PricingPage.tsx
+++ b/src/pages/PricingPage.tsx
@@ -72,7 +72,7 @@ export default function PricingPage() {
       
       <PublicNavigation />
       
-      <main className="min-h-screen bg-gradient-to-b from-background to-muted/30">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-gradient-to-b from-background to-muted/30">
         {/* Hero Section */}
         <section className="container mx-auto px-6 pt-20 pb-16 text-center">
           <Badge variant="secondary" className="mb-4">

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -179,7 +179,7 @@ export default function ProductDetailPage() {
 
       <PublicNavigation />
 
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         {/* Breadcrumb — minimal, Apple-style */}
         <div className="container mx-auto px-6 pt-6 pb-2">
           <nav className="flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/src/pages/PublicPage.tsx
+++ b/src/pages/PublicPage.tsx
@@ -455,7 +455,16 @@ export default function PublicPage() {
         )}
 
         {/* Content Blocks */}
-        <main>
+        {/* Overlay-headern tar ingen flödeshöjd. En sida vars FÖRSTA block är
+            full-bleed (hero/parallax/karusell) ska fortsätta upp bakom den —
+            det är overlay-designens poäng. Alla andra förstablock börjar
+            annars på y=0 under headern; de får headerns annonserade offset. */}
+        <main className={
+          ['hero', 'parallax-section', 'featured-carousel', 'marquee', 'announcement-bar']
+            .includes(pageData.content_json?.[0]?.type as string)
+            ? undefined
+            : 'pt-[var(--overlay-header-offset,0px)]'
+        }>
           {renderError ? (
             <div className="py-16 px-6">
               <div className="container mx-auto max-w-3xl text-center">

--- a/src/pages/ShopPage.tsx
+++ b/src/pages/ShopPage.tsx
@@ -59,7 +59,7 @@ export default function ShopPage() {
 
       <PublicNavigation />
 
-      <main className="min-h-screen bg-background">
+      <main className="pt-[var(--overlay-header-offset,0px)] min-h-screen bg-background">
         {/* Hero */}
         <section className="border-b bg-muted/30">
           <div className="container mx-auto px-6 py-16 text-center">


### PR DESCRIPTION
Headern annonserar uppmätt höjd som CSS-variabel i overlay-läge; 20 modulsidor + villkorad PublicPage konsumerar den. Pinnat med populationstest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)