### PR TITLE
fix(auth): delade djuplänkar överlever inloggningsväggen

### DIFF
--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -55,9 +55,15 @@ export function AdminLayout({ children }: AdminLayoutProps) {
 
   useEffect(() => {
     if (!loading && !user) {
-      navigate('/auth');
+      // Carry the intended destination through the sign-in detour, so a shared
+      // deep link (a wiki page, a KB article draft, a specific record) lands on
+      // the page that was shared — not on the dashboard. Links people share in
+      // chat only build a habit if they survive the login wall.
+      navigate('/auth', {
+        state: { from: location.pathname + location.search + location.hash },
+      });
     }
-  }, [loading, user, navigate]);
+  }, [loading, user, navigate, location]);
 
   if (loading) {
     return (

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 import { useBrandingSettings } from '@/hooks/useSiteSettings';
 import { supabase } from '@/integrations/supabase/client';
@@ -49,16 +49,26 @@ export default function AuthPage() {
   
   const { signIn, signUp, user } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const { toast } = useToast();
   const { data: branding } = useBrandingSettings();
-  
+
   // Get admin name from branding settings, fallback to generic
   const adminName = branding?.adminName || 'CMS';
   const logoInitial = adminName.charAt(0).toUpperCase();
 
+  // Where to land after sign-in: the page that sent us here (a shared deep
+  // link kept alive by AdminLayout), or the dashboard. Internal paths only —
+  // a state value that doesn't start with a single '/' is ignored.
+  const rawFrom = (location.state as { from?: unknown } | null)?.from;
+  const returnTo =
+    typeof rawFrom === 'string' && rawFrom.startsWith('/') && !rawFrom.startsWith('//')
+      ? rawFrom
+      : '/admin';
+
   // Redirect if already logged in
   if (user) {
-    navigate('/admin');
+    navigate(returnTo);
     return null;
   }
 
@@ -88,7 +98,7 @@ export default function AuthPage() {
         variant: 'destructive',
       });
     } else {
-      navigate('/admin');
+      navigate(returnTo);
     }
   };
 
@@ -127,7 +137,7 @@ export default function AuthPage() {
         title: 'Account created!',
         description: 'You can now log in with your credentials.',
       });
-      navigate('/admin');
+      navigate(returnTo);
     }
   };
 


### PR DESCRIPTION
## Vad

En delad admin-djuplänk (wiki-sida, KB-artikel, specifik post) som möter inloggningsväggen landar nu på den delade sidan efter inloggning — inte på dashboarden.

- `AdminLayout`: skickar `{ state: { from: pathname+search+hash } }` med till `/auth`
- `AuthPage`: navigerar till `state.from` efter inloggning (och för redan inloggade); endast interna sökvägar (`/`-prefix, ej `//`) accepteras — ingen öppen redirect

## Varför

Kunskapsdelning via wiki-/KB-länkar i chatt bygger bara vana om länkarna fungerar. I dag tappas målet vid inloggning och mottagaren ger upp — tillbaka till dokumentbilagor i WhatsApp.

## Verifierat

tsc (CI-config), full vitest 3382 gröna, lint-baslinjen oförändrad (enda felet är förexisterande `any`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)