### PR TITLE
feat(flowpilot): återkommande skill-fel blir lärdomar i agent_memory

### DIFF
--- a/src/lib/__tests__/skill-lessons.guardrails.test.ts
+++ b/src/lib/__tests__/skill-lessons.guardrails.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { recordSkillLesson } from '../../../supabase/functions/_shared/pilot/reason.ts';
+
+/**
+ * Fel som återkommer ska bli minnen (autoversio: write_blog_post failade
+ * identiskt i 5+ veckor utan att loopen lärde sig — Curator-gapet).
+ * Kontraktet: 1:a felet = brus (skriv inget), ≥2:a = lärdom i agent_memory
+ * som loadMemories lyfter in i nästa körnings systemprompt.
+ */
+function mockSupabase(failCount: number, existingLesson: boolean) {
+  const writes: any[] = [];
+  const chain = (table: string) => {
+    const q: any = {
+      select: vi.fn((_c?: any, opts?: any) => { q._count = opts?.count === 'exact'; return q; }),
+      eq: vi.fn(() => q), gte: vi.fn(() => q),
+      maybeSingle: vi.fn(async () => ({ data: existingLesson ? { id: 'x' } : null })),
+      update: vi.fn((v: any) => { writes.push({ table, op: 'update', v }); return q; }),
+      insert: vi.fn(async (v: any) => { writes.push({ table, op: 'insert', v }); return { data: null }; }),
+      then: undefined as any,
+    };
+    // count-frågan awaitar kedjan direkt
+    q.then = (resolve: any) => resolve({ count: failCount });
+    return q;
+  };
+  return { from: vi.fn((t: string) => chain(t)), writes };
+}
+
+describe('skill lessons', () => {
+  it('första felet skriver INGEN lärdom', async () => {
+    const sb = mockSupabase(0, false);
+    await recordSkillLesson(sb as any, 'write_blog_post', 'content is required');
+    expect(sb.writes).toEqual([]);
+  });
+
+  it('upprepat fel skriver lärdom med skillnamn, antal och felet', async () => {
+    const sb = mockSupabase(11, false);
+    await recordSkillLesson(sb as any, 'write_blog_post', 'content is required (markdown or plain text string)');
+    const ins = sb.writes.find(w => w.op === 'insert');
+    expect(ins?.table).toBe('agent_memory');
+    expect(ins?.v.key).toBe('skill_lesson:write_blog_post');
+    expect(ins?.v.category).toBe('skill_lessons');
+    expect(ins?.v.value).toContain('12x');
+    expect(ins?.v.value).toContain('content is required');
+    expect(ins?.v.value).toContain('Do NOT repeat');
+  });
+
+  it('befintlig lärdom uppdateras i stället för att dubbleras', async () => {
+    const sb = mockSupabase(3, true);
+    await recordSkillLesson(sb as any, 'send_newsletter', 'no recipients');
+    expect(sb.writes.some(w => w.op === 'update')).toBe(true);
+    expect(sb.writes.some(w => w.op === 'insert')).toBe(false);
+  });
+});

--- a/supabase/functions/_shared/pilot/reason.ts
+++ b/supabase/functions/_shared/pilot/reason.ts
@@ -879,11 +879,56 @@ export async function executeBuiltInTool(
   // Wrap with timeout (long-running skills get explicit overrides)
   try {
     const timeoutMs = getSkillTimeoutMs(fnName);
-    return await withTimeout(execute(), timeoutMs, fnName);
+    const result: any = await withTimeout(execute(), timeoutMs, fnName);
+    // Fel kan komma som returnerad data i två kuvert (direkt eller nästlat) —
+    // båda ska bli lärdomar, inte bara kastade undantag.
+    const returnedError = result && typeof result === 'object'
+      ? (result.error ?? result.result?.error ?? (result.status === 'failed' ? 'status: failed' : null))
+      : null;
+    if (returnedError) void recordSkillLesson(supabase, fnName, String(returnedError));
+    return result;
   } catch (err: any) {
     console.error(`[reason] trace=${traceId} ${fnName} error:`, err.message);
+    void recordSkillLesson(supabase, fnName, err.message);
     return { error: err.message, status: 'failed' };
   }
+}
+
+
+// ─── Skill Lessons: fel som återkommer blir minnen ───────────────────────────
+//
+// Observerat (autoversio, jul–aug 2026): heartbeaten anropade write_blog_post
+// utan content och fick EXAKT samma fel varje körning i fem veckor — ett
+// självförklarande felmeddelande som aldrig överlevde körningen. Loopen är
+// per-körning-statslös; lärdomen måste bo i agent_memory för att nå nästa
+// körnings systemprompt (loadMemories läser topp-20, kategori + 150 tecken).
+//
+// Tröskeln ≥2: engångsfel är brus, upprepning är ett mönster. Fire-and-forget:
+// en trasig lektionsskrivning får aldrig fälla skill-anropet den lär av.
+export async function recordSkillLesson(supabase: any, skillName: string, errorMsg: string): Promise<void> {
+  try {
+    const since = new Date(Date.now() - 30 * 24 * 3600 * 1000).toISOString();
+    const { count } = await supabase
+      .from('agent_activity')
+      .select('id', { count: 'exact', head: true })
+      .eq('skill_name', skillName)
+      .eq('status', 'failed')
+      .gte('created_at', since);
+    const total = (count ?? 0) + 1; // + det pågående felet, som loggas efter oss
+    if (total < 2) return;
+    const key = `skill_lesson:${skillName}`;
+    const value = `${skillName} has failed ${total}x in 30d, latest: "${errorMsg.slice(0, 90)}". Do NOT repeat the same call shape — change arguments/approach or skip with a reason.`;
+    const { data: existing } = await supabase
+      .from('agent_memory').select('id').eq('key', key).maybeSingle();
+    if (existing) {
+      await supabase.from('agent_memory')
+        .update({ value, category: 'skill_lessons', updated_at: new Date().toISOString() })
+        .eq('id', existing.id);
+    } else {
+      await supabase.from('agent_memory')
+        .insert({ key, value, category: 'skill_lessons' });
+    }
+  } catch { /* aldrig fälla anropet vi lär av */ }
 }
 
 export function isBuiltInTool(name: string): boolean {

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2103,7 +2103,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:90cc8d04f1638cd5ee4da52f124907a4bea438a94955f2e85352a6943fc4924b",
+      "shared_hash": "sha256:f2dcb599f88ddac82765d3827525fdfb0f3a3b602db02bd74a85a3b919d31d01",
       "functions": {
         "a2a": "sha256:33f9aa45f5a82d23f357aff397403b5b12a94dc3421984a1c883f23509c50f71",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",


### PR DESCRIPTION
Cross-run-lärande: ≥2 identiska skill-fel på 30 dagar → skill_lesson-minne som når nästa körnings systemprompt via loadMemories. Fem veckors identiska write_blog_post-fel på autoversio var beviset. Kontraktstestat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)