### PR TITLE
feat(bi): BI-editorn i sju flikar + Agent view på prompt-kompilatorns räls

### DIFF
--- a/src/hooks/useCompanyInsights.ts
+++ b/src/hooks/useCompanyInsights.ts
@@ -57,6 +57,23 @@ export interface CompanyProfile {
   financial_health: string;
   founded_year: string;
   legal_name: string;
+  // The register fields agents and enrichment write via update_company_profile's
+  // shallow merge. Stored and read by prompts long before they had an editor —
+  // load-bearing, invisible, uncorrectable (the tagline class). Now editable.
+  ceo: string;
+  website: string;
+  linkedin: string;
+  tagline_en: string;
+  city: string;
+  postal_code: string;
+  country: string;
+  legal_form: string;
+  vat_number: string;
+  share_capital: string;
+  /** Registration date at the companies office (YYYY-MM-DD). */
+  registered: string;
+  /** When the current company name was adopted (YYYY-MM-DD). */
+  name_adopted: string;
   // Enrichment metadata
   enrichment_log: EnrichmentEntry[];
 }
@@ -98,6 +115,18 @@ export const defaultProfile: CompanyProfile = {
   financial_health: "",
   founded_year: "",
   legal_name: "",
+  ceo: "",
+  website: "",
+  linkedin: "",
+  tagline_en: "",
+  city: "",
+  postal_code: "",
+  country: "",
+  legal_form: "",
+  vat_number: "",
+  share_capital: "",
+  registered: "",
+  name_adopted: "",
   enrichment_log: [],
 };
 

--- a/src/pages/admin/CompanyInsightsPage.tsx
+++ b/src/pages/admin/CompanyInsightsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { AdminLayout } from "@/components/admin/AdminLayout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -7,8 +8,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Building2, Save, Loader2, Plus, X, Globe, Sparkles, TrendingUp, Users, History, ShieldCheck, Info, Hash, MousePointerClick, Quote } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
+import { Building2, Save, Loader2, Plus, X, Globe, Sparkles, TrendingUp, Users, History, ShieldCheck, Hash, MousePointerClick, Quote, Package, ScrollText, Landmark, Bot } from "lucide-react";
+import { composeIdentityBlock, type IdentityDepth } from "../../../supabase/functions/_shared/domains/business-identity-block";
 import {
   useCompanyInsights,
   type CompanyProfile,
@@ -35,10 +37,6 @@ export default function CompanyInsightsPage() {
   };
 
   const handleSave = () => {
-    if (!p.company_name?.trim()) {
-      // Allow save but warn
-      // toast.warning("Consider adding a company name");
-    }
     save(p);
     setLocal(null);
   };
@@ -114,22 +112,31 @@ export default function CompanyInsightsPage() {
         </div>
 
         <Tabs defaultValue="identity" className="space-y-4">
-          <TabsList>
+          <TabsList className="flex-wrap h-auto">
             <TabsTrigger value="identity" className="gap-1.5">
               <Building2 className="h-3.5 w-3.5" /> Identity
+            </TabsTrigger>
+            <TabsTrigger value="offering" className="gap-1.5">
+              <Package className="h-3.5 w-3.5" /> Offering
+            </TabsTrigger>
+            <TabsTrigger value="voice" className="gap-1.5">
+              <ScrollText className="h-3.5 w-3.5" /> Voice & Rules
             </TabsTrigger>
             <TabsTrigger value="market" className="gap-1.5">
               <TrendingUp className="h-3.5 w-3.5" /> Market
             </TabsTrigger>
-            <TabsTrigger value="financials" className="gap-1.5">
-              <Users className="h-3.5 w-3.5" /> Financials
+            <TabsTrigger value="facts" className="gap-1.5">
+              <Landmark className="h-3.5 w-3.5" /> Company Facts
+            </TabsTrigger>
+            <TabsTrigger value="agent" className="gap-1.5">
+              <Bot className="h-3.5 w-3.5" /> Agent view
             </TabsTrigger>
             <TabsTrigger value="enrichment" className="gap-1.5">
               <History className="h-3.5 w-3.5" /> Enrichment
             </TabsTrigger>
           </TabsList>
 
-          {/* Identity Tab */}
+          {/* Identity Tab — who the company is, in its own words */}
           <TabsContent value="identity">
             <div className="grid gap-4 md:grid-cols-2">
               <Card>
@@ -143,14 +150,29 @@ export default function CompanyInsightsPage() {
                       shallow-merges any key) and read by every prompt long before they had a
                       field here — load-bearing, invisible, uncorrectable. Now editable. */}
                   <Field label="Tagline" value={p.tagline} onChange={v => update("tagline", v)} placeholder="One line under the name — the shortest true sentence about you" />
+                  <Field label="Tagline (English)" value={p.tagline_en} onChange={v => update("tagline_en", v)} placeholder="The same line for English surfaces, if it differs" />
                   <Field label="Industry" value={p.industry} onChange={v => update("industry", v)} placeholder="Digital Agency, SaaS..." />
                   <Field label="Domain" value={p.domain} onChange={v => update("domain", v)} placeholder="yourcompany.com" />
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-base">The Story</CardTitle>
+                  <CardDescription>The prose a page author writes from</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
                   <FieldArea label="About Us" value={p.about_us} onChange={v => update("about_us", v)} placeholder="Brief company description..." rows={3} />
                   <FieldArea label="Business Purpose" value={p.business_purpose} onChange={v => update("business_purpose", v)} placeholder="Why the company exists — the reason behind the offering, not the offering itself." rows={2} />
                   <FieldArea label="Value Proposition" value={p.value_proposition} onChange={v => update("value_proposition", v)} placeholder="What unique value do you deliver?" rows={2} />
                 </CardContent>
               </Card>
+            </div>
+          </TabsContent>
 
+          {/* Offering Tab — what a page-authoring agent spends */}
+          <TabsContent value="offering">
+            <div className="grid gap-4 md:grid-cols-2">
               <Card>
                 <CardHeader className="pb-3">
                   <CardTitle className="text-base">Services & Offerings</CardTitle>
@@ -178,72 +200,70 @@ export default function CompanyInsightsPage() {
                 </CardContent>
               </Card>
 
-              {/* Numbers as numbers. delivered_value is prose; a stats block needs
-                  {value, label} pairs, and a model asked to parse metrics out of a
-                  sentence is a model one step from inventing them. */}
-              <Card>
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-base flex items-center gap-2">
-                    <Hash className="h-4 w-4" /> Proof points
-                  </CardTitle>
-                  <CardDescription>
-                    The figures you stand behind, held as figures. Everything generated may quote these — and nothing else — as numbers.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <ProofPointEditor points={p.proof_points || []} onChange={v => update("proof_points", v)} />
-                </CardContent>
-              </Card>
+              <div className="space-y-4">
+                {/* Numbers as numbers. delivered_value is prose; a stats block needs
+                    {value, label} pairs, and a model asked to parse metrics out of a
+                    sentence is a model one step from inventing them. */}
+                <Card>
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-base flex items-center gap-2">
+                      <Hash className="h-4 w-4" /> Proof points
+                    </CardTitle>
+                    <CardDescription>
+                      The figures you stand behind, held as figures. Everything generated may quote these — and nothing else — as numbers.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <ProofPointEditor points={p.proof_points || []} onChange={v => update("proof_points", v)} />
+                  </CardContent>
+                </Card>
 
-              {/* Nothing in the profile said what the visitor should DO. A landing
-                  page without an ask is not a landing page. */}
-              <Card>
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-base flex items-center gap-2">
-                    <MousePointerClick className="h-4 w-4" /> Primary call to action
-                  </CardTitle>
-                  <CardDescription>
-                    The one thing a visitor should do. Generated pages end here.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <Field
-                    label="Button label"
-                    value={p.primary_cta?.label || ""}
-                    onChange={v => update("primary_cta", ctaWith(p.primary_cta, { label: v }))}
-                    placeholder="Book a scoping call"
-                  />
-                  <Field
-                    label="Destination"
-                    value={p.primary_cta?.destination || ""}
-                    onChange={v => update("primary_cta", ctaWith(p.primary_cta, { destination: v }))}
-                    placeholder="/kontakt · https://cal.com/… · mailto:sales@…"
-                  />
-                  <FieldArea
-                    label="What it is for"
-                    value={p.primary_cta?.intent || ""}
-                    onChange={v => update("primary_cta", ctaWith(p.primary_cta, { intent: v }))}
-                    placeholder="A 30-minute scoping call — no preparation needed, we bring the questions."
-                    rows={2}
-                  />
-                  {!p.primary_cta?.label && (
-                    <p className="text-xs text-muted-foreground">
-                      Without a label there is no CTA to render — generated pages will end without an ask.
-                    </p>
-                  )}
-                </CardContent>
-              </Card>
+                {/* Nothing in the profile said what the visitor should DO. A landing
+                    page without an ask is not a landing page. */}
+                <Card>
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-base flex items-center gap-2">
+                      <MousePointerClick className="h-4 w-4" /> Primary call to action
+                    </CardTitle>
+                    <CardDescription>
+                      The one thing a visitor should do. Generated pages end here.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <Field
+                      label="Button label"
+                      value={p.primary_cta?.label || ""}
+                      onChange={v => update("primary_cta", ctaWith(p.primary_cta, { label: v }))}
+                      placeholder="Book a scoping call"
+                    />
+                    <Field
+                      label="Destination"
+                      value={p.primary_cta?.destination || ""}
+                      onChange={v => update("primary_cta", ctaWith(p.primary_cta, { destination: v }))}
+                      placeholder="/kontakt · https://cal.com/… · mailto:sales@…"
+                    />
+                    <FieldArea
+                      label="What it is for"
+                      value={p.primary_cta?.intent || ""}
+                      onChange={v => update("primary_cta", ctaWith(p.primary_cta, { intent: v }))}
+                      placeholder="A 30-minute scoping call — no preparation needed, we bring the questions."
+                      rows={2}
+                    />
+                    {!p.primary_cta?.label && (
+                      <p className="text-xs text-muted-foreground">
+                        Without a label there is no CTA to render — generated pages will end without an ask.
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
 
               <Card className="md:col-span-2">
                 <CardHeader className="pb-3">
-                  <CardTitle className="text-base">Contact & References</CardTitle>
+                  <CardTitle className="text-base">References</CardTitle>
+                  <CardDescription>Who vouches for you — names and their words</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                  <div className="grid gap-3 sm:grid-cols-3">
-                    <Field label="Email" value={p.contact_email} onChange={v => update("contact_email", v)} placeholder="info@company.com" />
-                    <Field label="Phone" value={p.contact_phone} onChange={v => update("contact_phone", v)} placeholder="+46 8 123 45 67" />
-                    <Field label="Address" value={p.address} onChange={v => update("address", v)} placeholder="Street, City" />
-                  </div>
                   <Field label="Notable Clients" value={p.clients} onChange={v => update("clients", v)} placeholder="Volvo, IKEA, Spotify..." />
                   {/* One blob renders as a paragraph. A testimonial block needs the
                       quote AND who said it — an unattributed quote is honest, a
@@ -252,6 +272,37 @@ export default function CompanyInsightsPage() {
                 </CardContent>
               </Card>
             </div>
+          </TabsContent>
+
+          {/* Voice & Rules Tab — not facts about the company but rules about
+              how every outward AI surface may speak for it. Injected into the
+              always-on identity block; the stance overrides briefs. They lived
+              under Market, where nobody looked for them. */}
+          <TabsContent value="voice">
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base">Editorial rules</CardTitle>
+                <CardDescription>
+                  How every AI surface speaks for this company — chat, campaigns, letters. Rules, not facts. Both are injected into every outward prompt and override campaign briefs.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <FieldArea
+                  label="Claim stance — HOW claims are made"
+                  value={p.claim_stance}
+                  onChange={v => update("claim_stance", v)}
+                  placeholder={'e.g. "We describe what our services do, precisely enough for the customer and their advisers to assess. We never interpret what regulations require of a specific organization, and never imply that buying us makes anyone compliant."'}
+                  rows={5}
+                />
+                <FieldArea
+                  label="Answered by a person, not here"
+                  value={p.boundaries}
+                  onChange={v => update("boundaries", v)}
+                  placeholder={'Topics the site, chat and generated copy must route to a human — e.g. network routes, ownership, named competitors. Legitimate questions, wrong channel: say so and point to contact.'}
+                  rows={8}
+                />
+              </CardContent>
+            </Card>
           </TabsContent>
 
           {/* Market Tab */}
@@ -268,38 +319,10 @@ export default function CompanyInsightsPage() {
                 </CardContent>
               </Card>
 
-              {/* Editorial rules — not facts about the company but rules about
-                  how every outward AI surface may speak for it. Injected into
-                  the always-on identity block; the stance overrides briefs. */}
-              <Card>
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-base">Editorial rules</CardTitle>
-                  <CardDescription>
-                    How every AI surface speaks for this company — chat, campaigns, letters. Rules, not facts.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <FieldArea
-                    label="Claim stance — HOW claims are made"
-                    value={p.claim_stance}
-                    onChange={v => update("claim_stance", v)}
-                    placeholder={'e.g. "We describe what our services do, precisely enough for the customer and their advisers to assess. We never interpret what regulations require of a specific organization, and never imply that buying us makes anyone compliant."'}
-                    rows={4}
-                  />
-                  <FieldArea
-                    label="Answered by a person, not here"
-                    value={p.boundaries}
-                    onChange={v => update("boundaries", v)}
-                    placeholder={'Topics the site, chat and generated copy must route to a human — e.g. network routes, ownership, named competitors. Legitimate questions, wrong channel: say so and point to contact.'}
-                    rows={4}
-                  />
-                </CardContent>
-              </Card>
-
               <Card>
                 <CardHeader className="pb-3">
                   <CardTitle className="text-base">Competitive Intelligence</CardTitle>
-                  <CardDescription>Competitors and pricing strategy</CardDescription>
+                  <CardDescription>Competitors and pricing strategy — internal, never emitted into prompts</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <Field label="Competitors" value={p.competitors} onChange={v => update("competitors", v)} placeholder="Competitor A, Competitor B..." />
@@ -309,8 +332,12 @@ export default function CompanyInsightsPage() {
             </div>
           </TabsContent>
 
-          {/* Financials Tab */}
-          <TabsContent value="financials">
+          {/* Company Facts Tab — the register: facts about the legal entity, not
+              the identity that writes. Deliberately kept OUT of the prompt block
+              (invoices and contracts read them where they belong). Several of
+              these fields were written by agents and read by documents long
+              before they had an editor. */}
+          <TabsContent value="facts">
             <div className="grid gap-4 md:grid-cols-2">
               <Card>
                 <CardHeader className="pb-3">
@@ -319,24 +346,60 @@ export default function CompanyInsightsPage() {
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <Field label="Legal Name" value={p.legal_name} onChange={v => update("legal_name", v)} placeholder="Acme Consulting AB" />
-                  <Field label="Org Number" value={p.org_number} onChange={v => update("org_number", v)} placeholder="556XXX-XXXX" />
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <Field label="Org Number" value={p.org_number} onChange={v => update("org_number", v)} placeholder="556XXX-XXXX" />
+                    <Field label="VAT Number" value={p.vat_number} onChange={v => update("vat_number", v)} placeholder="SE556XXXXXXX01" />
+                    <Field label="Legal Form" value={p.legal_form} onChange={v => update("legal_form", v)} placeholder="Aktiebolag" />
+                    <Field label="Share Capital" value={p.share_capital} onChange={v => update("share_capital", v)} placeholder="25 000 kr" />
+                    <Field label="Registered" value={p.registered} onChange={v => update("registered", v)} placeholder="2015-01-31" />
+                    <Field label="Name Adopted" value={p.name_adopted} onChange={v => update("name_adopted", v)} placeholder="2015-01-31" />
+                  </div>
                   <Field label="Founded Year" value={p.founded_year} onChange={v => update("founded_year", v)} placeholder="2015" />
                 </CardContent>
               </Card>
 
               <Card>
                 <CardHeader className="pb-3">
-                  <CardTitle className="text-base">Financial Overview</CardTitle>
-                  <CardDescription>Revenue, employees, and financial health</CardDescription>
+                  <CardTitle className="text-base">People & Finance</CardTitle>
+                  <CardDescription>Leadership, size and financial standing</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <Field label="CEO" value={p.ceo} onChange={v => update("ceo", v)} placeholder="Firstname Lastname" />
+                    <Field label="Employees" value={p.employees} onChange={v => update("employees", v)} placeholder="25" />
+                  </div>
                   <Field label="Revenue" value={p.revenue} onChange={v => update("revenue", v)} placeholder="10 MSEK" />
-                  <Field label="Employees" value={p.employees} onChange={v => update("employees", v)} placeholder="25" />
                   <FieldArea label="Financial Health" value={p.financial_health} onChange={v => update("financial_health", v)} placeholder="Summary of financial standing..." rows={2} />
                   <TagEditor label="Board Members" tags={p.board_members || []} onChange={v => update("board_members", v)} placeholder="Add board member..." />
                 </CardContent>
               </Card>
+
+              <Card className="md:col-span-2">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-base">Contact & Location</CardTitle>
+                  <CardDescription>Routing data — owned by footers, signatures and the email shell, never emitted into prompt copy</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <Field label="Email" value={p.contact_email} onChange={v => update("contact_email", v)} placeholder="info@company.com" />
+                    <Field label="Phone" value={p.contact_phone} onChange={v => update("contact_phone", v)} placeholder="+46 8 123 45 67" />
+                    <Field label="Address" value={p.address} onChange={v => update("address", v)} placeholder="Street" />
+                    <Field label="City" value={p.city} onChange={v => update("city", v)} placeholder="Stockholm" />
+                    <Field label="Postal Code" value={p.postal_code} onChange={v => update("postal_code", v)} placeholder="111 22" />
+                    <Field label="Country" value={p.country} onChange={v => update("country", v)} placeholder="Sverige" />
+                    <Field label="Website" value={p.website} onChange={v => update("website", v)} placeholder="https://yourcompany.com" />
+                    <Field label="LinkedIn" value={p.linkedin} onChange={v => update("linkedin", v)} placeholder="https://linkedin.com/company/…" />
+                  </div>
+                </CardContent>
+              </Card>
             </div>
+          </TabsContent>
+
+          {/* Agent view Tab — the compiled identity block, from the SAME function
+              the prompts use. Provenance instead of a manual: an empty field is
+              a visible hole here, not a surprise downstream. */}
+          <TabsContent value="agent">
+            <AgentViewCard profile={p} isDirty={isDirty} />
           </TabsContent>
 
           {/* Enrichment Tab */}
@@ -451,6 +514,105 @@ export default function CompanyInsightsPage() {
         </div>
       </div>
     </AdminLayout>
+  );
+}
+
+/**
+ * The compiled identity block, produced by the SAME composeIdentityBlock the
+ * prompts run — imported from the edge-function module, not re-implemented.
+ * Shows the CURRENT editor state including unsaved edits, so "what happens if
+ * I fill this in" is answered by looking, not by saving and asking the chat.
+ */
+function AgentViewCard({ profile, isDirty }: { profile: CompanyProfile; isDirty: boolean }) {
+  const [depth, setDepth] = useState<IdentityDepth>("core");
+
+  // brand_tone rides in the same block but is edited elsewhere (branding).
+  const { data: brandTone } = useQuery({
+    queryKey: ["site-settings", "brand_tone"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("site_settings")
+        .select("value")
+        .eq("key", "brand_tone")
+        .maybeSingle();
+      if (error) throw error;
+      return data?.value ?? null;
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const preview = useMemo(
+    () =>
+      composeIdentityBlock(
+        {
+          company_profile: profile as unknown as Record<string, unknown>,
+          ...(brandTone != null ? { brand_tone: brandTone } : {}),
+        },
+        depth,
+      ),
+    [profile, brandTone, depth],
+  );
+
+  const approxTokens = Math.round(preview.block.length / 4);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Bot className="h-4 w-4" /> What the agent sees
+            </CardTitle>
+            <CardDescription>
+              The identity block exactly as it is injected into prompts — compiled by the same code, from the values on this page{isDirty ? ", including your unsaved edits" : ""}.
+            </CardDescription>
+          </div>
+          <div className="flex rounded-lg border p-0.5 shrink-0">
+            <Button
+              variant={depth === "core" ? "secondary" : "ghost"}
+              size="sm"
+              className="h-7 px-3 text-xs"
+              onClick={() => setDepth("core")}
+            >
+              Core
+            </Button>
+            <Button
+              variant={depth === "narrative" ? "secondary" : "ghost"}
+              size="sm"
+              className="h-7 px-3 text-xs"
+              onClick={() => setDepth("narrative")}
+            >
+              Narrative
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs text-muted-foreground">
+          {depth === "core"
+            ? "Core is always-on: every public chat turn, every workspace turn, every heartbeat iteration carries this."
+            : "Narrative is what a page or campaign author receives — the material a writer spends, on top of core."}
+        </p>
+        {preview.block ? (
+          <>
+            <pre className="whitespace-pre-wrap rounded-lg border bg-muted/40 p-4 text-xs leading-relaxed font-mono overflow-x-auto">
+              {preview.block.trim()}
+            </pre>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="outline" className="text-xs">~{approxTokens} tokens</Badge>
+              <Badge variant="outline" className="text-xs">{preview.fields.length} fields emitted</Badge>
+              <p className="text-xs text-muted-foreground">
+                Empty fields are omitted entirely — a hole here is a hole in every generated page and chat answer.
+              </p>
+            </div>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground py-6 text-center">
+            Nothing to emit yet — the profile is empty, so prompts run without an identity. Fill in Identity and Offering and watch this build up.
+          </p>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/supabase/functions/_shared/domains/business-identity-block.ts
+++ b/supabase/functions/_shared/domains/business-identity-block.ts
@@ -338,6 +338,20 @@ export async function loadBusinessIdentity(
 
   const map: Record<string, unknown> = {};
   for (const row of raw) map[row.key] = row.value;
+  return composeIdentityBlock(map, depth);
+}
+
+/**
+ * The pure half of loadBusinessIdentity: settings values in, prompt block out.
+ * No I/O, no Deno — importable by the admin editor, whose "what the agent
+ * sees" preview must be THIS function, not a client-side re-implementation
+ * that drifts. `map` holds the raw site_settings values keyed by settings key
+ * (`company_profile`, `brand_tone`).
+ */
+export function composeIdentityBlock(
+  map: Record<string, unknown>,
+  depth: IdentityDepth = 'core',
+): BusinessIdentity {
   const cp = (map.company_profile && typeof map.company_profile === 'object' && !Array.isArray(map.company_profile)
     ? map.company_profile
     : {}) as Record<string, unknown>;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2107,7 +2107,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:cd6cd38c7cf50a5c5af62919440de80b9f0cd8997c7bc93b0107a12a538910a6",
+      "shared_hash": "sha256:6ecab5110a7352a37470d69db15d334588d861ce1b19989b7f773a183ea10f64",
       "functions": {
         "a2a": "sha256:33f9aa45f5a82d23f357aff397403b5b12a94dc3421984a1c883f23509c50f71",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",


### PR DESCRIPTION
## Vad

Business Identity-editorn omstrukturerad efter v4-arbetet på optic:

| Flik | Innehåll |
|---|---|
| Identity | namn, taglines, bransch, domän, story-prosan |
| Offering | services, differentiators, proof points, CTA, referenser |
| Voice & Rules | claim stance + boundaries — flyttade ut ur Market |
| Market | ICP, industries, competitors, pricing |
| Company Facts | registrering + finans + kontakt/plats, inkl. 12 tidigare osynliga fält |
| **Agent view** | **det kompilerade identitetsblocket, core/narrative** |
| Enrichment | oförändrad |

## Varför

- `claim_stance`/`boundaries` styr varje AI-yta men låg gömda under Market.
- 12 fält (ceo, website, linkedin, tagline_en, city, legal_form, vat_number, …) skrivs av agenter och läses av prompter men hade ingen editor — tagline-klassen igen.
- Agent view: `composeIdentityBlock` extraherad som ren funktion ur `loadBusinessIdentity` och importerad av editorn — förhandsvisningen ÄR promptens kompilator, ingen klientkopia som driver. Osparade ändringar syns live.

## Verifierat

- tsc (CI-configen), produktionsbygge (cross-boundary-importen bundlar), full vitest 3383 gröna (manifestet omgenererat), lint-baslinjen oförändrad på berörda filer.
- Guardrail-sviten för identitetsprojektionen (58 test) går via samma import som editorn nu använder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)