### PR TITLE
fix(wiki): rännan är handtaget, inte död yta

### DIFF
--- a/src/lib/__tests__/wiki-reading-surface.guardrails.test.ts
+++ b/src/lib/__tests__/wiki-reading-surface.guardrails.test.ts
@@ -39,7 +39,20 @@ describe('bredden är läsarens', () => {
   it('handtaget erbjuds aldrig när det inte finns något att dra', () => {
     // Trädet är dolt i redigeringsläge och staplat på mobil.
     expect(page).toMatch(/\{!\(editing && page\) && \(/);
-    expect(page).toMatch(/hidden lg:flex w-1\.5/);
+    expect(page).toMatch(/hidden lg:flex w-3/);
+  });
+});
+
+describe('rännan är handtaget, inte död yta', () => {
+  it('inget gap mellan kolumnerna på desktop — bara när layouten staplar', () => {
+    // gap-6 på båda sidor gav ~54 px tomrum mitt i läsytan.
+    expect(page).toMatch(/flex flex-col gap-6 lg:flex-row lg:gap-0/);
+    expect(page).not.toMatch(/flex flex-col lg:flex-row gap-6/);
+  });
+
+  it('12 px att träffa, 1 px att se', () => {
+    expect(page).toMatch(/w-3 shrink-0 cursor-col-resize/);
+    expect(page).toMatch(/<div className="w-px bg-border/);
   });
 });
 

--- a/src/pages/admin/WikiPage.tsx
+++ b/src/pages/admin/WikiPage.tsx
@@ -294,7 +294,10 @@ function WikiPageInner() {
     <AdminLayout>
       <AdminPageContainer>
         <div
-          className="flex flex-col lg:flex-row gap-6"
+          // gap-6 mellan kolumnerna gav ~54 px död yta på lg (24 + handtaget +
+          // 24). På desktop ÄR handtaget rännan; gapet behövs bara när layouten
+          // staplar (Magnus 2026-08-29).
+          className="flex flex-col gap-6 lg:flex-row lg:gap-0"
           style={{ ['--wiki-sidebar' as string]: `${sidebarWidth}px` }}
         >
           {/* Sidebar — steps aside while WRITING an existing page: the moment
@@ -400,10 +403,11 @@ function WikiPageInner() {
                 if (e.key === 'ArrowLeft') { e.preventDefault(); nudge(-16); }
                 if (e.key === 'ArrowRight') { e.preventDefault(); nudge(16); }
               }}
-              className="hidden lg:flex w-1.5 shrink-0 cursor-col-resize items-center justify-center rounded-full bg-transparent transition-colors hover:bg-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              // 12 px att träffa, 1 px att se: greppytan får inte kosta läsyta.
+              className="group hidden lg:flex w-3 shrink-0 cursor-col-resize items-stretch justify-center bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               title="Drag to resize · double-click to reset"
             >
-              <div className="h-8 w-0.5 rounded-full bg-border" />
+              <div className="w-px bg-border transition-colors group-hover:bg-primary/50 group-focus-visible:bg-primary/50" />
             </div>
           )}
 


### PR DESCRIPTION
## Vad

`gap-6` låg på **båda** sidor om dragkanten: 24 px + handtaget + 24 px ≈ **54 px tomrum** mitt i läsytan.

Gapet behövs bara när layouten staplar, så det gäller nu enbart under `lg`. På desktop **är** handtaget rännan: 12 px att träffa, 1 px att se. Linjen tänds i primärfärg vid hover och tangentbordsfokus — synlig när den ska gripas, osynlig annars.

## Verifierat

tsc, lint-baslinjen oförändrad (fyra förexisterande `any`), full vitest **3471 gröna** (2 nya påståenden), negativtestade: återinfört gap → rött.

🤖 Generated with [Claude Code](https://claude.com/claude-code)