### PR TITLE
fix(crm): "Note Added" → "Note" — och en etikettkarta i stället för två

### DIFF
--- a/src/hooks/useActivities.ts
+++ b/src/hooks/useActivities.ts
@@ -217,20 +217,29 @@ export function useDeleteDealActivity() {
   });
 }
 
-// Activity type helpers
+// Activity type helpers — the ONE map. The unified timeline defers to this one
+// (it used to carry a second, drifted copy that said "Note added" where the
+// button that creates the entry says "Note" — Magnus 2026-08-29).
+//
+// Naming rule: a manually logged type is a NOUN. Every row in the ledger is an
+// added entry, so "added" is noise on exactly one of them — and the log should
+// echo the button that created it (Note / Call / Email / Meeting in
+// RecordDiscussPanel). System observations keep their verb, because there the
+// verb IS the content: an email being OPENED is the whole event.
 export function getActivityTypeInfo(type: string): { label: string; icon: string; color: string } {
   const types: Record<string, { label: string; icon: string; color: string }> = {
     call: { label: 'Call', icon: 'Phone', color: 'text-green-500' },
     email: { label: 'Email', icon: 'Mail', color: 'text-blue-500' },
     meeting: { label: 'Meeting', icon: 'Users', color: 'text-purple-500' },
     note: { label: 'Note', icon: 'MessageSquare', color: 'text-muted-foreground' },
-    form_submit: { label: 'Form Submitted', icon: 'FileText', color: 'text-orange-500' },
-    email_open: { label: 'Email Opened', icon: 'MailOpen', color: 'text-blue-400' },
-    link_click: { label: 'Link Clicked', icon: 'MousePointer', color: 'text-cyan-500' },
-    status_change: { label: 'Status Changed', icon: 'RefreshCw', color: 'text-yellow-500' },
+    form_submit: { label: 'Form submitted', icon: 'FileText', color: 'text-orange-500' },
+    email_open: { label: 'Email opened', icon: 'MailOpen', color: 'text-blue-400' },
+    link_click: { label: 'Link clicked', icon: 'MousePointer', color: 'text-cyan-500' },
+    status_change: { label: 'Status changed', icon: 'RefreshCw', color: 'text-yellow-500' },
     deal_closed_won: { label: 'Deal Won', icon: 'Trophy', color: 'text-green-500' },
     deal_closed_lost: { label: 'Deal Lost', icon: 'XCircle', color: 'text-red-500' },
-    webinar_register: { label: 'Webinar Registration', icon: 'Users', color: 'text-indigo-500' },
+    webinar_register: { label: 'Webinar registration', icon: 'Video', color: 'text-indigo-500' },
+    task_completed: { label: 'Task completed', icon: 'CheckCircle2', color: 'text-green-500' },
   };
   return types[type] || { label: type, icon: 'Activity', color: 'text-muted-foreground' };
 }

--- a/src/hooks/useUnifiedTimeline.ts
+++ b/src/hooks/useUnifiedTimeline.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { getActivityTypeInfo } from '@/hooks/useActivities';
 
 export interface TimelineEvent {
   id: string;
@@ -242,60 +243,27 @@ export function useUnifiedTimeline(leadId: string | undefined, email: string | u
   });
 }
 
+/**
+ * The row's headline. Contextual titles live here because the context is in the
+ * metadata (which form, which task, which transition); the plain labels come
+ * from getActivityTypeInfo, the one map — this function used to carry a second
+ * copy that had drifted ("Note added" where the button says "Note", "Email
+ * sent" on an activity a human logs for mail in EITHER direction).
+ */
 function getActivityTitle(type: string, meta: Record<string, unknown> | null): string {
-  if (type === 'task_completed') {
-    return meta?.task_title ? `Task done: ${meta.task_title}` : 'Task completed';
-  }
-  const titles: Record<string, string> = {
-    call: 'Phone call',
-    email: 'Email sent',
-    meeting: 'Meeting',
-    note: 'Note added',
-    form_submit: `Form: ${meta?.form_name || 'submitted'}`,
-    email_open: 'Email opened',
-    link_click: 'Link clicked',
-    status_change: `Status: ${meta?.from} → ${meta?.to}`,
-    deal_closed_won: 'Deal won',
-    deal_closed_lost: 'Deal lost',
-    webinar_register: 'Webinar registration',
-  };
-  return meta?.title as string || titles[type] || type;
+  if (meta?.title) return meta.title as string;
+  if (type === 'task_completed' && meta?.task_title) return `Task done: ${meta.task_title}`;
+  if (type === 'form_submit') return `Form: ${meta?.form_name || 'submitted'}`;
+  if (type === 'status_change') return `Status: ${meta?.from} → ${meta?.to}`;
+  return getActivityTypeInfo(type).label;
 }
 
 function getActivityIcon(type: string): string {
-  const icons: Record<string, string> = {
-    call: 'Phone',
-    email: 'Mail',
-    meeting: 'Users',
-    note: 'MessageSquare',
-    form_submit: 'FileText',
-    email_open: 'MailOpen',
-    link_click: 'MousePointer',
-    status_change: 'RefreshCw',
-    deal_closed_won: 'Trophy',
-    deal_closed_lost: 'XCircle',
-    webinar_register: 'Video',
-    task_completed: 'CheckCircle2',
-  };
-  return icons[type] || 'Activity';
+  return getActivityTypeInfo(type).icon;
 }
 
 function getActivityColor(type: string): string {
-  const colors: Record<string, string> = {
-    call: 'text-green-500',
-    email: 'text-blue-500',
-    meeting: 'text-purple-500',
-    note: 'text-muted-foreground',
-    form_submit: 'text-orange-500',
-    email_open: 'text-blue-400',
-    link_click: 'text-cyan-500',
-    status_change: 'text-yellow-500',
-    deal_closed_won: 'text-green-500',
-    deal_closed_lost: 'text-red-500',
-    webinar_register: 'text-indigo-500',
-    task_completed: 'text-green-500',
-  };
-  return colors[type] || 'text-muted-foreground';
+  return getActivityTypeInfo(type).color;
 }
 
 /**

--- a/src/lib/__tests__/activity-labels-one-map.guardrails.test.ts
+++ b/src/lib/__tests__/activity-labels-one-map.guardrails.test.ts
@@ -1,0 +1,73 @@
+/**
+ * En etikettkarta för aktiviteter — och manuella typer är substantiv.
+ *
+ * Fyndet (Magnus 2026-08-29): loggen visade "Note Added" medan knappen som
+ * skapar posten säger "Note". Orsaken var inte ordvalet utan att det fanns TVÅ
+ * kartor: getActivityTypeInfo (useActivities) sa "Note", "Call", "Email" och
+ * användes av ActivityTimeline; getActivityTitle (useUnifiedTimeline) bar en
+ * andra, drivande kopia som sa "Note added", "Phone call", "Email sent" — det
+ * sista dessutom fel, eftersom en människa loggar mejl i BÅDA riktningarna.
+ *
+ * Namnregeln som följer av liggaren: varje rad ÄR en tillagd post, så "added"
+ * är brus på exakt en typ. Manuellt loggade typer är substantiv och ska eka
+ * knappen som skapade dem. Systemobservationer behåller sitt verb, för där ÄR
+ * verbet innehållet — ett mejl som ÖPPNAS är hela händelsen.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getActivityTypeInfo } from '@/hooks/useActivities';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const timeline = read('src/hooks/useUnifiedTimeline.ts');
+const panel = read('src/components/admin/crm/RecordDiscussPanel.tsx');
+
+describe('manuellt loggade typer är substantiv', () => {
+  for (const [type, label] of [['note', 'Note'], ['call', 'Call'], ['email', 'Email'], ['meeting', 'Meeting']] as const) {
+    it(`${type} → "${label}"`, () => {
+      expect(getActivityTypeInfo(type).label).toBe(label);
+    });
+  }
+
+  it('och etiketten ekar knappen som skapar posten', () => {
+    for (const label of ['Note', 'Call', 'Email', 'Meeting']) {
+      expect(panel).toMatch(new RegExp(`label: '${label}'`));
+    }
+  });
+
+  it('systemobservationer behåller sitt verb — där är verbet innehållet', () => {
+    expect(getActivityTypeInfo('email_open').label).toBe('Email opened');
+    expect(getActivityTypeInfo('link_click').label).toBe('Link clicked');
+  });
+});
+
+describe('en karta, inte två', () => {
+  it('tidslinjen hämtar etikett, ikon och färg ur den delade kartan', () => {
+    expect(timeline).toMatch(/import \{ getActivityTypeInfo \}/);
+    expect(timeline).toMatch(/return getActivityTypeInfo\(type\)\.label;/);
+    expect(timeline).toMatch(/return getActivityTypeInfo\(type\)\.icon;/);
+    expect(timeline).toMatch(/return getActivityTypeInfo\(type\)\.color;/);
+  });
+
+  it('och bär ingen egen kopia av de enkla etiketterna längre', () => {
+    expect(timeline).not.toMatch(/note: 'Note added'/);
+    expect(timeline).not.toMatch(/email: 'Email sent'/);
+    expect(timeline).not.toMatch(/const icons: Record<string, string>/);
+    expect(timeline).not.toMatch(/const colors: Record<string, string>/);
+  });
+
+  it('men behåller de kontextuella titlarna — metadatan bor där', () => {
+    expect(timeline).toMatch(/Task done: \$\{meta\.task_title\}/);
+    expect(timeline).toMatch(/Form: \$\{meta\?\.form_name/);
+    expect(timeline).toMatch(/Status: \$\{meta\?\.from\} → \$\{meta\?\.to\}/);
+  });
+
+  it('varje typ tidslinjen kan möta har en etikett i kartan', () => {
+    // Fallbacken returnerar råa typnamnet; det är en degradering, inte en design.
+    for (const t of ['note', 'call', 'email', 'meeting', 'form_submit', 'email_open',
+                     'link_click', 'status_change', 'deal_closed_won', 'deal_closed_lost',
+                     'webinar_register', 'task_completed']) {
+      expect(getActivityTypeInfo(t).label).not.toBe(t);
+    }
+  });
+});


### PR DESCRIPTION
## Fyndet

Loggen visade **"Note Added"** där knappen som skapar posten säger **"Note"**. Ordvalet var symptomet; orsaken var två kartor som drivit isär:

| | `getActivityTypeInfo` (useActivities) | `getActivityTitle` (useUnifiedTimeline) |
|---|---|---|
| note | Note | **Note added** |
| call | Call | **Phone call** |
| email | Email | **Email sent** ← presumerar riktning |

"Email sent" var dessutom sakfel: en människa loggar mejl i båda riktningarna. Riktningen är känd först i `outbound_communications` — och där renderas den redan korrekt.

## Åtgärd

Tidslinjen hämtar etikett, ikon och färg ur den delade kartan och behåller bara de **kontextuella** titlarna, där metadatan bor (vilket formulär, vilken uppgift, vilken statusövergång). Kartan kompletterades med `task_completed`, som bara den lokala kopian hade.

## Namnregeln, nu skriven i koden

Varje rad i liggaren **är** en tillagd post — "added" är brus på exakt en typ. Manuellt loggade typer är **substantiv** och ekar knappen som skapade dem. Systemobservationer behåller sitt **verb**, för där är verbet innehållet: ett mejl som *öppnas* är hela händelsen.

## Verifierat

tsc, eslint rent, full vitest **3454 gröna** (10 nya påståenden), negativtestade i båda halvorna: återinförd "Note added" → rött, bruten delegering av ikonen → rött.

🤖 Generated with [Claude Code](https://claude.com/claude-code)