### PR TITLE
fix(crm): triagekön står utanför ägarlinsen

### DIFF
--- a/src/lib/__tests__/ownership-lens.guardrails.test.ts
+++ b/src/lib/__tests__/ownership-lens.guardrails.test.ts
@@ -87,3 +87,29 @@ describe('the lens narrows lists, never stats, never policies', () => {
     }
   });
 });
+
+// ─── En triagekö är ingens, alltså allas (Magnus 2026-08-29) ────────────────
+//
+// Prospects-fliken läste den LINSADE listan. Prospekteringsfynd får aldrig
+// någon ägare — agenten kör som service_role och ska inte gissa vem som äger
+// en kontakt (grinden ownership-on-create pinnar just det) — så under "Mina"
+// var triagekön tom FÖR ALLTID: en delad inkorg som såg ut som ett fungerande
+// filter. Ägarskap börjar när någon befordrar, inte innan.
+
+describe('triagekön står utanför linsen', () => {
+  const leadsPage = read('src/pages/admin/LeadsPage.tsx');
+
+  it('prospects läser rawLeads, inte den linsade listan', () => {
+    expect(leadsPage).toMatch(/const prospects = \(rawLeads \?\? \[\]\)\.filter/);
+    expect(leadsPage).not.toMatch(/const prospects = \(leads \?\? \[\]\)\.filter/);
+  });
+
+  it('kontaktlistan däremot ÄR linsad — det är där ägarskap betyder något', () => {
+    expect(leadsPage).toMatch(/const contactLeads = \(leads \?\? \[\]\)\.filter/);
+    expect(leadsPage).toMatch(/applyLens\(rawLeads, 'leads', lens, uid, coveredUids\)/);
+  });
+
+  it('skälet står i koden, så nästa läsare inte "städar" tillbaka buggen', () => {
+    expect(leadsPage).toMatch(/Read from rawLeads, NOT the lens-filtered list/);
+  });
+});

--- a/src/pages/admin/LeadsPage.tsx
+++ b/src/pages/admin/LeadsPage.tsx
@@ -59,7 +59,13 @@ export default function LeadsPage() {
   const q = searchQuery.trim().toLowerCase();
   // Prospects (pre-leads from prospecting) live in their own tab; the default
   // views leave them out so a Hunter batch can't drown the contact list.
-  const prospects = (leads ?? []).filter((l) => l.status === 'prospect');
+  //
+  // Read from rawLeads, NOT the lens-filtered list: prospecting finds carry no
+  // owner (the agent inserts them as service_role and must never guess who owns
+  // a contact), so under the "Mine" lens a lens-filtered triage queue is empty
+  // FOREVER — a shared inbox that looks like a working filter. Triage is a queue
+  // the team empties together; ownership starts when someone promotes.
+  const prospects = (rawLeads ?? []).filter((l) => l.status === 'prospect');
   const contactLeads = (leads ?? []).filter((l) => l.status !== 'prospect');
   const filteredLeads = (statusFilter === 'prospect' ? prospects : contactLeads).filter((l) => {
     if (statusFilter !== 'all' && statusFilter !== 'prospect' && l.status !== statusFilter) return false;


### PR DESCRIPTION
## Vad

`prospects` läser `rawLeads` i stället för den lins-filtrerade listan. Kontaktlistan (`contactLeads`) förblir linsad.

## Varför

Prospekteringsfynd har `assigned_to = NULL` med flit — agentens service-role-inserts ska inte gissa ägare (egen grind sedan 2026-08-08). Konsekvens: under linsen **Mina** var Prospects-fliken tom för alltid. En delad triagekö som såg ut som ett fungerande filter — och som därmed dolde precis det arbete fliken finns för.

Ägarskap börjar när någon befordrar ett prospekt till kontakt.

## Verifierat

tsc, full vitest **3390 gröna** (3 nya grindpåståenden), eslint rent. Grinden **negativtestad**: återinförd linsad lista → rött, återställd → grönt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)