### PR TITLE
fix(crm): leads.company var ett spöke — typen lovade en kolumn som inte finns

### DIFF
--- a/src/lib/__tests__/leads-company-ghost.guardrails.test.ts
+++ b/src/lib/__tests__/leads-company-ghost.guardrails.test.ts
@@ -1,0 +1,59 @@
+/**
+ * `leads.company` finns inte — och typen får inte påstå motsatsen.
+ *
+ * Fyndet (2026-08-29): den nya lägesbilden föll på sitt FÖRSTA skarpa anrop med
+ * "column leads.company does not exist". Kolumnen är normaliserad bort till
+ * companies via company_id och saknas i samtliga fyra instanser jag kunde nå
+ * (optic, www, resta, autoversio) — men frontend-typen deklarerade den
+ * fortfarande, med en "legacy fallback" som läste ett fält som aldrig kan bli
+ * satt.
+ *
+ * Spökfältsklassen, spegelvänd: vanligtvis är det en whitelist som lovar fält
+ * ingen renderare läser; här lovade TYPEN en kolumn databasen inte har. Den
+ * sortens lögn är osynlig så länge alla gör `select('*')` — PostgREST utelämnar
+ * bara fältet och fallbacken faller igenom — och smäller först när någon skriver
+ * ut kolumnnamnet i en select. Fyra ytor hade läst det i månader.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+
+/**
+ * Kommentarer får nämna spöket — de är just det som förklarar varför det inte
+ * ska tillbaka. Grinden ska falla på KOD, inte på en förklaring.
+ */
+const code = (p: string) =>
+  read(p)
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*') && !l.trim().startsWith('/*'))
+    .join('\n');
+
+describe('ingen typ lovar kolumnen', () => {
+  for (const f of ['src/lib/lead-utils.ts', 'src/pages/admin/LeadsPage.tsx']) {
+    it(`${f} deklarerar inte company på en lead-form`, () => {
+      // company_id och companies(...) är riktiga; ett blankt `company` är spöket.
+      expect(code(f)).not.toMatch(/^\s*company: string \| null;/m);
+    });
+  }
+});
+
+describe('ingen yta läser den', () => {
+  for (const f of [
+    'src/pages/admin/LeadsPage.tsx',
+    'src/pages/admin/DealsPage.tsx',
+    'src/pages/admin/DealDetailPage.tsx',
+    'supabase/functions/_shared/handlers/contact-state.ts',
+  ]) {
+    it(`${f} går via relationen companies, inte det borttagna fältet`, () => {
+      expect(code(f)).not.toMatch(/lead\.company\b(?!_id|s)/);
+      expect(code(f)).not.toMatch(/l\.company\b(?!_id|s)/);
+    });
+  }
+
+  it('och ingen select nämner kolumnen vid namn', () => {
+    const handler = read('supabase/functions/_shared/handlers/contact-state.ts');
+    expect(handler).toMatch(/\.select\('id, name, email, status, score, company_id, companies\(name, notes\)'\)/);
+  });
+});

--- a/src/lib/lead-utils.ts
+++ b/src/lib/lead-utils.ts
@@ -12,7 +12,6 @@ export interface Lead {
   id: string;
   email: string;
   name: string | null;
-  company: string | null;
   company_id: string | null;
   phone: string | null;
   source: string;

--- a/src/pages/admin/DealDetailPage.tsx
+++ b/src/pages/admin/DealDetailPage.tsx
@@ -329,10 +329,10 @@ export default function DealDetailPage() {
                   </Link>
                 </div>
 
-                {lead.company && (
+                {lead.companies?.name && (
                   <div className="flex items-center gap-3">
                     <Building className="h-4 w-4 text-muted-foreground" />
-                    <span className="text-sm">{lead.company}</span>
+                    <span className="text-sm">{lead.companies.name}</span>
                   </div>
                 )}
 

--- a/src/pages/admin/DealsPage.tsx
+++ b/src/pages/admin/DealsPage.tsx
@@ -570,7 +570,7 @@ function CreateDealDialogWithLeadPicker({ open, onOpenChange }: CreateDealDialog
                 <SelectContent>
                   {availableLeads.map(lead => (
                     <SelectItem key={lead.id} value={lead.id}>
-                      {lead.name || lead.email} {lead.company ? `(${lead.company})` : ''}
+                      {lead.name || lead.email} {lead.companies?.name ? `(${lead.companies.name})` : ''}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/pages/admin/LeadsPage.tsx
+++ b/src/pages/admin/LeadsPage.tsx
@@ -70,7 +70,7 @@ export default function LeadsPage() {
   const filteredLeads = (statusFilter === 'prospect' ? prospects : contactLeads).filter((l) => {
     if (statusFilter !== 'all' && statusFilter !== 'prospect' && l.status !== statusFilter) return false;
     if (!q) return true;
-    return [l.name, l.email, l.company, l.companies?.name]
+    return [l.name, l.email, l.companies?.name]
       .some((f) => (f || '').toLowerCase().includes(q));
   });
   const isFiltering = q !== '' || statusFilter !== 'all';
@@ -614,7 +614,6 @@ interface LeadCardProps {
     id: string;
     email: string;
     name: string | null;
-    company: string | null;
     company_id: string | null;
     companies: {
       id: string;
@@ -641,7 +640,8 @@ interface LeadCardProps {
 function LeadCard({ lead, showStatus, onClick, selected, onToggleSelect, onDelete, onPromote, promoteLabel = 'Lead' }: LeadCardProps) {
   const statusInfo = getLeadStatusInfo(lead.status);
   // Display company name from linked company, fallback to text field for legacy data
-  const companyName = lead.companies?.name || lead.company;
+  // No `lead.company` fallback: that column exists in no instance's schema.
+  const companyName = lead.companies?.name;
   const navigate = useNavigate();
   const { data: overdue } = useOverdueActivityIndex();
   const hasOverdue = overdue?.leadIds.has(lead.id) ?? false;

--- a/supabase/functions/_shared/handlers/contact-state.ts
+++ b/supabase/functions/_shared/handlers/contact-state.ts
@@ -47,7 +47,10 @@ export async function distillContactState(
 ): Promise<{ success: boolean; summary?: string; entries?: number; skipped?: string }> {
   const { data: lead, error: leadErr } = await supabase
     .from('leads')
-    .select('id, name, email, status, score, company, company_id, companies(name, notes)')
+    // `company` finns INTE i schemat — B2B-namnet bor på companies via
+    // company_id. Frontend-typen påstod motsatsen och den lögnen kostade den
+    // här funktionen sitt första skarpa anrop (2026-08-29).
+    .select('id, name, email, status, score, company_id, companies(name, notes)')
     .eq('id', leadId)
     .maybeSingle();
   if (leadErr) throw new Error(`contact-state: lead read failed: ${leadErr.message}`);
@@ -77,7 +80,7 @@ export async function distillContactState(
   // importing our marketing claims into a factual status note.
   const identity = await loadBusinessIdentityBlock(supabase, 'core');
 
-  const companyName = lead.companies?.name || lead.company || null;
+  const companyName = lead.companies?.name || null;
   const companyNotes = (lead.companies?.notes ?? '').toString().trim();
 
   const ledgerText = entries

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2123,7 +2123,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:acd7604c91ea321124ea6571c67a6b0102ab8a3b416526de266b5123f9bbda91",
+      "shared_hash": "sha256:edcb2c054fc1c5b8fd3f4603b7f13ccb090071160ead90269eb49509cb97c4a2",
       "functions": {
         "a2a": "sha256:33f9aa45f5a82d23f357aff397403b5b12a94dc3421984a1c883f23509c50f71",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",


### PR DESCRIPTION
## Fyndet

Lägesbilden (#336) föll på sitt **första skarpa anrop** mot optic:

```
contact-state: lead read failed: column leads.company does not exist
```

Kolumnen är normaliserad bort till `companies` via `company_id` och saknas i **alla fyra instanser** jag kunde nå (optic, www, resta, autoversio). Frontend-typen deklarerade den ändå, med en "legacy fallback" som läste ett fält som aldrig kan bli satt.

## Klassen

Spökfältsklassen spegelvänd: normalt lovar en whitelist fält ingen renderare läser — här lovade **typen** en kolumn databasen inte har. Osynligt så länge alla kör `select('*')` (PostgREST utelämnar fältet, fallbacken faller igenom), smäller först när någon skriver ut kolumnnamnet. Fyra ytor hade läst det i månader.

## Åtgärd

Fältet borttaget ur `Lead` och `LeadCardProps`. Kompilatorn pekade då ut varje läsare — sökfiltret i LeadsPage, raden i DealsPage, panelen i DealDetailPage — och alla går nu via relationen `companies`. Handlern läser rätt kolumner.

## Verifierat

tsc, eslint rent, full vitest **3424 gröna** (7 nya påståenden, negativtestade), manifest regenererat. Grinden är kodmedveten: kommentarer får nämna spöket, för de är det som förklarar varför det inte ska tillbaka.

🤖 Generated with [Claude Code](https://claude.com/claude-code)