### PR TITLE
fix(ui): scrollområden i flexkolumner får krympa — sista meddelandet blir nåbart

### DIFF
--- a/src/components/admin/chat/VisitorSessionsTab.tsx
+++ b/src/components/admin/chat/VisitorSessionsTab.tsx
@@ -243,7 +243,7 @@ export function VisitorSessionsTab() {
               )}
             </DialogDescription>
           </DialogHeader>
-          <ScrollArea className="flex-1 -mx-6 px-6">
+          <ScrollArea className="flex-1 min-h-0 -mx-6 px-6">
             {loadingMsgs ? (
               <p className="text-sm text-muted-foreground py-12 text-center">Loading messages…</p>
             ) : messages.length === 0 ? (

--- a/src/components/admin/content-hub/ContentProposalPreview.tsx
+++ b/src/components/admin/content-hub/ContentProposalPreview.tsx
@@ -224,7 +224,7 @@ export function ContentProposalPreview({ proposal, onClose, onRegenerate }: Cont
           </TabsList>
         </div>
 
-        <ScrollArea className="flex-1">
+        <ScrollArea className="flex-1 min-h-0">
           <div className="p-6">
             {ALL_CHANNELS.map((channel) => {
               const isPublished = proposal.published_channels?.includes(channel);

--- a/src/components/admin/copilot/CopilotMigrationPreview.tsx
+++ b/src/components/admin/copilot/CopilotMigrationPreview.tsx
@@ -269,7 +269,7 @@ export function CopilotMigrationPreview({
         )}
       </div>
 
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 min-h-0">
         <div className="p-4 space-y-4">
           {/* Current block preview */}
           {currentBlock && !isComplete && (

--- a/src/components/admin/copilot/CopilotPageSelector.tsx
+++ b/src/components/admin/copilot/CopilotPageSelector.tsx
@@ -120,7 +120,7 @@ export function CopilotPageSelector({
       </div>
 
       {/* Page list */}
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 min-h-0">
         <div className="p-2 space-y-1">
           {filteredPages.map((page) => {
             const typeConfig = TYPE_CONFIG[page.suggestedType];

--- a/src/components/admin/copilot/FlowPilotTraceTab.tsx
+++ b/src/components/admin/copilot/FlowPilotTraceTab.tsx
@@ -377,7 +377,7 @@ function RunDetailPanel({ traceId }: { traceId: string | null }) {
         )}
       </div>
 
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 min-h-0">
         <div className="p-4 space-y-3">
           {run.steps.map((s, i) => (
             <StepRow key={s.id} step={s} index={i} />

--- a/src/components/admin/templates/TemplateImportDialog.tsx
+++ b/src/components/admin/templates/TemplateImportDialog.tsx
@@ -193,7 +193,7 @@ export function TemplateImportDialog({ trigger, onImport }: TemplateImportDialog
           </DialogDescription>
         </DialogHeader>
 
-        <ScrollArea className="flex-1 pr-4">
+        <ScrollArea className="flex-1 min-h-0 pr-4">
           <div className="space-y-4">
             {/* ZIP Import Progress */}
             {isZipImporting && (

--- a/src/components/admin/tickets/TicketDetailDrawer.tsx
+++ b/src/components/admin/tickets/TicketDetailDrawer.tsx
@@ -149,7 +149,7 @@ export function TicketDetailDrawer({ ticket, open, onOpenChange }: TicketDetailD
           </div>
         </SheetHeader>
 
-        <ScrollArea className="flex-1 px-6">
+        <ScrollArea className="flex-1 min-h-0 px-6">
           {/* Status & Priority Controls */}
           <div className="flex gap-3 mb-4">
             <Select value={ticket.status} onValueChange={handleStatusChange}>

--- a/src/components/admin/wiki/WikiHistorySheet.tsx
+++ b/src/components/admin/wiki/WikiHistorySheet.tsx
@@ -105,7 +105,7 @@ export function WikiHistorySheet({ slug }: { slug: string }) {
           <SheetDescription>Every edit is captured automatically — restore any version.</SheetDescription>
         </SheetHeader>
 
-        <ScrollArea className="flex-1 -mx-2 mt-4 px-2">
+        <ScrollArea className="flex-1 min-h-0 -mx-2 mt-4 px-2">
           {isLoading ? (
             <div className="flex justify-center py-10">
               <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />

--- a/src/components/docs/DocsChat.tsx
+++ b/src/components/docs/DocsChat.tsx
@@ -131,7 +131,7 @@ export function DocsChat() {
         </Button>
       </header>
 
-      <ScrollArea className="flex-1 p-4" ref={scrollRef as any}>
+      <ScrollArea className="flex-1 min-h-0 p-4" ref={scrollRef as any}>
         {messages.length === 0 ? (
           <div className="space-y-4">
             <div className="text-sm text-muted-foreground">

--- a/src/lib/__tests__/scroll-region-min-h-0.guardrails.test.ts
+++ b/src/lib/__tests__/scroll-region-min-h-0.guardrails.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Ett scrollområde i en flexkolumn måste få krympa.
+ *
+ * Fyndet (Magnus 2026-08-29, /admin/chat?tab=sessions): "det ser ut som om jag
+ * inte kan scrolla ned till det sista chatmeddelandet". Dialogen är
+ * `max-h-[80vh] flex flex-col` och transkriptet `<ScrollArea className="flex-1">`
+ * — men ett flexbarn har `min-height: auto`, alltså en innehållsbaserad
+ * minimihöjd. Barnet växer med texten i stället för att bli scrollbart, och
+ * dialogens maxhöjd klipper resten. Det sista meddelandet finns, men går inte
+ * att nå.
+ *
+ * `min-h-0` upphäver den minimihöjden. Där ingen krympning behövs är den en
+ * no-op, vilket är varför regeln kan gälla utan undantag: ett flex-1-
+ * scrollområde ska ALLTID kunna krympa under sitt innehåll — det är hela
+ * poängen med att det scrollar.
+ *
+ * Huset kunde redan mönstret (ChatConversation bär till och med en kommentar om
+ * det); tio ytor hade bara missat det.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+describe('flex-1 på ett scrollområde följs alltid av min-h-0', () => {
+  const files = execSync(
+    "grep -rl 'ScrollArea className=\"flex-1' src/components src/pages || true",
+    { encoding: 'utf-8' },
+  ).split('\n').filter(Boolean);
+
+  it('svepet hittar faktiskt filer — annars mäter grinden ingenting', () => {
+    expect(files.length).toBeGreaterThan(5);
+  });
+
+  for (const f of files) {
+    it(`${f}`, () => {
+      const src = readFileSync(f, 'utf-8');
+      const offenders = src
+        .split('\n')
+        .filter((l) => l.includes('ScrollArea className="flex-1') && !l.includes('min-h-0'));
+      expect(offenders).toEqual([]);
+    });
+  }
+});

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -149,7 +149,7 @@ export default function ChatPage() {
             </Button>
           </div>
 
-          <ScrollArea className="flex-1">
+          <ScrollArea className="flex-1 min-h-0">
             {conversations.length === 0 ? (
               <div className="p-4 text-xs text-muted-foreground text-center">
                 Your conversations will appear here.


### PR DESCRIPTION
## Buggen

`/admin/chat?tab=sessions` → öppna en session → **det går inte att scrolla till sista meddelandet.**

Dialogen är `max-h-[80vh] flex flex-col`, transkriptet `<ScrollArea className="flex-1">`. Ett flexbarn har `min-height: auto` — en **innehållsbaserad** minimihöjd. Barnet växer alltså med texten i stället för att bli scrollbart, och dialogens maxhöjd klipper resten. Meddelandet finns; det går bara inte att nå.

## Fixen

`min-h-0` upphäver minimihöjden. Där ingen krympning behövs är den en **no-op** — vilket är varför regeln kan gälla utan undantag: ett `flex-1`-scrollområde ska alltid kunna krympa under sitt innehåll, det är hela poängen med att det scrollar.

Tio ytor rättade: sessionstranskriptet, ärendelådan, wiki-historiken, mallimporten, tre copilot-vyer, innehållsförslaget, docs-chatten och ChatPage. Huset kunde redan mönstret (`ChatConversation` bär en kommentar om exakt detta) — det var tio missade tillämpningar, inte en ny insikt.

## Metodnot

Jag skrev först en snabb heuristik för att avgöra *vilka* av de tio som satt i en höjdbegränsad förälder. Den klassade fel på den fil jag just läst och visste svaret på, så jag slängde den i stället för att bygga på den. Regeln gäller alla; grinden sveper efter mönstret snarare än att lita på min gissning.

## Verifierat

tsc, eslint rent, full vitest **3485 gröna** (14 nya påståenden — ett per fil, plus ett som kräver att svepet faktiskt hittar filer så grinden inte tyst mäter ingenting). Negativtestad: återinförd `flex-1` utan `min-h-0` → rött.

🤖 Generated with [Claude Code](https://claude.com/claude-code)