### PR TITLE
feat(wiki): läsytan först — dragbar kolumn och tyst New page

### DIFF
--- a/src/lib/__tests__/wiki-reading-surface.guardrails.test.ts
+++ b/src/lib/__tests__/wiki-reading-surface.guardrails.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Wikin är en läsyta — bredden är läsarens, och skapandet är tyst.
+ *
+ * Två fynd samma dag (Magnus 2026-08-29), båda om samma sak: sidan ska bära
+ * innehåll, inte gränssnitt.
+ *
+ * 1. Trädet tog en fast tredjedel. På en mindre desktop äter det läsytan, och
+ *    wikin är på väg att bli navet — ett Enterprise Context System. Bredden
+ *    dras nu av läsaren och minns per ENHET (localStorage), till skillnad från
+ *    ägarlinsen som följer människan mellan enheter (profiles.preferences). En
+ *    kolumnbredd hör till skärmen man sitter vid.
+ * 2. "New page" var en fylld helbreddsknapp — det tyngsta ett gränssnitt kan
+ *    innehålla, riktat mot den ovanligaste handlingen på sidan. De flesta besök
+ *    läser, några redigerar, få skapar. Sökrutan behåller vikten.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const page = readFileSync(join(process.cwd(), 'src/pages/admin/WikiPage.tsx'), 'utf-8');
+
+describe('bredden är läsarens', () => {
+  it('kolumnen är dragbar och klamrad', () => {
+    expect(page).toMatch(/cursor-col-resize/);
+    expect(page).toMatch(/Math\.min\(SIDEBAR_MAX, Math\.max\(SIDEBAR_MIN/);
+  });
+
+  it('och nåbar utan mus', () => {
+    expect(page).toMatch(/role="separator"/);
+    expect(page).toMatch(/e\.key === 'ArrowLeft'/);
+    expect(page).toMatch(/e\.key === 'ArrowRight'/);
+  });
+
+  it('minns per enhet, och klarar att lagringen är blockerad', () => {
+    expect(page).toMatch(/localStorage\.getItem\(SIDEBAR_KEY\)/);
+    expect(page).toMatch(/} catch \{/);
+  });
+
+  it('handtaget erbjuds aldrig när det inte finns något att dra', () => {
+    // Trädet är dolt i redigeringsläge och staplat på mobil.
+    expect(page).toMatch(/\{!\(editing && page\) && \(/);
+    expect(page).toMatch(/hidden lg:flex w-1\.5/);
+  });
+});
+
+describe('skapandet är tyst, sökandet har vikten', () => {
+  it('ingen fylld helbreddsknapp för New page', () => {
+    expect(page).not.toMatch(/<Button onClick=\{handleNew\} size="sm" className="w-full">/);
+  });
+
+  it('utan en diskret ikonknapp — som ändå går att nå med skärmläsare', () => {
+    expect(page).toMatch(/onClick=\{handleNew\}[\s\S]{0,200}variant="ghost"/);
+    expect(page).toMatch(/aria-label="New page"/);
+  });
+
+  it('sökrutan är kvar som ytans tyngsta element', () => {
+    expect(page).toMatch(/placeholder="Search pages & content…"/);
+    expect(page).toMatch(/⌘K/);
+  });
+});

--- a/src/pages/admin/WikiPage.tsx
+++ b/src/pages/admin/WikiPage.tsx
@@ -46,6 +46,39 @@ import { usePlatformFormat } from '@/hooks/usePlatformFormat';
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
 
+
+/**
+ * The tree's width, dragged by the reader.
+ *
+ * Wikin är på väg att bli navet — ett Enterprise Context System — och på en
+ * mindre desktop äter en fast tredjedel av läsytan (Magnus 2026-08-29).
+ *
+ * Varför inte ResizablePanelGroup, som redan finns i projektet: den kräver båda
+ * panelerna som direkta barn och delar alltid horisontellt. Den här sidan
+ * STAPLAR på mobil och DÖLJER trädet helt i redigeringsläge, så biblioteket
+ * hade tvingat fram två parallella JSX-träd med samma barn. En dragbar kant på
+ * en flexrad behåller ett träd.
+ *
+ * Bredden sparas i localStorage och INTE i profiles.preferences, till skillnad
+ * från ägarlinsen. Skillnaden är avsiktlig: linsen är ett sätt att arbeta och
+ * följer människan mellan enheter, medan en kolumnbredd hör till skärmen man
+ * sitter vid. En bredd som följde med från 34 tum till en laptop vore fel.
+ */
+const SIDEBAR_KEY = 'wiki-sidebar-width';
+const SIDEBAR_DEFAULT = 288;
+const SIDEBAR_MIN = 180;
+const SIDEBAR_MAX = 560;
+
+function readStoredWidth(): number {
+  try {
+    const raw = Number(localStorage.getItem(SIDEBAR_KEY));
+    if (Number.isFinite(raw) && raw >= SIDEBAR_MIN && raw <= SIDEBAR_MAX) return raw;
+  } catch {
+    // Private mode / blocked storage: the default is a perfectly good answer.
+  }
+  return SIDEBAR_DEFAULT;
+}
+
 export default function WikiPage() {
   const enabled = useIsModuleEnabled('wiki');
   if (!enabled) {
@@ -228,28 +261,72 @@ function WikiPageInner() {
 
   const searching2 = search.trim().length >= 2;
 
+  // Sidebar width: dragged, clamped, remembered per device.
+  const [sidebarWidth, setSidebarWidth] = useState<number>(readStoredWidth);
+  const widthRef = useRef(sidebarWidth);
+  widthRef.current = sidebarWidth;
+
+  const startResize = (e: React.PointerEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = widthRef.current;
+    const onMove = (ev: PointerEvent) => {
+      const next = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, startW + ev.clientX - startX));
+      setSidebarWidth(next);
+    };
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      try { localStorage.setItem(SIDEBAR_KEY, String(widthRef.current)); } catch { /* ignore */ }
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
+
+  // Keyboard: a drag handle nobody can reach without a mouse is half a feature.
+  const nudge = (delta: number) => {
+    const next = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, widthRef.current + delta));
+    setSidebarWidth(next);
+    try { localStorage.setItem(SIDEBAR_KEY, String(next)); } catch { /* ignore */ }
+  };
+
   return (
     <AdminLayout>
       <AdminPageContainer>
-        <div className="grid grid-cols-12 gap-6">
+        <div
+          className="flex flex-col lg:flex-row gap-6"
+          style={{ ['--wiki-sidebar' as string]: `${sidebarWidth}px` }}
+        >
           {/* Sidebar — steps aside while WRITING an existing page: the moment
               full width is needed is known (edit mode), so no show/hide buttons.
               A NEW page auto-opens in edit mode — hiding the tree there made the
               whole wiki look empty (/admin/wiki lands on a not-yet-created
               HomePage, live 2026-08-20), so new-page editing keeps navigation. */}
-          <aside className={editing && page ? 'hidden' : 'col-span-12 lg:col-span-3 min-w-0 space-y-3'}>
+          <aside className={editing && page ? 'hidden' : 'w-full lg:w-[var(--wiki-sidebar)] lg:shrink-0 min-w-0 space-y-3'}>
+            {/* A reading surface, not a dashboard. A full-width filled button
+                is the loudest thing a page can contain, and it was pointed at
+                the rarest action here: most visits read, some edit, few create
+                (Magnus 2026-08-29 — "fokus ska vara på content och läsbarhet").
+                Creation moves to a quiet + beside the title, the Notion/Docs
+                placement; search keeps the weight, because finding is what
+                people actually came to do. */}
             <div className="flex items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <BookOpen className="h-5 w-5 text-primary" />
-                <h1 className="font-serif text-lg font-bold text-foreground">Wiki</h1>
+              <div className="flex items-center gap-2 min-w-0">
+                <BookOpen className="h-5 w-5 text-primary shrink-0" />
+                <h1 className="font-serif text-lg font-bold text-foreground truncate">Wiki</h1>
+                <span className="text-xs text-muted-foreground shrink-0">{pages.length}</span>
               </div>
-              <Badge variant="secondary" className="text-[10px]">
-                {pages.length} pages
-              </Badge>
+              <Button
+                onClick={handleNew}
+                size="sm"
+                variant="ghost"
+                className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                title="New page"
+                aria-label="New page"
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
             </div>
-            <Button onClick={handleNew} size="sm" className="w-full">
-              <Plus className="h-3.5 w-3.5 mr-1.5" /> New page
-            </Button>
             <div className="relative">
               <Search className="absolute left-2 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
               <Input
@@ -304,8 +381,34 @@ function WikiPageInner() {
             </ScrollArea>
           </aside>
 
+          {/* The drag handle. Hidden on small screens (the layout stacks) and in
+              edit mode (the tree is gone), so it never offers a grip on nothing.
+              Double-click restores the default — a reader who drags too far
+              should not have to guess the original number. */}
+          {!(editing && page) && (
+            <div
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="Resize the page list"
+              aria-valuenow={sidebarWidth}
+              aria-valuemin={SIDEBAR_MIN}
+              aria-valuemax={SIDEBAR_MAX}
+              tabIndex={0}
+              onPointerDown={startResize}
+              onDoubleClick={() => nudge(SIDEBAR_DEFAULT - sidebarWidth)}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowLeft') { e.preventDefault(); nudge(-16); }
+                if (e.key === 'ArrowRight') { e.preventDefault(); nudge(16); }
+              }}
+              className="hidden lg:flex w-1.5 shrink-0 cursor-col-resize items-center justify-center rounded-full bg-transparent transition-colors hover:bg-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              title="Drag to resize · double-click to reset"
+            >
+              <div className="h-8 w-0.5 rounded-full bg-border" />
+            </div>
+          )}
+
           {/* Main */}
-          <main className={editing && page ? 'col-span-12 space-y-4' : 'col-span-12 lg:col-span-9 space-y-4'}>
+          <main className={editing && page ? 'w-full space-y-4' : 'flex-1 min-w-0 space-y-4'}>
             {trail.length > 0 && (
               <nav className="flex items-center gap-1 text-xs text-muted-foreground">
                 {trail.map((t) => (


### PR DESCRIPTION
## Två fynd, samma sak

Wikin ska bära innehåll, inte gränssnitt.

**Bredden är läsarens.** Trädet tog en fast tredjedel — på en mindre desktop äter det läsytan. Kolumnen dras nu (180–560 px), dubbelklick återställer, piltangenter fungerar för den som inte har mus. Bredden minns **per enhet** i localStorage: medvetet *inte* i `profiles.preferences` som ägarlinsen, eftersom linsen är ett sätt att arbeta som följer människan mellan enheter medan en kolumnbredd hör till skärmen man sitter vid.

**Skapandet är tyst.** `New page` var en fylld helbreddsknapp — det tyngsta ett gränssnitt kan innehålla, riktat mot den ovanligaste handlingen på sidan. De flesta besök läser, några redigerar, få skapar. Nu en diskret `+` bredvid rubriken (Notion/Docs-placeringen), sidräknaren utan badge, och sökrutan behåller vikten.

## Varför inte ResizablePanelGroup

Den finns i projektet, men kräver båda panelerna som direkta barn och delar alltid horisontellt. Den här sidan **staplar** på mobil och **döljer** trädet helt i redigeringsläge — biblioteket hade tvingat fram två parallella JSX-träd med samma barn. En dragbar kant på en flexrad behåller ett träd.

## Verifierat

tsc, lint-baslinjen oförändrad (de fyra `any` är förexisterande `page as any`), full vitest **3461 gröna** (7 nya påståenden), negativtestade i båda halvorna: borttaget tangentbordsstöd → rött, återinförd fylld knapp → rött.

🤖 Generated with [Claude Code](https://claude.com/claude-code)