### PR TITLE
feat(crm): den redigerbara liggaren — posten orubblig, texten rättningsbar

### DIFF
--- a/src/components/admin/crm/UnifiedTimeline.tsx
+++ b/src/components/admin/crm/UnifiedTimeline.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { useAuth } from '@/hooks/useAuth';
+import { useEditActivityNote } from '@/hooks/useEditActivityNote';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Phone, Mail, Users, MessageSquare, FileText, MailOpen,
   MousePointer, RefreshCw, Trophy, XCircle, Calendar,
-  ShoppingCart, Video, Activity, CheckCircle2, ArrowDownLeft, ArrowUpRight, ChevronDown, ChevronRight
+  ShoppingCart, Video, Activity, CheckCircle2, ArrowDownLeft, ArrowUpRight, ChevronDown, ChevronRight, Pencil
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { cn } from '@/lib/utils';
@@ -95,8 +99,32 @@ function isExpandable(text: string): boolean {
   return text.length > 160 || text.includes('\n');
 }
 
+/**
+ * Which entries carry text a human wrote — the only text anyone may correct.
+ * A system observation ("email opened", "deal created") has no authored
+ * sentence in it, so it needs no edit affordance at all.
+ */
+const HUMAN_LOGGED = new Set(['note', 'call', 'meeting', 'email', 'task_completed']);
+
 function TimelineList({ events, isLoading }: { events: TimelineEvent[]; isLoading: boolean }) {
+  const { user, isAdmin } = useAuth();
+  const editNote = useEditActivityNote();
+  const [editing, setEditing] = useState<string | null>(null);
+  const [draft, setDraft] = useState('');
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  // The entry is immutable; its text is correctable — by the person who wrote
+  // it, or an admin. Rows from before authorship was recorded have no author,
+  // so only an admin may touch them: we do not know whose words they are.
+  const mayCorrect = (e: TimelineEvent) =>
+    !!e.activityId &&
+    HUMAN_LOGGED.has(e.activityType ?? '') &&
+    (isAdmin || (!!e.authorId && e.authorId === user?.id));
+
+  const startEdit = (e: TimelineEvent) => {
+    setEditing(e.id);
+    setDraft(e.description ?? '');
+  };
   const toggle = (id: string) =>
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -140,27 +168,81 @@ function TimelineList({ events, isLoading }: { events: TimelineEvent[]; isLoadin
                 )}
                 <TypeBadge type={event.type} />
               </div>
-              {event.description && (
-                <>
-                  <p
-                    className={cn(
-                      'text-xs text-muted-foreground mt-0.5',
-                      expanded.has(event.id) ? 'whitespace-pre-wrap' : 'line-clamp-2',
-                    )}
-                  >
-                    {event.description}
-                  </p>
-                  {isExpandable(event.description) && (
-                    <button
-                      type="button"
-                      onClick={() => toggle(event.id)}
-                      className="mt-0.5 inline-flex items-center gap-0.5 text-xs text-primary hover:underline"
+              {editing === event.id ? (
+                <div className="mt-1 space-y-2">
+                  <Textarea
+                    value={draft}
+                    onChange={(ev) => setDraft(ev.target.value)}
+                    rows={4}
+                    className="[field-sizing:content] max-h-96 resize-y text-xs leading-relaxed"
+                    placeholder="Correct the wording. Emptying it redacts the text and leaves the entry standing."
+                  />
+                  <div className="flex items-center gap-2">
+                    <Button
+                      size="sm"
+                      className="h-7 text-xs"
+                      disabled={editNote.isPending}
+                      onClick={() =>
+                        editNote.mutate(
+                          { activityId: event.activityId!, note: draft },
+                          { onSuccess: () => setEditing(null) },
+                        )
+                      }
                     >
-                      {expanded.has(event.id)
-                        ? <><ChevronDown className="h-3 w-3" /> Show less</>
-                        : <><ChevronRight className="h-3 w-3" /> Show more</>}
-                    </button>
+                      Save correction
+                    </Button>
+                    <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => setEditing(null)}>
+                      Cancel
+                    </Button>
+                    <span className="text-[10px] text-muted-foreground">
+                      The entry, its time and its points stay as they are.
+                    </span>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  {event.description ? (
+                    <p
+                      className={cn(
+                        'text-xs text-muted-foreground mt-0.5',
+                        expanded.has(event.id) ? 'whitespace-pre-wrap' : 'line-clamp-2',
+                      )}
+                    >
+                      {event.description}
+                    </p>
+                  ) : (
+                    // A corrected-away note: the row stands, the words are gone.
+                    event.editedAt && HUMAN_LOGGED.has(event.activityType ?? '') && (
+                      <p className="text-xs text-muted-foreground/70 italic mt-0.5">Note redacted</p>
+                    )
                   )}
+                  <div className="flex items-center gap-2 mt-0.5">
+                    {event.description && isExpandable(event.description) && (
+                      <button
+                        type="button"
+                        onClick={() => toggle(event.id)}
+                        className="inline-flex items-center gap-0.5 text-xs text-primary hover:underline"
+                      >
+                        {expanded.has(event.id)
+                          ? <><ChevronDown className="h-3 w-3" /> Show less</>
+                          : <><ChevronRight className="h-3 w-3" /> Show more</>}
+                      </button>
+                    )}
+                    {mayCorrect(event) && (
+                      <button
+                        type="button"
+                        onClick={() => startEdit(event)}
+                        className="inline-flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground"
+                      >
+                        <Pencil className="h-3 w-3" /> Correct
+                      </button>
+                    )}
+                    {event.editedAt && (
+                      <span className="text-[10px] text-muted-foreground/70" title={new Date(event.editedAt).toLocaleString()}>
+                        edited
+                      </span>
+                    )}
+                  </div>
                 </>
               )}
               <p className="text-xs text-muted-foreground mt-1">

--- a/src/hooks/useEditActivityNote.ts
+++ b/src/hooks/useEditActivityNote.ts
@@ -1,0 +1,55 @@
+/**
+ * Correct the text of a ledger entry — never the entry itself.
+ *
+ * The activity log is the sales ledger: entries are immutable in position,
+ * type and points, because the chronology has to be complete and the score
+ * must not be rewritable after the fact. What a human wrote about another
+ * human is a different matter: it can be wrong, and a person has the right to
+ * have it corrected or removed. So the text is correctable, visibly — the
+ * database stamps `edited_at` and keeps the superseded wording in
+ * `metadata.note_history` (lead_activity_ledger_guard). Emptying the text is
+ * allowed and leaves the row standing as a tombstone; that is the difference
+ * between redacting a statement and deleting a record.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+
+export function useEditActivityNote() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ activityId, note }: { activityId: string; note: string }) => {
+      // Read-modify-write the metadata object: the guard needs the untouched
+      // structured keys (deal_id, message_id, subject…) to survive a correction.
+      const { data: row, error: readErr } = await supabase
+        .from('lead_activities')
+        .select('metadata')
+        .eq('id', activityId)
+        .maybeSingle();
+      if (readErr) throw readErr;
+      if (!row) throw new Error('The entry is gone — reload the timeline.');
+
+      const metadata = { ...((row.metadata ?? {}) as Record<string, unknown>), note };
+      // Read the row back: an RLS-denied update returns success with 0 rows,
+      // and a toast that says "saved" about text nobody stored is the worst
+      // outcome of all.
+      const { data, error } = await supabase
+        .from('lead_activities')
+        .update({ metadata: metadata as never })
+        .eq('id', activityId)
+        .select('id, edited_at');
+      if (error) throw error;
+      if (!data?.length) {
+        throw new Error('Nothing was saved — only the author or an admin may correct an entry.');
+      }
+      return data[0];
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['unified-timeline'] });
+      qc.invalidateQueries({ queryKey: ['lead-activities'] });
+      toast.success('Entry corrected');
+    },
+    onError: (e: Error) => toast.error(e.message || 'Could not correct the entry'),
+  });
+}

--- a/src/hooks/useUnifiedTimeline.ts
+++ b/src/hooks/useUnifiedTimeline.ts
@@ -15,6 +15,17 @@ export interface TimelineEvent {
   direction?: 'inbound' | 'outbound';
   actor?: string;
   status?: string;
+  /**
+   * Set for rows in `lead_activities` — the ledger. Carries what the UI needs
+   * to correct the TEXT of an entry it may correct: the row id, who wrote it
+   * (null = written by the system, nobody may rewrite it), and whether it has
+   * already been corrected. The entry itself is immutable; see the
+   * lead_activity_ledger_guard trigger.
+   */
+  activityId?: string;
+  activityType?: string;
+  authorId?: string | null;
+  editedAt?: string | null;
 }
 
 
@@ -102,6 +113,10 @@ export function useUnifiedTimeline(leadId: string | undefined, email: string | u
               icon: getActivityIcon(a.type),
               color: getActivityColor(a.type),
               points: a.points || undefined,
+              activityId: a.id,
+              activityType: a.type,
+              authorId: (a as { created_by?: string | null }).created_by ?? null,
+              editedAt: (a as { edited_at?: string | null }).edited_at ?? null,
             });
           }
         }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -9289,6 +9289,9 @@ export type Database = {
       lead_activities: {
         Row: {
           created_at: string
+          created_by: string | null
+          edited_at: string | null
+          edited_by: string | null
           id: string
           lead_id: string
           metadata: Json | null
@@ -9297,6 +9300,9 @@ export type Database = {
         }
         Insert: {
           created_at?: string
+          created_by?: string | null
+          edited_at?: string | null
+          edited_by?: string | null
           id?: string
           lead_id: string
           metadata?: Json | null
@@ -9305,6 +9311,9 @@ export type Database = {
         }
         Update: {
           created_at?: string
+          created_by?: string | null
+          edited_at?: string | null
+          edited_by?: string | null
           id?: string
           lead_id?: string
           metadata?: Json | null

--- a/src/lib/__tests__/editable-ledger.guardrails.test.ts
+++ b/src/lib/__tests__/editable-ledger.guardrails.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Posten är orubblig, texten är rättningsbar (Magnus 2026-08-29).
+ *
+ * Aktivitetsloggen är säljbearbetningens huvudbok: `points` summeras till
+ * kontaktens score, och kronologin är underlaget både människan och agenterna
+ * svarar ur. Bokföringens disciplin ger oföränderlighet — men en mening om en
+ * människa måste gå att rätta och att ta bort. Regeln som förenar dem är
+ * hela poängen med den här grinden, åt båda hållen: struktur som inte kan
+ * ändras, text som kan.
+ *
+ * Bevisat live på optic i en rullad-tillbaka transaktion, fyra riktningar:
+ * poängändring stoppad, typändring stoppad, texträttelse genomförd med
+ * edited_at satt och den ersatta lydelsen (2 608 tecken) bevarad i
+ * note_history, och tömning genomförd med raden kvarstående.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const sql = read('supabase/migrations/20260829190000_posten-orubblig-texten-rattningsbar.sql');
+const hook = read('src/hooks/useEditActivityNote.ts');
+const ui = read('src/components/admin/crm/UnifiedTimeline.tsx');
+const timeline = read('src/hooks/useUnifiedTimeline.ts');
+
+describe('posten är orubblig', () => {
+  it('struktur som ändras SMÄLLER — den backas inte tyst', () => {
+    expect(sql).toMatch(/NEW\.points\s+IS DISTINCT FROM OLD\.points/);
+    expect(sql).toMatch(/NEW\.type\s+IS DISTINCT FROM OLD\.type/);
+    expect(sql).toMatch(/NEW\.created_at IS DISTINCT FROM OLD\.created_at/);
+    expect(sql).toMatch(/RAISE EXCEPTION 'lead_activities: the entry is immutable/);
+  });
+
+  it('saldot kan därmed inte skrivas om i efterhand', () => {
+    // points summeras till leads.score. Vore posten redigerbar vore scoringen
+    // det också — en poäng som går att ändra i efterhand är ingen poäng.
+    expect(sql).toMatch(/points/);
+    expect(sql).not.toMatch(/NEW\.points := /);
+  });
+});
+
+describe('texten är rättningsbar — men bara av den som skrev den', () => {
+  it('författare eller admin, aldrig vem som helst', () => {
+    expect(sql).toMatch(/OLD\.created_by IS NOT NULL AND OLD\.created_by = v_uid/);
+    expect(sql).toMatch(/has_role\(v_uid, 'admin'::app_role\)/);
+    expect(sql).toMatch(/RAISE EXCEPTION 'lead_activities: only the author or an admin/);
+  });
+
+  it('författaren stämplas vid insert, men gissas aldrig åt en agent', () => {
+    expect(sql).toMatch(/IF NEW\.created_by IS NULL THEN NEW\.created_by := v_uid/);
+  });
+
+  it('den ersatta lydelsen bevaras — annars är rättelse omskrivning', () => {
+    expect(sql).toMatch(/'\{note_history\}'/);
+    expect(sql).toMatch(/NEW\.edited_at := now\(\)/);
+  });
+});
+
+describe('ytan visar vad som gäller', () => {
+  it('bara människoskrivna rader får en rättelseknapp', () => {
+    expect(ui).toMatch(/HUMAN_LOGGED = new Set\(\['note', 'call', 'meeting', 'email', 'task_completed'\]\)/);
+    expect(ui).toMatch(/HUMAN_LOGGED\.has\(e\.activityType \?\? ''\)/);
+    expect(ui).toMatch(/isAdmin \|\| \(!!e\.authorId && e\.authorId === user\?\.id\)/);
+  });
+
+  it('en rättad post säger att den är rättad, en tömd står kvar som gravsten', () => {
+    expect(ui).toMatch(/>\s*edited\s*</);
+    expect(ui).toMatch(/Note redacted/);
+  });
+
+  it('tidslinjen bär författare och redigeringsstämpel hela vägen ut', () => {
+    expect(timeline).toMatch(/authorId\?: string \| null;/);
+    expect(timeline).toMatch(/authorId: \(a as \{ created_by\?: string \| null \}\)\.created_by \?\? null/);
+  });
+
+  it('skrivningen läses tillbaka — en nekad rättelse får aldrig se ut som sparad', () => {
+    expect(hook).toMatch(/\.select\('id, edited_at'\)/);
+    expect(hook).toMatch(/if \(!data\?\.length\)/);
+    expect(hook).toMatch(/only the author or an admin may correct an entry/);
+  });
+});

--- a/supabase/migrations/20260829190000_posten-orubblig-texten-rattningsbar.sql
+++ b/supabase/migrations/20260829190000_posten-orubblig-texten-rattningsbar.sql
@@ -1,0 +1,103 @@
+-- Aktivitetsloggen blir en redigerbar liggare (Magnus 2026-08-29).
+--
+-- Ramen: aktiviteterna är säljbearbetningens huvudbok — verifikat, inte
+-- uppsatser, med `points` som löpande saldo. Bokföringens disciplin ger
+-- oföränderlighet; dataskyddet kräver att en mening om en människa går att
+-- rätta och att ta bort. Regeln som förenar dem:
+--
+--   POSTEN ÄR ORUBBLIG, TEXTEN ÄR RÄTTNINGSBAR.
+--
+-- Raden försvinner aldrig, dess plats i tiden ändras aldrig, dess typ och
+-- poäng ändras aldrig — så kronologin är komplett och saldot kan inte
+-- manipuleras i efterhand. Det som får ändras är den text en människa skrivit,
+-- synligt (edited_at) och utan att den ersatta lydelsen går förlorad
+-- (metadata.note_history). Att tömma texten är tillåtet — då står raden kvar
+-- som gravsten, vilket är skillnaden mot att radera en post.
+--
+-- Före detta saknade tabellen både författare och ändringsstämpel, medan
+-- RLS-policyn "Staff can manage lead_activities" tillät ALL: allt gick att
+-- ändra av vem som helst utan spår, och ingenting gick att rätta av den som
+-- skrev det. Precis bakvänt.
+--
+-- Idempotent + forward-daterad.
+
+ALTER TABLE public.lead_activities
+  ADD COLUMN IF NOT EXISTS created_by uuid,
+  ADD COLUMN IF NOT EXISTS edited_at timestamptz,
+  ADD COLUMN IF NOT EXISTS edited_by uuid;
+
+CREATE OR REPLACE FUNCTION public.lead_activity_ledger_guard()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_old_note text;
+  v_new_note text;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    -- Författaren stämplas som i ownership-on-create: den inloggade, aldrig
+    -- en gissning. En agent kör som service_role utan auth.uid() och gör
+    -- därför inte anspråk på författarskap — raden blir systemets.
+    IF NEW.created_by IS NULL THEN NEW.created_by := v_uid; END IF;
+    RETURN NEW;
+  END IF;
+
+  -- ── UPDATE: posten är orubblig ───────────────────────────────────────────
+  -- Ett försök att ändra strukturen SMÄLLER i stället för att tyst backas —
+  -- en anropare som tror sig ha flyttat en post ska få veta att den inte kan
+  -- flyttas. Fel poäng eller fel typ rättas som i bokföringen: med en ny rad.
+  IF NEW.lead_id    IS DISTINCT FROM OLD.lead_id
+  OR NEW.type       IS DISTINCT FROM OLD.type
+  OR NEW.points     IS DISTINCT FROM OLD.points
+  OR NEW.created_at IS DISTINCT FROM OLD.created_at
+  OR NEW.created_by IS DISTINCT FROM OLD.created_by THEN
+    RAISE EXCEPTION 'lead_activities: the entry is immutable (lead, type, points, created_at, created_by) — correct it with a new entry';
+  END IF;
+
+  IF NEW.metadata IS NOT DISTINCT FROM OLD.metadata THEN
+    RETURN NEW;
+  END IF;
+
+  -- ── Texten är rättningsbar — av den som skrev den ────────────────────────
+  -- Rader från tiden före den här migrationen har created_by NULL: vi vet
+  -- inte vem som skrev dem, så bara en admin får röra dem.
+  IF NOT (
+       auth.role() = 'service_role'
+    OR (OLD.created_by IS NOT NULL AND OLD.created_by = v_uid)
+    OR has_role(v_uid, 'admin'::app_role)
+  ) THEN
+    RAISE EXCEPTION 'lead_activities: only the author or an admin may correct an entry';
+  END IF;
+
+  v_old_note := COALESCE(OLD.metadata->>'note', '');
+  v_new_note := COALESCE(NEW.metadata->>'note', '');
+
+  NEW.edited_at := now();
+  NEW.edited_by := COALESCE(v_uid, OLD.edited_by);
+
+  -- Den ersatta lydelsen bevaras. Rättelse ska vara spårbar, annars är den
+  -- omskrivning av historien med ett annat namn.
+  IF v_old_note <> v_new_note THEN
+    NEW.metadata := jsonb_set(
+      COALESCE(NEW.metadata, '{}'::jsonb),
+      '{note_history}',
+      COALESCE(OLD.metadata->'note_history', '[]'::jsonb) ||
+      jsonb_build_array(jsonb_build_object(
+        'note', v_old_note,
+        'replaced_at', now(),
+        'replaced_by', v_uid
+      ))
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS lead_activities_ledger_guard ON public.lead_activities;
+CREATE TRIGGER lead_activities_ledger_guard
+  BEFORE INSERT OR UPDATE ON public.lead_activities
+  FOR EACH ROW EXECUTE FUNCTION public.lead_activity_ledger_guard();
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260829170000",
-      "migrations_count": 525,
+      "migration_head": "20260829190000",
+      "migrations_count": 526,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2105,6 +2105,10 @@
         {
           "version": "20260829170000",
           "name": "prospect-ar-inte-lead"
+        },
+        {
+          "version": "20260829190000",
+          "name": "posten-orubblig-texten-rattningsbar"
         }
       ]
     },


### PR DESCRIPTION
## Regeln

Aktivitetsloggen är säljbearbetningens huvudbok. Bokföringens disciplin ger oföränderlighet; dataskyddet kräver att en mening om en människa går att rätta och att ta bort.

**Posten är orubblig.** Triggern vägrar ändring av `lead_id`, `type`, `points`, `created_at`, `created_by` — och kastar fel i stället för att tyst backa. Kronologin förblir komplett, saldot (`points` → `leads.score`) kan inte skrivas om i efterhand.

**Texten är rättningsbar** — av författaren eller en admin. `edited_at` stämplas, den ersatta lydelsen bevaras i `metadata.note_history`. Tömning tillåten: raden står kvar som gravsten (*Note redacted*).

## Före

Tabellen saknade författare och ändringsstämpel, medan RLS gav `ALL` till all personal: allt gick att ändra av vem som helst utan spår, ingenting gick att rätta av den som skrev det.

## Verifierat

Live på optic i rullad-tillbaka transaktion, fyra riktningar:

| Test | Utfall |
|---|---|
| Poängändring | stoppad |
| Typändring | stoppad |
| Texträttelse | OK — `edited_at` satt, 2 608 tecken bevarade i historiken |
| Tömning | OK — raden kvar, historiken två poster |

tsc, eslint rent, full vitest **3407 gröna** (9 nya påståenden), manifest regenererat. Grinden negativtestad åt båda håll: borttagen poängspärr → rött, borttagen behörighetskontroll i UI → rött.

🤖 Generated with [Claude Code](https://claude.com/claude-code)