### PR TITLE
feat(crm): researchen syns på bolaget — fit-poäng, beslutsfattare och problemkarta

### DIFF
--- a/src/components/admin/companies/CompanyResearchHistory.tsx
+++ b/src/components/admin/companies/CompanyResearchHistory.tsx
@@ -1,0 +1,153 @@
+/**
+ * What the research actually found — on the record it was about.
+ *
+ * prospect_research and prospect_fit_analysis have been writing to `activities`
+ * (entity_type 'company') all along: the distilled summary, offerings, pain
+ * points, sources — and from the fit pass a score, an advice paragraph, the
+ * decision maker and a problem↔solution mapping. On Vinge that came to a fit of
+ * 86/100 and a named CFO at 99% confidence. None of it was rendered anywhere:
+ * the company page read only `web_summary` (Magnus, 2026-08-29).
+ *
+ * So this is not new intelligence — it is the intelligence the platform already
+ * paid for, finally shown. Which is also why it renders defensively: these rows
+ * were written by earlier versions of the handlers and by agents, so every
+ * field is treated as possibly absent rather than assumed.
+ */
+import { useCompanyResearch } from '@/hooks/useEntityActivities';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Sparkles, Target, User, Link2, Microscope } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { LinkifiedText } from '@/components/ui/linkified-text';
+
+const str = (v: unknown): string => (typeof v === 'string' ? v.trim() : '');
+const list = (v: unknown): string[] => (Array.isArray(v) ? v.filter((x) => typeof x === 'string') : []);
+
+export function CompanyResearchHistory({ companyId }: { companyId: string }) {
+  const { data: rows = [], isLoading } = useCompanyResearch(companyId);
+
+  if (isLoading) return null;
+  if (rows.length === 0) return null;
+
+  const latestFit = rows.find((r) => r.activity_type === 'fit_analysis');
+  const fit = (latestFit?.metadata ?? {}) as Record<string, unknown>;
+  const score = typeof fit.fit_score === 'number' ? fit.fit_score : null;
+  const advice = str(fit.fit_advice);
+  const dm = (fit.decision_maker ?? null) as Record<string, unknown> | null;
+  const mapping = Array.isArray(fit.problem_mapping)
+    ? (fit.problem_mapping as Array<Record<string, unknown>>)
+    : [];
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Microscope className="h-4 w-4" />
+          Research & fit
+        </CardTitle>
+        <CardDescription>
+          What prospecting found about this company — {rows.length} run{rows.length === 1 ? '' : 's'}, most recent first.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {latestFit && (
+          <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
+            <div className="flex items-center gap-3 flex-wrap">
+              <Target className="h-4 w-4 text-primary" />
+              <span className="text-sm font-medium">Fit</span>
+              {score !== null && (
+                <Badge variant={score >= 70 ? 'default' : 'outline'} className="font-mono">{score}/100</Badge>
+              )}
+              <span className="text-xs text-muted-foreground">
+                {formatDistanceToNow(new Date(latestFit.created_at), { addSuffix: true })}
+              </span>
+            </div>
+
+            {advice && <p className="text-sm leading-relaxed whitespace-pre-wrap">{advice}</p>}
+
+            {dm && str(dm.email) && (
+              <div className="flex items-start gap-2 text-sm">
+                <User className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+                <div>
+                  <span className="font-medium">
+                    {[str(dm.first_name), str(dm.last_name)].filter(Boolean).join(' ') || str(dm.email)}
+                  </span>
+                  {str(dm.position) && <span className="text-muted-foreground"> · {str(dm.position)}</span>}
+                  <div className="text-xs text-muted-foreground">{str(dm.email)}</div>
+                </div>
+              </div>
+            )}
+
+            {mapping.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-xs font-medium text-muted-foreground">Their problem → what we do about it</p>
+                {mapping.slice(0, 4).map((m, i) => (
+                  <div key={i} className="rounded-md border bg-background p-2 text-xs space-y-1">
+                    <p className="text-muted-foreground">{str(m.prospect_problem)}</p>
+                    <p>{str(m.our_solution)}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {rows.map((r) => {
+            const meta = (r.metadata ?? {}) as Record<string, unknown>;
+            const offerings = list(meta.main_offerings);
+            const pains = list(meta.potential_pain_points);
+            const sources = Array.isArray(meta.sources) ? (meta.sources as Array<Record<string, unknown>>) : [];
+            const contacts = typeof meta.contacts_found === 'number' ? meta.contacts_found : null;
+            return (
+              <div key={r.id} className="border-l-2 border-muted pl-3 space-y-1.5">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-sm font-medium">
+                    {r.activity_type === 'fit_analysis' ? 'Fit analysis' : 'Research'}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {formatDistanceToNow(new Date(r.created_at), { addSuffix: true })}
+                  </span>
+                  {contacts !== null && (
+                    <Badge variant="outline" className="text-[10px]">{contacts} contacts found</Badge>
+                  )}
+                </div>
+
+                {r.body && r.body !== 'Se metadata för hela bedömningen.' && (
+                  <p className="text-xs text-muted-foreground whitespace-pre-wrap">
+                    <LinkifiedText text={r.body} />
+                  </p>
+                )}
+
+                {offerings.length > 0 && (
+                  <p className="text-xs"><span className="text-muted-foreground">Offering: </span>{offerings.slice(0, 4).join(' · ')}</p>
+                )}
+                {pains.length > 0 && (
+                  <p className="text-xs"><span className="text-muted-foreground">Likely pain: </span>{pains.slice(0, 4).join(' · ')}</p>
+                )}
+
+                {sources.length > 0 && (
+                  <div className="flex flex-wrap gap-2 pt-0.5">
+                    {sources.slice(0, 4).map((s, i) => (
+                      <a
+                        key={i}
+                        href={str(s.url)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
+                      >
+                        <Link2 className="h-3 w-3" />
+                        {str(s.title) || str(s.url)}
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useEntityActivities.ts
+++ b/src/hooks/useEntityActivities.ts
@@ -144,3 +144,42 @@ export function useDeleteEntityActivity() {
     },
   });
 }
+
+/**
+ * Research and fit-analysis rows for one company.
+ *
+ * Lives here rather than in the companies component that renders it: this
+ * module owns reads of `activities`, and the table-ownership guardrail is
+ * right to insist — a domain reaching into another domain's table is how two
+ * readers of the same rows drift apart. (It caught exactly that on the first
+ * attempt, 2026-08-29.)
+ */
+export interface CompanyResearchRow {
+  id: string;
+  activity_type: string;
+  subject: string | null;
+  body: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export const COMPANY_RESEARCH_TYPES = ['research', 'fit_analysis'];
+
+export function useCompanyResearch(companyId: string | undefined) {
+  return useQuery({
+    queryKey: ['company-research', companyId],
+    enabled: !!companyId,
+    queryFn: async (): Promise<CompanyResearchRow[]> => {
+      const { data, error } = await supabase
+        .from('activities')
+        .select('id, activity_type, subject, body, metadata, created_at')
+        .eq('entity_type', 'company')
+        .eq('entity_id', companyId!)
+        .in('activity_type', COMPANY_RESEARCH_TYPES)
+        .order('created_at', { ascending: false })
+        .limit(20);
+      if (error) throw error;
+      return (data ?? []) as unknown as CompanyResearchRow[];
+    },
+  });
+}

--- a/src/lib/__tests__/research-is-shown.guardrails.test.ts
+++ b/src/lib/__tests__/research-is-shown.guardrails.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Det som prospekteringen fann ska synas på bolaget det handlar om.
+ *
+ * Fyndet (Magnus 2026-08-29, efter research på Vinge): "det finns är jag säker
+ * på men det presenteras förmodligen inte". Han hade rätt. prospect_research
+ * och prospect_fit_analysis skriver till `activities` (entity_type 'company')
+ * sedan handlarna skrevs: destillerad sammanfattning, erbjudanden, smärtpunkter,
+ * källor — och ur fit-passet ett poäng, en rådgivningsparagraf, beslutsfattaren
+ * och en problem↔lösning-mappning. På Vinge blev det fit 86/100 och en namngiven
+ * CFO med 99% konfidens. Företagssidan renderade bara `web_summary`.
+ *
+ * Det här är alltså ingen ny intelligens — det är den plattformen redan betalat
+ * för, äntligen visad. Grinden finns för att den inte ska bli osynlig igen.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const comp = read('src/components/admin/companies/CompanyResearchHistory.tsx');
+const hook = read('src/hooks/useEntityActivities.ts');
+const page = read('src/pages/admin/CompanyDetailPage.tsx');
+const handler = read('supabase/functions/_shared/handlers/prospect-research.ts');
+
+describe('läsaren hittar det skrivaren skrev', () => {
+  it('samma tabell, samma entity_type, samma activity_types', () => {
+    // Skrivarsidan: research-aktiviteten skrivs mot company-entiteten.
+    expect(handler).toMatch(/activity_type: 'research'/);
+    // Läsarsidan måste matcha exakt — det är här ett par som detta glider isär.
+    // Läsningen bor i hooken som ÄGER activities — table-ownership-grinden
+    // fångade att komponenten först läste tabellen rått, och hade rätt.
+    expect(hook).toMatch(/\.eq\('entity_type', 'company'\)/);
+    expect(hook).toMatch(/COMPANY_RESEARCH_TYPES = \['research', 'fit_analysis'\]/);
+    expect(comp).toMatch(/useCompanyResearch\(companyId\)/);
+    expect(comp).not.toMatch(/from\('activities'\)/);
+  });
+
+  it('och företagssidan monterar den', () => {
+    expect(page).toMatch(/<CompanyResearchHistory companyId=\{company\.id\} \/>/);
+  });
+});
+
+describe('fit-passets resultat visas, inte bara att det kördes', () => {
+  for (const [field, label] of [
+    ['fit_score', 'poängen'],
+    ['fit_advice', 'rådgivningen'],
+    ['decision_maker', 'beslutsfattaren'],
+    ['problem_mapping', 'problem→lösning'],
+  ] as const) {
+    it(`${label} renderas`, () => {
+      expect(comp).toMatch(new RegExp(`fit\\.${field}|${field}`));
+    });
+  }
+});
+
+describe('den ljuger inte när det saknas', () => {
+  it('ingen research → ingen kortyta alls', () => {
+    expect(comp).toMatch(/if \(rows\.length === 0\) return null;/);
+  });
+
+  it('varje fält behandlas som möjligen frånvarande — raderna är skrivna av agenter', () => {
+    expect(comp).toMatch(/const str = \(v: unknown\)/);
+    expect(comp).toMatch(/const list = \(v: unknown\)/);
+    expect(comp).toMatch(/typeof fit\.fit_score === 'number' \? fit\.fit_score : null/);
+  });
+});

--- a/src/pages/admin/CompanyDetailPage.tsx
+++ b/src/pages/admin/CompanyDetailPage.tsx
@@ -29,6 +29,7 @@ import { useCompany, useCompanyLeads, useUpdateCompany, useDeleteCompany } from 
 import { CreateLeadDialog } from '@/components/admin/CreateLeadDialog';
 import { usePlatformFormat } from '@/hooks/usePlatformFormat';
 import { getLeadStatusInfo } from '@/lib/lead-utils';
+import { CompanyResearchHistory } from '@/components/admin/companies/CompanyResearchHistory';
 import { supabase } from '@/integrations/supabase/client';
 import { callSkill } from '@/lib/call-skill';
 import { CompanyContactsSection } from '@/components/admin/CompanyContactsSection';
@@ -447,6 +448,14 @@ export default function CompanyDetailPage() {
               )}
             </CardContent>
           </Card>
+
+          {/* What prospecting found — stored in `activities` since the research
+              handler was written, rendered nowhere until now (Magnus 2026-08-29:
+              "det finns är jag säker på men det presenteras förmodligen inte").
+              Renders nothing when the company has never been researched. */}
+          <div className="lg:col-span-2">
+            <CompanyResearchHistory companyId={company.id} />
+          </div>
 
           {/* Contacts/Leads */}
           <Card className="lg:col-span-2">


### PR DESCRIPTION
## Fyndet

Magnus öppnade Vinge efter en prospektering och såg ingenting av den. Datat fanns:

| Sparat sedan länge i `activities` | Visades |
|---|---|
| Fit-poäng **86/100** | nej |
| Rådgivningsparagraf | nej |
| Beslutsfattare (CFO, 99% konfidens) | nej |
| Problem↔lösning-mappning | nej |
| Sammanfattning, erbjudanden, smärtpunkter, källor | nej |
| `web_summary` | ja |

## Vad som byggdes

Ett **Research & fit**-kort på företagssidan: senaste fit-passet överst (poäng, råd, beslutsfattare, fyra första problem→lösning-paren), därunder varje körning i tidsordning med sammanfattning, erbjudanden, smärtpunkter och klickbara källor.

Ingen ny intelligens — den plattformen redan betalat för, äntligen visad.

Renderar defensivt: raderna skrevs av agenter och av tidigare versioner av handlarna, så varje fält behandlas som möjligen frånvarande. Ingen research → ingen kortyta alls.

## Bifynd som blev rätt

`table-ownership`-grinden fällde första versionen: komponenten läste `activities` rått från companies-domänen. Frågan bor nu i `useEntityActivities`, som äger tabellen. Grinden hade rätt — två läsare av samma rader i olika domäner är hur de driver isär.

## Verifierat

tsc, eslint rent, full vitest **3452 gröna** (11 nya påståenden, negativtestade). Datat bekräftat på optic: Vinge har `research` + `fit_analysis` med fullständig metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)