### PR TITLE
feat(projects): projekt får ägare, uppgifter får handavtryck, "Mina" betyder en sak

### DIFF
--- a/src/components/admin/projects/ActivitiesView.tsx
+++ b/src/components/admin/projects/ActivitiesView.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { useAuth } from "@/hooks/useAuth";
+import { useOwnershipLens } from "@/hooks/useOwnershipLens";
+import { LensToggle } from "@/components/admin/LensToggle";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -35,9 +36,12 @@ export function ActivitiesView({
   projects: Project[];
   onOpenProject: (projectId: string) => void;
 }) {
-  const { user } = useAuth();
-  const [scope, setScope] = useState<"all" | "mine">("all");
+  // The shared CRM lens, not a toggle of its own: narrowing contacts and
+  // narrowing activities is the same act of focus, and two toggles that mean
+  // the same thing are two truths waiting to disagree.
+  const { lens, uid, coveredUids } = useOwnershipLens();
   const [showDone, setShowDone] = useState(false);
+  const mineUids = useMemo(() => new Set([uid, ...coveredUids].filter(Boolean) as string[]), [uid, coveredUids]);
 
   const { data: tasks, isLoading } = useQuery({
     queryKey: ["project_tasks", "cross-project"],
@@ -57,12 +61,23 @@ export function ActivitiesView({
   );
   const today = new Date().toISOString().slice(0, 10);
 
+  // "Mine" means what Magnus decided it should mean (2026-08-29): assigned to
+  // me, PLUS unassigned work in projects I own. The strict reading — only what
+  // is assigned — hides exactly the tasks nobody has picked up, which is the
+  // work most likely to be dropped. An owner sees their project's loose ends.
+  const isMine = (t: Row) => {
+    if (t.assigned_to) return mineUids.has(t.assigned_to);
+    const owner = byProject.get(t.project_id)?.owner_id;
+    return !!owner && mineUids.has(owner);
+  };
+
   const rows = useMemo(() => {
     return (tasks ?? [])
       .filter((t) => (showDone ? true : !DONE.has(t.status)))
-      .filter((t) => (scope === "mine" ? t.assigned_to === user?.id : true))
+      .filter((t) => (lens === "mine" ? isMine(t) : true))
       .filter((t) => byProject.has(t.project_id));
-  }, [tasks, showDone, scope, user?.id, byProject]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tasks, showDone, lens, mineUids, byProject]);
 
   const overdueCount = rows.filter(
     (t) => t.due_date && t.due_date < today && !DONE.has(t.status)
@@ -71,22 +86,9 @@ export function ActivitiesView({
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-2">
-        <div className="flex rounded-md border p-0.5">
-          <Button
-            size="sm"
-            variant={scope === "all" ? "secondary" : "ghost"}
-            onClick={() => setScope("all")}
-          >
-            All
-          </Button>
-          <Button
-            size="sm"
-            variant={scope === "mine" ? "secondary" : "ghost"}
-            onClick={() => setScope("mine")}
-          >
-            Mine
-          </Button>
-        </div>
+        {/* The CRM's own lens — the same switch as on Contacts and Projects,
+            so "Mine" means one thing across the product. */}
+        <LensToggle />
         <Button
           size="sm"
           variant={showDone ? "secondary" : "outline"}

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -15,6 +15,8 @@ export type Project = {
   color: string | null;
   deadline: string | null;
   visibility: 'shared' | 'private';
+  /** Who is accountable now. Defaults to the creator, changeable; the lens reads this. */
+  owner_id: string | null;
   created_by: string | null;
   created_at: string;
   updated_at: string;

--- a/src/lib/__tests__/project-ownership.guardrails.test.ts
+++ b/src/lib/__tests__/project-ownership.guardrails.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Projekt får ägare, och "Mina" betyder samma sak överallt.
+ *
+ * Mätt före bygget (optic, 2026-08-29): 12 uppgifter, NOLL med ägare — därför
+ * visade "Mine" i aktivitetsvyn ingenting. Filtret fungerade; det fanns ingen
+ * data att filtrera på. Kontakterna räddades av ownership-on-create sedan
+ * 2026-08-08; projekt och uppgifter hade aldrig fått motsvarande, och
+ * ActivitiesView bar dessutom en EGEN All/Mine-växel vid sidan av CRM-linsen —
+ * en tredje sanning om vad "mitt" betyder.
+ *
+ * Magnus definition (hans beslut, inte en teknisk bekvämlighet): tilldelade mig
+ * PLUS otilldelat i projekt jag äger. Den strikta läsningen döljer just de
+ * uppgifter ingen tagit — det arbete som är mest sannolikt att tappas.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { OWNERSHIP } from '@/lib/ownership';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const sql = read('supabase/migrations/20260829230000_projekt-far-agare-och-handavtryck.sql');
+const view = read('src/components/admin/projects/ActivitiesView.tsx');
+const page = read('src/pages/admin/ProjectsPage.tsx');
+const crud = read('supabase/functions/agent-execute/index.ts');
+
+describe('ägarskapet finns innan filtret får finnas', () => {
+  it('projects står i ägarkartan med sin egen kolumn', () => {
+    expect(OWNERSHIP).toHaveProperty('projects');
+    expect(OWNERSHIP.projects.column).toBe('owner_id');
+  });
+
+  it('skaparen blir projektets ägare — men gissas aldrig åt en agent', () => {
+    expect(sql).toMatch(/IF v_uid IS NULL THEN RETURN NEW; END IF;/);
+    expect(sql).toMatch(/TG_TABLE_NAME = 'projects' AND NEW\.owner_id IS NULL/);
+  });
+
+  it('uppgifter tilldelas INTE automatiskt — annars finns ingen backlogg att fånga', () => {
+    // Följer direkt av Magnus definition av "Mina": otilldelat i mina projekt.
+    expect(sql).not.toMatch(/NEW\.assigned_to := v_uid/);
+  });
+
+  it('befintliga projekt får ägare ur created_by, men en satt ägare rörs inte', () => {
+    expect(sql).toMatch(/SET owner_id = created_by\s*\n\s*WHERE owner_id IS NULL AND created_by IS NOT NULL/);
+  });
+});
+
+describe('"Mina" betyder en sak, på alla tre ytorna', () => {
+  it('aktivitetsvyn använder CRM-linsen, inte en egen växel', () => {
+    expect(view).toMatch(/useOwnershipLens\(\)/);
+    expect(view).toMatch(/<LensToggle \/>/);
+    expect(view).not.toMatch(/setScope\(/);
+  });
+
+  it('och tolkningen är den generösa: tilldelat mig ELLER otilldelat i mitt projekt', () => {
+    expect(view).toMatch(/if \(t\.assigned_to\) return mineUids\.has\(t\.assigned_to\)/);
+    expect(view).toMatch(/const owner = byProject\.get\(t\.project_id\)\?\.owner_id/);
+  });
+
+  it('vyn får HELA projektlistan — en uppgift åt mig i någon annans projekt är min', () => {
+    expect(page).toMatch(/<ActivitiesView\s*\n\s*projects=\{rawProjects \?\? \[\]\}/);
+    // Projektlistan i rälsen ÄR däremot linsad — där betyder ägarskap urval.
+    expect(page).toMatch(/<ProjectRail\s*\n\s*projects=\{projects\}/);
+  });
+});
+
+describe('när en agent skriver syns det att det var en agent', () => {
+  it('den generiska CRUD-motorn stämplar agentnamnet vid create och update', () => {
+    expect(crud).toMatch(/cleanInsert\.created_by_agent = auditCtx\.agent_type/);
+    expect(crud).toMatch(/cleanUpdate\.updated_by_agent = auditCtx\.agent_type/);
+  });
+
+  it('men attribution får aldrig fälla en skrivning på en tabell som saknar kolumnen', () => {
+    expect(crud).toMatch(/\['created_by_agent', 'created_by'\]\.filter/);
+    expect(crud).toMatch(/\['updated_by_agent', 'updated_at'\]\.filter/);
+  });
+});

--- a/src/lib/ownership.ts
+++ b/src/lib/ownership.ts
@@ -32,6 +32,10 @@ export const OWNERSHIP = {
     column: 'owner_id',
     invalidate: ['quotes', 'quote'],
   },
+  projects: {
+    column: 'owner_id',
+    invalidate: ['projects', 'project'],
+  },
 } as const;
 
 export type OwnedEntity = keyof typeof OWNERSHIP;

--- a/src/pages/admin/ProjectsPage.tsx
+++ b/src/pages/admin/ProjectsPage.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from "react";
 import { AdminLayout } from "@/components/admin/AdminLayout";
 import { useOpenOnQueryParam } from "@/hooks/useOpenOnQueryParam";
 import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { LensToggle } from "@/components/admin/LensToggle";
+import { useOwnershipLens } from "@/hooks/useOwnershipLens";
+import { applyLens } from "@/lib/ownership";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -464,7 +467,12 @@ function ProjectCard({ project, selected, onSelect }: { project: Project; select
 }
 
 export default function ProjectsPage() {
-  const { data: projects, isLoading } = useProjects();
+  const { data: rawProjects, isLoading } = useProjects();
+  // ONE lens across the CRM: narrowing contacts and narrowing projects is the
+  // same act of focus, so Projects reads the shared preference rather than
+  // carrying a toggle of its own (ActivitiesView used to — a third truth).
+  const { lens, uid, coveredUids } = useOwnershipLens();
+  const projects = applyLens(rawProjects, 'projects', lens, uid, coveredUids);
   const { data: stats } = useProjectTaskStats();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
@@ -491,7 +499,10 @@ export default function ProjectsPage() {
     <AdminLayout>
       <div className="space-y-6">
         <AdminPageHeader title="Projects" description="Manage projects, tasks, and track progress">
-          <NewProjectDialog open={newProjectOpen} onOpenChange={setNewProjectOpen} />
+          <div className="flex items-center gap-2">
+            <LensToggle />
+            <NewProjectDialog open={newProjectOpen} onOpenChange={setNewProjectOpen} />
+          </div>
         </AdminPageHeader>
 
         {isLoading ? (
@@ -518,8 +529,11 @@ export default function ProjectsPage() {
           </div>
 
           {mode === "activities" ? (
+            // Hela listan, inte den linsade: en uppgift tilldelad mig i NÅGON
+            // annans projekt är fortfarande min, så vyn gör sin egen
+            // sammansatta filtrering i stället för att ärva urvalet.
             <ActivitiesView
-              projects={projects}
+              projects={rawProjects ?? []}
               onOpenProject={(pid) => { setSelectedId(pid); setMode("projects"); setTab("board"); }}
             />
           ) : (

--- a/supabase/functions/agent-execute/index.ts
+++ b/supabase/functions/agent-execute/index.ts
@@ -13069,12 +13069,23 @@ async function executeGenericCrud(
         if ((insertData as any)._caller_user_id && !cleanInsert.created_by) {
           cleanInsert.created_by = (insertData as any)._caller_user_id;
         }
+        // Agent attribution, wiki_pages' convention (2026-08-29): when an agent
+        // writes, say WHICH agent. A NULL created_by already means "no logged-in
+        // human", but that conflates "FlowPilot did it" with "we don't know" —
+        // and to a colleague deciding whether to trust a row, those are
+        // different facts. Tables without the column fall through below.
+        if (auditCtx?.agent_type && !cleanInsert.created_by_agent) {
+          cleanInsert.created_by_agent = auditCtx.agent_type;
+        }
         let createdItem: any;
         try {
           const { data, error } = await supabase.from(table).insert(cleanInsert).select().single();
           if (error) {
-            if (error.message?.includes('created_by')) {
-              delete cleanInsert.created_by;
+            // Optional stamp columns: strip whichever this table lacks and retry
+            // once. Attribution is a bonus, never a reason a write fails.
+            const missing = ['created_by_agent', 'created_by'].filter((c) => error.message?.includes(c));
+            if (missing.length) {
+              for (const c of missing) delete cleanInsert[c];
               const { data: d2, error: e2 } = await supabase.from(table).insert(cleanInsert).select().single();
               if (e2) throw new Error(`Create ${table} failed: ${e2.message}`);
               createdItem = d2;
@@ -13109,12 +13120,15 @@ async function executeGenericCrud(
         const { limit: _l, offset: _o, order_by: _ob, ascending: _a, filters: _f, ...updateData } = fields;
         const cleanUpdate = stripInternalFields(updateData);
         cleanUpdate.updated_at = new Date().toISOString();
+        // Same reasoning as create: an agent's correction says whose it was.
+        if (auditCtx?.agent_type) cleanUpdate.updated_by_agent = auditCtx.agent_type;
         let updatedItem: any;
         try {
           const { data, error } = await supabase.from(table).update(cleanUpdate).eq('id', id).select().single();
           if (error) {
-            if (error.message?.includes('updated_at')) {
-              delete cleanUpdate.updated_at;
+            const missing = ['updated_by_agent', 'updated_at'].filter((c) => error.message?.includes(c));
+            if (missing.length) {
+              for (const c of missing) delete cleanUpdate[c];
               const { data: d2, error: e2 } = await supabase.from(table).update(cleanUpdate).eq('id', id).select().single();
               if (e2) throw new Error(`Update ${table} failed: ${e2.message}`);
               updatedItem = d2;

--- a/supabase/migrations/20260829230000_projekt-far-agare-och-handavtryck.sql
+++ b/supabase/migrations/20260829230000_projekt-far-agare-och-handavtryck.sql
@@ -1,0 +1,83 @@
+-- Projekt får ägare, och båda tabellerna får handavtryck (Magnus 2026-08-29).
+--
+-- Mätt före bygget på optic: 12 uppgifter, NOLL med ägare — därför visade
+-- "Mine" i aktivitetsvyn ingenting. Filtret fungerade; det fanns bara ingen
+-- data att filtrera på. Kontakterna räddades av ownership-on-create sedan
+-- 2026-08-08; projekt och uppgifter hade aldrig fått motsvarande.
+--
+-- Tre frågor, tre fält (wiki_pages är plattformens förebild):
+--   created_by  — proveniens. Vem förde in den. Oföränderlig.
+--   owner_id    — ansvar. Vems är den NU. Föränderlig; det är den linsen läser.
+--   updated_by  — sista handavtrycket. Vem rörde den sist, ihop med updated_at.
+--
+-- Skaparen blir ägare till PROJEKTET, men uppgifter tilldelas INTE automatiskt.
+-- Det följer direkt av vad "Mina" ska betyda (Magnus val): tilldelade mig plus
+-- OTILLDELAT i projekt jag äger. Tilldelade sig självt vid skapande fanns ingen
+-- backlogg kvar att fånga upp — och en uppgift ingen tagit är ett riktigt och
+-- användbart tillstånd.
+--
+-- Agentmarkörerna (created_by_agent/updated_by_agent) följer wikins konvention
+-- och läggs till HÄR därför att de nu har en skrivare: den generiska
+-- CRUD-motorn i agent-execute stämplar auditCtx.agent_type på varje db:-skrivning
+-- (manage_project, manage_project_task går den vägen). En NULL created_by säger
+-- bara "ingen inloggad människa" och blandar ihop "FlowPilot gjorde det" med
+-- "vi vet inte" — för en kollega som ska bedöma om raden går att lita på är det
+-- två helt olika fakta. Kolumn utan skrivare hade däremot varit samma spöke vi
+-- grävde bort ur leads samma kväll.
+--
+-- Idempotent + forward-daterad.
+
+ALTER TABLE public.projects
+  ADD COLUMN IF NOT EXISTS owner_id uuid,
+  ADD COLUMN IF NOT EXISTS updated_by uuid,
+  ADD COLUMN IF NOT EXISTS created_by_agent text,
+  ADD COLUMN IF NOT EXISTS updated_by_agent text;
+
+ALTER TABLE public.project_tasks
+  ADD COLUMN IF NOT EXISTS updated_by uuid,
+  ADD COLUMN IF NOT EXISTS created_by_agent text,
+  ADD COLUMN IF NOT EXISTS updated_by_agent text;
+
+COMMENT ON COLUMN public.projects.owner_id IS
+  'Who is accountable for this project now. Defaults to the creator, changeable. The ownership lens reads this.';
+
+-- Backfill: den som skapade projektet ansvarar för det tills någon annan tar
+-- över. Rör bara rader utan ägare — en satt ägare är ett beslut.
+UPDATE public.projects
+   SET owner_id = created_by
+ WHERE owner_id IS NULL AND created_by IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.project_stamp_hands()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE v_uid uuid := auth.uid();
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    -- Under service_role är auth.uid() NULL: en agent gör inte anspråk på
+    -- vare sig författarskap eller ansvar. En oägd rad är synlig sanning, en
+    -- felägd är en lögn med revisionsspår.
+    IF v_uid IS NULL THEN RETURN NEW; END IF;
+    IF NEW.created_by IS NULL THEN NEW.created_by := v_uid; END IF;
+    IF TG_TABLE_NAME = 'projects' AND NEW.owner_id IS NULL THEN
+      NEW.owner_id := v_uid;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  NEW.updated_by := COALESCE(v_uid, OLD.updated_by);
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS projects_stamp_hands ON public.projects;
+CREATE TRIGGER projects_stamp_hands
+  BEFORE INSERT OR UPDATE ON public.projects
+  FOR EACH ROW EXECUTE FUNCTION public.project_stamp_hands();
+
+DROP TRIGGER IF EXISTS project_tasks_stamp_hands ON public.project_tasks;
+CREATE TRIGGER project_tasks_stamp_hands
+  BEFORE INSERT OR UPDATE ON public.project_tasks
+  FOR EACH ROW EXECUTE FUNCTION public.project_stamp_hands();
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260829210000",
-      "migrations_count": 527,
+      "migration_head": "20260829230000",
+      "migrations_count": 528,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2113,6 +2113,10 @@
         {
           "version": "20260829210000",
           "name": "lagesbilden-vilar-pa-liggaren"
+        },
+        {
+          "version": "20260829230000",
+          "name": "projekt-far-agare-och-handavtryck"
         }
       ]
     },
@@ -2127,7 +2131,7 @@
       "functions": {
         "a2a": "sha256:33f9aa45f5a82d23f357aff397403b5b12a94dc3421984a1c883f23509c50f71",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
-        "agent-execute": "sha256:352821d8dd8d0b7c700ea1eede59d158bc140154fa62d9d4b5b6967b83ceba75",
+        "agent-execute": "sha256:99bf48242972cec07a3501f860c8c646d9163a64c78418befa347032e66e79c5",
         "agent-operate": "sha256:9edc79c928f9920a74d8cfbba484aeabe7b21fba0018ae2ec813031593a74798",
         "ai-task": "sha256:35ae34d3748467b51f716cfef3d80af31b08e92e801905277b8460765b017169",
         "automation-dispatcher": "sha256:3cb8681d7acce65624bd7957a432b143a2d959d769845dc71696b95c2ea2012b",


### PR DESCRIPTION
## Fyndet

Magnus valde "Mine" i aktivitetsvyn och fick tomt. Mätt på optic: **12 uppgifter, noll med ägare.** Filtret fungerade — det fanns ingen data att filtrera på. Kontakterna fick en ägar-trigger 2026-08-08; projekt och uppgifter fick aldrig motsvarande.

## Tre frågor, tre fält

| Fält | Fråga | Föränderligt |
|---|---|---|
| `created_by` | vem förde in den | nej |
| `owner_id` | vems är den **nu** | ja — linsen läser denna |
| `updated_by` | vem rörde den sist | ja |

Skaparen blir ägare till **projektet**. Uppgifter tilldelas **inte** automatiskt — det följer av definitionen av "Mina": *tilldelade mig plus otilldelat i projekt jag äger*. Autotilldelning hade utplånat den backlogg regeln finns för att fånga.

## Agentattribuering

Den generiska CRUD-motorn stämplar nu `created_by_agent` / `updated_by_agent` från `auditCtx.agent_type` — wiki_pages konvention, nu på varje `db:`-tabell som har kolumnerna. NULL `created_by` sa bara "ingen inloggad människa" och blandade ihop *FlowPilot gjorde det* med *vi vet inte*. Saknar tabellen kolumnen strippas fältet och skrivningen görs om: attribution får aldrig fälla en skrivning.

## En lins, tre ytor

ActivitiesView bar en egen All/Mine-växel vid sidan av CRM-linsen — en tredje sanning om vad "mitt" betyder. Nu delas linsen av Contacts, Projects och Activities. Aktivitetsvyn får **hela** projektlistan (en uppgift åt mig i någon annans projekt är fortfarande min) medan projekträlsen är linsad.

## Verifierat

tsc, eslint rent, full vitest **3426 gröna** (9 nya påståenden, negativtestade), manifest regenererat. Migrationen körd på optic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)