### PR TITLE
fix(crm): statusväljaren följer tratten — prospect · lead · opportunity · customer

### DIFF
--- a/src/hooks/usePipelineStages.ts
+++ b/src/hooks/usePipelineStages.ts
@@ -61,3 +61,37 @@ export function getStageColor(stage: PipelineStage, index: number): string {
   if (stage.is_lost) return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300';
   return STAGE_COLOR_CYCLE[index % STAGE_COLOR_CYCLE.length];
 }
+
+/**
+ * The contact funnel as ONE list — prospect → lead → opportunity → customer
+ * (+ lost), for every status dropdown on the contact surfaces.
+ *
+ * Same one-truth rule as deal stages: the options come from the configured
+ * `pipeline_stages` rows, so a stage an admin renames, adds or deactivates
+ * changes the kanban columns AND the dropdowns together. The hardcoded list
+ * below is a pre-load fallback mirroring the seed, never a second truth.
+ *
+ * `prospect` is prepended rather than configured: prospecting finds live
+ * OUTSIDE the pipeline by design (they carry no stage_id — see the Prospects
+ * triage tab), but a human still has to be able to read the status on a record
+ * and send one back to triage. A dropdown missing the record's own status
+ * renders an EMPTY trigger, which is how this surfaced (Magnus, 2026-08-29).
+ */
+export const PROSPECT_STATUS_OPTION = { key: 'prospect', name: 'Prospect' };
+
+const LEAD_STAGE_FALLBACK = [
+  { key: 'lead', name: 'Lead' },
+  { key: 'opportunity', name: 'Opportunity' },
+  { key: 'customer', name: 'Customer' },
+  { key: 'lost', name: 'Lost' },
+];
+
+export function useLeadStatusOptions(opts?: { includeProspect?: boolean }): Array<{ key: string; name: string }> {
+  const { data: stages = [] } = usePipelineStages('lead');
+  const configured = stages.length
+    ? stages.map((s) => ({ key: s.key, name: s.name }))
+    : LEAD_STAGE_FALLBACK;
+  return opts?.includeProspect === false
+    ? configured
+    : [PROSPECT_STATUS_OPTION, ...configured];
+}

--- a/src/lib/__tests__/pipeline-stages-one-truth.guardrails.test.ts
+++ b/src/lib/__tests__/pipeline-stages-one-truth.guardrails.test.ts
@@ -97,3 +97,54 @@ describe('the admin can FIND the config from where the work happens', () => {
     expect(ticketsKanban).toMatch(/\?entity=ticket/);
   });
 });
+
+// ─── Samma regel på kontaktsidan (Magnus 2026-08-29) ────────────────────────
+//
+// Fyndet: statusväljaren på kontaktdetaljsidan hårdkodade fyra alternativ och
+// saknade 'prospect' — ett prospekt öppnat ur triagefliken visade en TOM
+// statusruta, och etiketten sa "Contact" där resten av produkten sa "Lead".
+// Exakt deals-klassen från 2026-08-08, en yta bort.
+
+describe('kontaktens statusväljare följer den konfigurerade tratten', () => {
+  const leadDetail = readFileSync(
+    resolve(__dirname, '../../../src/pages/admin/LeadDetailPage.tsx'), 'utf-8');
+  const leadsPage = readFileSync(
+    resolve(__dirname, '../../../src/pages/admin/LeadsPage.tsx'), 'utf-8');
+  const stagesHook = readFileSync(
+    resolve(__dirname, '../../../src/hooks/usePipelineStages.ts'), 'utf-8');
+  const leadUtils = readFileSync(
+    resolve(__dirname, '../../../src/lib/lead-utils.ts'), 'utf-8');
+
+  it('detaljsidan renderar alternativen ur useLeadStatusOptions, inte ur en egen lista', () => {
+    expect(leadDetail).toMatch(/useLeadStatusOptions\(\)/);
+    expect(leadDetail).toMatch(/statusOptions\.map\(\(o\) => \(/);
+    expect(leadDetail).not.toMatch(/<SelectItem value="lead">Contact<\/SelectItem>/);
+    expect(leadDetail).not.toMatch(/<SelectItem value="opportunity">/);
+  });
+
+  it('listans filter OCH bulkväljare läser samma lista', () => {
+    expect(leadsPage).toMatch(/useLeadStatusOptions\(\)/);
+    // Två dropdowns, samma källa — ingen får återfalla i egna SelectItems.
+    expect(leadsPage.match(/statusOptions\.map\(\(o\) => \(/g)?.length).toBe(2);
+    expect(leadsPage).not.toMatch(/<SelectItem value="opportunity">/);
+    expect(leadsPage).not.toMatch(/<SelectItem value="customer">/);
+  });
+
+  it("'prospect' ligger först och kommer aldrig ur pipelinekonfigurationen", () => {
+    // Prospekt lever utanför pipelinen (inget stage_id) men MÅSTE gå att läsa
+    // och sätta — en väljare utan postens egen status renderar tom ruta.
+    expect(stagesHook).toMatch(/PROSPECT_STATUS_OPTION = \{ key: 'prospect'/);
+    expect(stagesHook).toMatch(/\[PROSPECT_STATUS_OPTION, \.\.\.configured\]/);
+  });
+
+  it('fallbacken speglar enum-tratten tills konfigurationen laddat (Law 4)', () => {
+    expect(stagesHook).toMatch(/usePipelineStages\('lead'\)/);
+    expect(stagesHook).toMatch(/LEAD_STAGE_FALLBACK[\s\S]{0,200}'opportunity'[\s\S]{0,120}'customer'/);
+  });
+
+  it("badge-etiketten säger 'Lead', inte 'Contact' — samma ord som tratten", () => {
+    expect(leadUtils).toMatch(/prospect: \{ label: 'Prospect'/);
+    expect(leadUtils).toMatch(/lead: \{ label: 'Lead'/);
+    expect(leadUtils).not.toMatch(/lead: \{ label: 'Contact'/);
+  });
+});

--- a/src/lib/lead-utils.ts
+++ b/src/lib/lead-utils.ts
@@ -703,7 +703,7 @@ export async function qualifyLead(leadId: string): Promise<void> {
 export function getLeadStatusInfo(status: LeadStatus): { label: string; color: string } {
   const statusMap: Record<LeadStatus, { label: string; color: string }> = {
     prospect: { label: 'Prospect', color: 'bg-slate-500' },
-    lead: { label: 'Contact', color: 'bg-blue-500' },
+    lead: { label: 'Lead', color: 'bg-blue-500' },
     opportunity: { label: 'Opportunity', color: 'bg-amber-500' },
     customer: { label: 'Customer', color: 'bg-green-500' },
     lost: { label: 'Lost', color: 'bg-gray-500' },

--- a/src/pages/admin/LeadDetailPage.tsx
+++ b/src/pages/admin/LeadDetailPage.tsx
@@ -17,6 +17,7 @@ import { useLead, useLeadActivities, useUpdateLead, useQualifyLead, useDeleteLea
 import { useCompanies, useCreateCompany } from '@/hooks/useCompanies';
 import { useAddLeadActivity, type ActivityType } from '@/hooks/useActivities';
 import { getLeadStatusInfo, type LeadStatus } from '@/lib/lead-utils';
+import { useLeadStatusOptions } from '@/hooks/usePipelineStages';
 import { DealSection } from '@/components/admin/DealSection';
 import { RecordDiscussPanel } from '@/components/admin/crm/RecordDiscussPanel';
 import { LeadProcessFlow } from '@/components/admin/crm/LeadProcessFlow';
@@ -75,6 +76,9 @@ export default function LeadDetailPage() {
   const [showEnrichedFields, setShowEnrichedFields] = useState(false);
   const [showEmailDialog, setShowEmailDialog] = useState(false);
   const [showLostDialog, setShowLostDialog] = useState(false);
+  // Above the loading/not-found returns: hooks must run in the same order every
+  // render, and the early returns below are exactly the trap.
+  const statusOptions = useLeadStatusOptions();
 
   if (isLoading) {
     return (
@@ -230,10 +234,13 @@ export default function LeadDetailPage() {
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="lead">Contact</SelectItem>
-                      <SelectItem value="opportunity">Opportunity</SelectItem>
-                      <SelectItem value="customer">Customer</SelectItem>
-                      <SelectItem value="lost">Lost</SelectItem>
+                      {/* The whole funnel, from the configured pipeline —
+                          prospect first (triage, outside the pipeline). A
+                          record whose status is missing here renders a blank
+                          trigger, which is exactly what a prospect did. */}
+                      {statusOptions.map((o) => (
+                        <SelectItem key={o.key} value={o.key}>{o.name}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </div>

--- a/src/pages/admin/LeadsPage.tsx
+++ b/src/pages/admin/LeadsPage.tsx
@@ -28,6 +28,7 @@ import { LeadKanban } from '@/components/admin/leads/LeadKanban';
 import { BulkLeadEmailDialog } from '@/components/admin/crm/BulkLeadEmailDialog';
 import { SavedViewsMenu } from '@/components/admin/SavedViewsMenu';
 import { useOverdueActivityIndex } from '@/hooks/useOverdueActivityIndex';
+import { useLeadStatusOptions } from '@/hooks/usePipelineStages';
 import { OwnerChip } from '@/components/admin/OwnerChip';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
@@ -73,6 +74,7 @@ export default function LeadsPage() {
   const queryClient = useQueryClient();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const deleteLead = useDeleteLead();
+  const statusOptions = useLeadStatusOptions();
 
   const promoteProspect = useMutation({
     mutationFn: async (id: string) => {
@@ -418,11 +420,9 @@ export default function LeadsPage() {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All statuses</SelectItem>
-                <SelectItem value="prospect">Prospect</SelectItem>
-                <SelectItem value="lead">Lead</SelectItem>
-                <SelectItem value="opportunity">Opportunity</SelectItem>
-                <SelectItem value="customer">Customer</SelectItem>
-                <SelectItem value="lost">Lost</SelectItem>
+                {statusOptions.map((o) => (
+                  <SelectItem key={o.key} value={o.key}>{o.name}</SelectItem>
+                ))}
               </SelectContent>
             </Select>
             {isFiltering && (
@@ -459,10 +459,9 @@ export default function LeadsPage() {
                     <SelectValue placeholder="Set status…" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="lead">Lead</SelectItem>
-                    <SelectItem value="opportunity">Opportunity</SelectItem>
-                    <SelectItem value="customer">Customer</SelectItem>
-                    <SelectItem value="lost">Lost</SelectItem>
+                    {statusOptions.map((o) => (
+                      <SelectItem key={o.key} value={o.key}>{o.name}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
                 <Button


### PR DESCRIPTION
## Vad

- `useLeadStatusOptions()` i `usePipelineStages` — EN källa för kontaktens statusalternativ: `prospect` först, därefter de konfigurerade lead-stegen ur `pipeline_stages`. Fallback speglar enumet tills config laddat.
- Detaljsidans väljare, listans statusfilter och bulkväljaren läser alla den listan.
- Badge-etikett `Contact` → `Lead`.

## Varför

Detaljsidan hårdkodade fyra alternativ utan `prospect`: ett prospekt öppnat ur triagefliken visade **tom statusruta**, och "Contact" krockade med tratten överallt annars. Exakt deals-fyndet från 2026-08-08 (som redan har egen grind), en yta bort.

## Verifierat

tsc, full vitest 3387 gröna (5 nya grindpåståenden), lint-baslinjen oförändrad — den rules-of-hooks-miss jag införde på vägen (hook efter early return) är rättad. Grinden **negativtestad**: hårdkodad lista → rött, återställd → grönt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)