### PR TITLE
feat(ui): länkar i fri text lever — en implementation, alla ytor

### DIFF
--- a/src/components/admin/crm/UnifiedTimeline.tsx
+++ b/src/components/admin/crm/UnifiedTimeline.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useAuth } from '@/hooks/useAuth';
 import { useEditActivityNote } from '@/hooks/useEditActivityNote';
+import { LinkifiedText } from '@/components/ui/linkified-text';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -208,7 +209,10 @@ function TimelineList({ events, isLoading }: { events: TimelineEvent[]; isLoadin
                         expanded.has(event.id) ? 'whitespace-pre-wrap' : 'line-clamp-2',
                       )}
                     >
-                      {event.description}
+                      {/* A ledger entry that points at the wiki instead of
+                          repeating it is the right shape — so the pointer has
+                          to be a link, not text to select and copy. */}
+                      <LinkifiedText text={event.description} />
                     </p>
                   ) : (
                     // A corrected-away note: the row stands, the words are gone.

--- a/src/components/ui/linkified-text.tsx
+++ b/src/components/ui/linkified-text.tsx
@@ -1,0 +1,70 @@
+/**
+ * Free text with live links — one implementation, every surface.
+ *
+ * Born in River as a local `autoLink`, needed the moment someone logged a
+ * contact activity that pointed at the wiki instead of repeating it (Magnus,
+ * 2026-08-29): "teamets samlade reflektioner finns i wikin: <url>". That is
+ * exactly how a ledger should work — the entry stays short and points at the
+ * material — but the timeline printed the URL as dead text, so the reader had
+ * to select and copy it.
+ *
+ * Two decisions worth keeping:
+ *
+ * 1. An internal link navigates IN the app. A link to this instance's own
+ *    /admin/... is a route, not a destination on the internet; sending it
+ *    through target="_blank" reboots the whole SPA to land three metres away.
+ *    Same origin → router. Everything else → new tab, noreferrer.
+ *
+ * 2. The link's text is always the URL itself. Activities are not written only
+ *    by us — inbound email becomes activities and agents write them — so a
+ *    label someone else chose over a destination someone else chose is a small
+ *    phishing surface. Showing the address means seeing where you are going.
+ */
+import { Link } from 'react-router-dom';
+import { cn } from '@/lib/utils';
+
+/** Same-origin http(s) URL → the path a router can navigate to. Otherwise null. */
+export function internalPath(url: string): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const u = new URL(url);
+    if (u.origin !== window.location.origin) return null;
+    return `${u.pathname}${u.search}${u.hash}`;
+  } catch {
+    return null;
+  }
+}
+
+export function LinkifiedText({ text, className }: { text: string; className?: string }) {
+  // URLs and #tags; everything between them is rendered untouched as text.
+  const parts = text.split(/(\bhttps?:\/\/\S+|#[\w-]+)/g);
+
+  return (
+    <>
+      {parts.map((p, i) => {
+        if (/^https?:\/\//.test(p)) {
+          // Trailing punctuation belongs to the sentence, not the address:
+          // "…/wiki/MoteRedeye." must not link the full stop.
+          const trailing = p.match(/[.,;:!?)\]]+$/)?.[0] ?? '';
+          const url = trailing ? p.slice(0, -trailing.length) : p;
+          const path = internalPath(url);
+          const cls = cn('text-primary underline-offset-2 hover:underline break-all', className);
+          return (
+            <span key={i}>
+              {path ? (
+                <Link to={path} className={cls}>{url}</Link>
+              ) : (
+                <a href={url} target="_blank" rel="noreferrer" className={cls}>{url}</a>
+              )}
+              {trailing}
+            </span>
+          );
+        }
+        if (/^#[\w-]+$/.test(p)) {
+          return <span key={i} className="text-primary font-medium">{p}</span>;
+        }
+        return <span key={i}>{p}</span>;
+      })}
+    </>
+  );
+}

--- a/src/lib/__tests__/linkified-text.guardrails.test.ts
+++ b/src/lib/__tests__/linkified-text.guardrails.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Fri text får levande länkar — en implementation, alla ytor.
+ *
+ * Magnus loggade en aktivitet som pekade på wikin i stället för att upprepa
+ * den: "teamets samlade reflektioner finns i wikin: <url>" (2026-08-29). Det
+ * är exakt rätt form för en liggare — posten är kort och pekar på underlaget —
+ * men tidslinjen skrev ut adressen som död text. Samtidigt hade River redan
+ * löst det, i en lokal funktion ingen annan kunde nå.
+ *
+ * Två beslut pinnas här, båda värda mer än de ser ut:
+ *
+ * 1. Intern länk navigerar I appen. En länk till instansens eget /admin/... är
+ *    en rutt, inte en destination på internet; target="_blank" startar om hela
+ *    SPA:t för att landa tre meter bort.
+ * 2. Länkens text ÄR adressen. Aktiviteter skrivs inte bara av oss — inkommande
+ *    mejl blir aktiviteter och agenter skriver dem — så en etikett någon annan
+ *    valt över ett mål någon annan valt är en liten nätfiskeyta.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const comp = read('src/components/ui/linkified-text.tsx');
+const river = read('src/pages/admin/RiverPage.tsx');
+const timeline = read('src/components/admin/crm/UnifiedTimeline.tsx');
+
+describe('intern länk är en rutt, inte en resa ut', () => {
+  it('samma origin ger en router-länk — och beslutet är faktiskt inkopplat', () => {
+    expect(comp).toMatch(/if \(u\.origin !== window\.location\.origin\) return null/);
+    // Att <Link> FINNS i filen räcker inte: första versionen av den här grinden
+    // överlevde att `path` hårdkodades till null. Pinna kopplingen, inte
+    // närvaron — annars mäter grinden att koden är skriven, inte att den kör.
+    expect(comp).toMatch(/const path = internalPath\(url\);/);
+    expect(comp).toMatch(/\{path \? \(\s*\n\s*<Link to=\{path\}/);
+  });
+
+  it('allt annat öppnas i ny flik utan referrer', () => {
+    expect(comp).toMatch(/target="_blank" rel="noreferrer"/);
+  });
+
+  it('en trasig URL kraschar inte raden — den förblir text', () => {
+    expect(comp).toMatch(/\} catch \{\s*\n\s*return null;/);
+  });
+});
+
+describe('adressen är sin egen etikett', () => {
+  it('länktexten är URL:en, aldrig något annat', () => {
+    // Ingen etikettparameter, inget label-prop: komponenten kan inte ljuga om målet.
+    expect(comp).not.toMatch(/label\s*[?:]/);
+    expect(comp).toMatch(/>\{url\}<\/Link>/);
+    expect(comp).toMatch(/>\{url\}<\/a>/);
+  });
+
+  it('avslutande skiljetecken hör till meningen, inte till adressen', () => {
+    expect(comp).toMatch(/p\.match\(\/\[\.,;:!\?\)\\\]\]\+\$\/\)/);
+  });
+});
+
+describe('en implementation, inte två', () => {
+  it('River använder den delade komponenten och har ingen egen kvar', () => {
+    expect(river).toMatch(/import \{ LinkifiedText \}/);
+    expect(river).not.toMatch(/function autoLink\(/);
+  });
+
+  it('tidslinjen använder samma komponent', () => {
+    expect(timeline).toMatch(/import \{ LinkifiedText \}/);
+    expect(timeline).toMatch(/<LinkifiedText text=\{event\.description\} \/>/);
+  });
+});

--- a/src/lib/__tests__/linkified-text.render.test.tsx
+++ b/src/lib/__tests__/linkified-text.render.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { LinkifiedText } from '@/components/ui/linkified-text';
+
+const show = (text: string) =>
+  render(<MemoryRouter><LinkifiedText text={text} /></MemoryRouter>);
+
+describe('LinkifiedText renderar på riktigt', () => {
+  it('samma origin blir en router-länk (relativ href, ingen ny flik)', () => {
+    const url = `${window.location.origin}/admin/wiki/MoteRedeye`;
+    show(`Teamets reflektioner finns i wikin : ${url}`);
+    const a = screen.getByRole('link');
+    expect(a.getAttribute('href')).toBe('/admin/wiki/MoteRedeye');
+    expect(a.getAttribute('target')).toBeNull();
+    expect(a.textContent).toBe(url);
+  });
+
+  it('extern länk öppnas i ny flik utan referrer', () => {
+    show('Se https://redeye.se/analys för underlaget');
+    const a = screen.getByRole('link');
+    expect(a.getAttribute('href')).toBe('https://redeye.se/analys');
+    expect(a.getAttribute('target')).toBe('_blank');
+    expect(a.getAttribute('rel')).toBe('noreferrer');
+  });
+
+  it('punkten efter adressen hör till meningen', () => {
+    show('Underlaget ligger på https://redeye.se/analys.');
+    expect(screen.getByRole('link').getAttribute('href')).toBe('https://redeye.se/analys');
+    expect(document.body.textContent).toContain('analys.');
+  });
+
+  it('text utan länk lämnas orörd', () => {
+    show('Bara en vanlig anteckning');
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+});

--- a/src/pages/admin/RiverPage.tsx
+++ b/src/pages/admin/RiverPage.tsx
@@ -43,6 +43,7 @@ import {
   useTogglePin,
 } from '@/hooks/useRiver';
 import { cn } from '@/lib/utils';
+import { LinkifiedText } from '@/components/ui/linkified-text';
 
 const QUICK_EMOJIS = ['👍', '❤️', '🎉', '🚀', '🔥', '👀', '💡', '😂'];
 
@@ -57,34 +58,6 @@ function initialsFor(author: RiverAuthor | undefined, id: string) {
 
 function displayName(author: RiverAuthor | undefined, id: string) {
   return author?.full_name?.trim() || id.slice(0, 8);
-}
-
-function autoLink(text: string) {
-  // Linkify URLs and #tags
-  const parts = text.split(/(\bhttps?:\/\/\S+|#[\w-]+)/g);
-  return parts.map((p, i) => {
-    if (/^https?:\/\//.test(p)) {
-      return (
-        <a
-          key={i}
-          href={p}
-          target="_blank"
-          rel="noreferrer"
-          className="text-primary underline-offset-2 hover:underline break-all"
-        >
-          {p}
-        </a>
-      );
-    }
-    if (/^#[\w-]+$/.test(p)) {
-      return (
-        <span key={i} className="text-primary font-medium">
-          {p}
-        </span>
-      );
-    }
-    return <span key={i}>{p}</span>;
-  });
 }
 
 function Composer({
@@ -334,7 +307,7 @@ function RepliesThread({ parentId }: { parentId: string }) {
                 )}
               </div>
               <div className="text-sm whitespace-pre-wrap break-words mt-0.5">
-                {autoLink(r.body)}
+                <LinkifiedText text={r.body} />
               </div>
               {Array.isArray(r.media_urls) && r.media_urls.length > 0 && (
                 <div className="grid grid-cols-2 gap-2 mt-2 max-w-md">
@@ -434,7 +407,7 @@ function PostCard({
               </div>
             </div>
             <div className="text-[15px] whitespace-pre-wrap break-words mt-1 leading-relaxed">
-              {autoLink(post.body)}
+              <LinkifiedText text={post.body} />
             </div>
             {Array.isArray(post.media_urls) && post.media_urls.length > 0 && (
               <div


### PR DESCRIPTION
## Vad

`LinkifiedText` — Rivers lokala `autoLink` lyft till en delad komponent, använd i aktivitetstidslinjen och i River.

Två saker den tillför utöver originalet:

**Intern länk är en rutt.** En länk till instansens eget `/admin/wiki/…` navigerar i appen via routern. `target="_blank"` hade startat om hela SPA:t för att landa tre meter bort. Allt annat öppnas i ny flik med `noreferrer`.

**Adressen är sin egen etikett.** Komponenten har ingen label-parameter och kan därför inte ljuga om målet — relevant eftersom aktiviteter skrivs av inkommande mejl och av agenter, inte bara av oss.

Plus: avslutande skiljetecken hör till meningen, inte till adressen.

## Varför

Magnus loggade `"teamets samlade reflektioner finns i wikin: <url>"` — exakt rätt form för en liggare (posten är kort och pekar på underlaget), men adressen renderades som död text.

## Verifierat

tsc, eslint rent, full vitest **3435 gröna**.

Grindarna är av två slag med flit: sju källpåståenden **plus fyra riktiga renderingstester** (jsdom + MemoryRouter) som bevisar att intern länk får relativ href utan `target`, extern får `_blank`+`noreferrer`, och att punkten efter adressen stannar i meningen.

Noterbart: **första versionen av källgrinden överlevde att `path` hårdkodades till `null`** — den mätte att koden var skriven, inte att den kördes. Skärpt att pinna kopplingen, och beteendet bevisas nu i DOM:en där det hör hemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)