### PR TITLE
feat(crm): prospektets proveniens — vem bad, vem gjorde, och vems den blir

### DIFF
--- a/src/lib/__tests__/prospect-provenance.guardrails.test.ts
+++ b/src/lib/__tests__/prospect-provenance.guardrails.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Vem bad om researchen, vem gjorde jobbet, och vems blir kontakten.
+ *
+ * Fyndet (Magnus 2026-08-29): "när jag körde en research och fick Lisa som lead
+ * — så står hon inte på admin som körde researchen. Är det systemet som kör
+ * researchen? Och isåfall, hur lägger jag kontakten på mig?"
+ *
+ * Nej, det är inte systemet. En människa bad om den, agenten utförde den. Tre
+ * fakta, tre kolumner:
+ *   created_by        vem som bad (proveniens, oföränderlig)
+ *   created_by_agent  vilken agent som gjorde jobbet
+ *   assigned_to       ansvar — och det BÖRJAR vid befordran
+ *
+ * Att låta researchen sätta ägare vore att upphäva triagen (#330): ett fynd är
+ * ingens tills någon väljer att gå vidare. Men den som väljer är den självklara
+ * ägaren — så "hur lägger jag kontakten på mig" blir ett klick.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const handler = read('supabase/functions/_shared/handlers/prospect-research.ts');
+const page = read('src/pages/admin/LeadsPage.tsx');
+const sql = read('supabase/migrations/20260830090000_prospektets-proveniens.sql');
+
+describe('researchen stämplar vem som bad och vem som gjorde', () => {
+  it('båda fälten sätts på prospektet', () => {
+    const insert = handler.slice(handler.indexOf('const leadPayload'));
+    expect(insert).toMatch(/created_by: \(args as any\)\._caller_user_id \?\? null/);
+    expect(insert).toMatch(/created_by_agent: \(args as any\)\._effective_agent \?\? null/);
+  });
+
+  it('men ingen ägare — triagen upphävs inte', () => {
+    const insert = handler.slice(handler.indexOf('const leadPayload'), handler.indexOf('const contactMeta'));
+    expect(insert).not.toMatch(/assigned_to:/);
+  });
+
+  it('och en instans utan kolumnerna tappar inte sina kontakter', () => {
+    // Attribution är en bonus, aldrig en grind: strippa och skriv om.
+    expect(handler).toMatch(/\['created_by_agent', 'created_by'\]\.filter/);
+    expect(handler).toMatch(/lead insert failed after stripping provenance/);
+  });
+
+  it('kolumnerna finns i schemat', () => {
+    expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS created_by_agent text/);
+  });
+});
+
+describe('befordran gör kontakten till min', () => {
+  it('otilldelat prospekt hamnar på den som befordrar', () => {
+    expect(page).toMatch(/if \(!current\?\.assigned_to && uid\) patch\.assigned_to = uid;/);
+  });
+
+  it('men en redan tilldelad kontakt kapas inte', () => {
+    expect(page).toMatch(/\.select\('assigned_to'\)\.eq\('id', id\)/);
+  });
+
+  it('och besked ges bara när något faktiskt togs över', () => {
+    expect(page).toMatch(/claimed \? ' — assigned to you' : ''/);
+  });
+});

--- a/src/pages/admin/LeadsPage.tsx
+++ b/src/pages/admin/LeadsPage.tsx
@@ -88,13 +88,25 @@ export default function LeadsPage() {
 
   const promoteProspect = useMutation({
     mutationFn: async (id: string) => {
+      // Ownership begins on promotion. A prospecting find is deliberately
+      // nobody's while it sits in triage — the agent must not guess an owner —
+      // but the person who decides to pursue it is the obvious owner, and
+      // saying so here means "how do I put this contact on me" is one click
+      // (Magnus 2026-08-29). An already-assigned prospect keeps its owner:
+      // claiming someone else's contact by promoting it would be a surprise.
+      const { data: current } = await supabase
+        .from('leads').select('assigned_to').eq('id', id).maybeSingle();
+      const patch: Record<string, unknown> = { status: promoteTarget.key as LeadStatus };
+      if (!current?.assigned_to && uid) patch.assigned_to = uid;
+
       const { data, error } = await supabase
-        .from('leads').update({ status: promoteTarget.key as LeadStatus }).eq('id', id).select('id');
+        .from('leads').update(patch).eq('id', id).select('id, assigned_to');
       if (error) throw error;
       if (!data?.length) throw new Error('Nothing was updated — you may not have permission.');
+      return { claimed: data[0].assigned_to === uid && !current?.assigned_to };
     },
-    onSuccess: () => {
-      toast.success(`Promoted to ${promoteTarget.name}`);
+    onSuccess: ({ claimed }) => {
+      toast.success(`Promoted to ${promoteTarget.name}${claimed ? ' — assigned to you' : ''}`);
       queryClient.invalidateQueries({ queryKey: ['leads'] });
       queryClient.invalidateQueries({ queryKey: ['lead-stats'] });
     },

--- a/supabase/functions/_shared/handlers/prospect-research.ts
+++ b/supabase/functions/_shared/handlers/prospect-research.ts
@@ -238,6 +238,14 @@ export async function executeProspectResearch(
         // promotes it (or deletes it). Existing leads matched by email keep
         // their status — an already-working contact is never demoted.
         status: 'prospect',
+        // Who asked, and who did the work — two facts, two columns. A human
+        // triggered this research; the agent carried it out. Ownership is
+        // deliberately NOT set: the whole point of the triage tab is that a
+        // find is nobody's until someone promotes it (#330). But "who asked
+        // for this" must never be unknown — an empty created_by used to say
+        // both "the system" and "we have no idea" (Magnus 2026-08-29).
+        created_by: (args as any)._caller_user_id ?? null,
+        created_by_agent: (args as any)._effective_agent ?? null,
         // Trust fields: what Hunter's domain search already told us, kept
         // instead of dropped. Status stays 'unverified' until an explicit
         // verify_email (that one costs a credit). Provenance doubles as the
@@ -279,11 +287,26 @@ export async function executeProspectResearch(
           .insert(leadPayload)
           .select('id')
           .single();
+        let row = inserted;
         if (error) {
-          console.error('lead insert failed:', error.message);
-          continue;
+          // An instance that has not run the provenance migration yet must not
+          // lose every contact the research found. Strip the columns it lacks
+          // and insert again — attribution is a bonus, never a gate (Law 4).
+          const missing = ['created_by_agent', 'created_by'].filter((c) => error.message?.includes(c));
+          if (missing.length) {
+            for (const c of missing) delete leadPayload[c];
+            const retry = await supabase.from('leads').insert(leadPayload).select('id').single();
+            if (retry.error) {
+              console.error('lead insert failed after stripping provenance:', retry.error.message);
+              continue;
+            }
+            row = retry.data;
+          } else {
+            console.error('lead insert failed:', error.message);
+            continue;
+          }
         }
-        if (inserted?.id) savedContacts.push({ id: inserted.id, email, name, ...contactMeta });
+        if (row?.id) savedContacts.push({ id: row.id, email, name, ...contactMeta });
       }
     }
 

--- a/supabase/migrations/20260830090000_prospektets-proveniens.sql
+++ b/supabase/migrations/20260830090000_prospektets-proveniens.sql
@@ -1,0 +1,25 @@
+-- Prospektets proveniens (Magnus 2026-08-29→30).
+--
+-- "När jag körde en research och fick Lisa som lead — så står hon inte på
+-- admin som körde researchen. Är det systemet som kör researchen?"
+--
+-- Nej. En människa bad om den; agenten utförde den. Det är två fakta, och de
+-- har varsin kolumn — samma modell som wikin och som projekten fick:
+--   created_by        vem som bad om researchen (proveniens, oföränderlig)
+--   created_by_agent  vilken agent som gjorde jobbet
+--   assigned_to       ansvar — och det börjar när någon BEFORDRAR prospektet
+--
+-- Att låta researchen tilldela ägare vore fel: hela poängen med triagen (#330)
+-- är att fyndet ännu inte är någons. Men "vem bad om detta" ska aldrig vara
+-- okänt, och en tom created_by sa tidigare både "systemet" och "vi vet inte".
+--
+-- Idempotent + forward-daterad.
+
+ALTER TABLE public.leads
+  ADD COLUMN IF NOT EXISTS created_by_agent text,
+  ADD COLUMN IF NOT EXISTS updated_by_agent text;
+
+COMMENT ON COLUMN public.leads.created_by_agent IS
+  'Which agent created this row, when one did. Distinct from created_by (the human who asked) and from assigned_to (who is accountable — set on promotion).';
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260829230000",
-      "migrations_count": 528,
+      "migration_head": "20260830090000",
+      "migrations_count": 529,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2117,6 +2117,10 @@
         {
           "version": "20260829230000",
           "name": "projekt-far-agare-och-handavtryck"
+        },
+        {
+          "version": "20260830090000",
+          "name": "prospektets-proveniens"
         }
       ]
     },
@@ -2127,7 +2131,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:edcb2c054fc1c5b8fd3f4603b7f13ccb090071160ead90269eb49509cb97c4a2",
+      "shared_hash": "sha256:44c82b78fa54ce9a7d62a5664f81d2b2ec2dc667c14101d3da90e23df374600c",
       "functions": {
         "a2a": "sha256:33f9aa45f5a82d23f357aff397403b5b12a94dc3421984a1c883f23509c50f71",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",


### PR DESCRIPTION
## Frågan

> "När jag körde en research och fick Lisa som lead — så står hon inte på admin som körde researchen. Är det systemet som kör researchen? Och isåfall, hur lägger jag kontakten på mig?"

Nej. En människa bad om den, agenten utförde den. **Tre fakta, tre kolumner:**

| Kolumn | Fråga | Sätts av |
|---|---|---|
| `created_by` | vem bad om researchen | researchen, från anroparen |
| `created_by_agent` | vilken agent gjorde jobbet | researchen |
| `assigned_to` | vems ansvar | **befordran** |

## Vad som ändrades

`prospect_research` stämplar de två första. Ägaren sätts medvetet **inte** — hela poängen med triagen (#330) är att ett fynd är ingens tills någon väljer att gå vidare. En tom `created_by` sa tidigare både *"systemet"* och *"vi vet inte"*.

**Promote tilldelar den som befordrar** — men bara om prospektet är otilldelat. Att kapa en kollegas kontakt genom att befordra den vore en överraskning. Toasten säger *"assigned to you"* bara när något faktiskt togs över.

En instans som inte kört migrationen tappar inte sina kontakter: samma strip-och-skriv-om som den generiska CRUD-motorn. Attribution är en bonus, aldrig en grind.

## Verifierat

tsc, full vitest **3478 gröna** (7 nya påståenden), manifest regenererat, migrationen körd på optic. Negativtestad i båda halvorna: borttagen agentstämpel → rött, ovillkorlig tilldelning → rött.

🤖 Generated with [Claude Code](https://claude.com/claude-code)