### PR TITLE
fix(crm): researchen får hela bredden, kontakterna flyttar upp

### DIFF
--- a/src/lib/__tests__/research-is-shown.guardrails.test.ts
+++ b/src/lib/__tests__/research-is-shown.guardrails.test.ts
@@ -35,8 +35,12 @@ describe('läsaren hittar det skrivaren skrev', () => {
     expect(comp).not.toMatch(/from\('activities'\)/);
   });
 
-  it('och företagssidan monterar den', () => {
+  it('och företagssidan monterar den — över hela bredden, under kontakterna', () => {
     expect(page).toMatch(/<CompanyResearchHistory companyId=\{company\.id\} \/>/);
+    // Fit-råd, beslutsfattare och problem→lösning-paren är mycket text; en
+    // tredjedels kolumn gjorde den till en smal remsa (Magnus 2026-08-29).
+    expect(page).toMatch(/lg:col-span-3">\s*\n\s*<CompanyResearchHistory/);
+    expect(page.indexOf('Contacts/Leads')).toBeLessThan(page.indexOf('<CompanyResearchHistory companyId'));
   });
 });
 

--- a/src/pages/admin/CompanyDetailPage.tsx
+++ b/src/pages/admin/CompanyDetailPage.tsx
@@ -449,13 +449,6 @@ export default function CompanyDetailPage() {
             </CardContent>
           </Card>
 
-          {/* What prospecting found — stored in `activities` since the research
-              handler was written, rendered nowhere until now (Magnus 2026-08-29:
-              "det finns är jag säker på men det presenteras förmodligen inte").
-              Renders nothing when the company has never been researched. */}
-          <div className="lg:col-span-2">
-            <CompanyResearchHistory companyId={company.id} />
-          </div>
 
           {/* Contacts/Leads */}
           <Card className="lg:col-span-2">
@@ -533,6 +526,14 @@ export default function CompanyDetailPage() {
               )}
             </CardContent>
           </Card>
+
+          {/* Research under kontakterna och över hela bredden: fit-råd,
+              beslutsfattare och problem→lösning-paren är mycket text, och en
+              tredjedels kolumn gör den till en smal remsa. Kontakterna är en
+              lista och trivs bredvid faktarutan (Magnus 2026-08-29). */}
+          <div className="lg:col-span-3">
+            <CompanyResearchHistory companyId={company.id} />
+          </div>
         </div>
 
         {id && <CompanyContactsSection companyId={id} />}


### PR DESCRIPTION
## Vad

| | Före | Efter |
|---|---|---|
| Rad 1 | faktaruta (1) + **research** (2) | faktaruta (1) + **kontakter** (2) |
| Rad 2 | kontakter (2) + tomrum (1) | **research (3 av 3)** |

Fit-råd, beslutsfattare och problem→lösning-paren är mycket text; en tredjedels kolumn gjorde den till en smal remsa. Kontakterna är en lista och trivs bredvid faktarutan — och bytet fyller samtidigt tomrummet kontakterna lämnade när de låg ensamma på sin rad.

## Verifierat

tsc, full vitest **3471 gröna**. Grinden pinnar både bredden och ordningen, eftersom det är kombinationen som ger läsytan — negativtestad: `col-span-2` → rött.

🤖 Generated with [Claude Code](https://claude.com/claude-code)