### PR TITLE
fix(projects): en synlighetsväljare per dialog — och redigeringen får sin

### DIFF
--- a/src/lib/__tests__/project-visibility-control.guardrails.test.ts
+++ b/src/lib/__tests__/project-visibility-control.guardrails.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Exakt en synlighetsväljare per dialog — och båda dialogerna har en.
+ *
+ * Fyndet (Magnus 2026-08-30): "när jag skapar ett nytt projekt så har jag två
+ * visibility-val — tror en är dubblett". Det var den. Och samma klipp-och-
+ * klistra hade motsatt utfall i redigeringsdialogen, som LÄSTE och SPARADE
+ * visibility utan att ha någon kontroll: ett projekt kunde alltså aldrig göras
+ * privat i efterhand. Två gånger i den ena, noll i den andra.
+ *
+ * Grinden räknar, för det är räkningen ögat missar i en lång formulärfil.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const src = readFileSync(join(process.cwd(), 'src/pages/admin/ProjectsPage.tsx'), 'utf-8');
+
+const dialogBody = (name: string) => {
+  const start = src.indexOf(`function ${name}`);
+  expect(start).toBeGreaterThan(-1);
+  const next = src.indexOf('\nfunction ', start + 1);
+  return src.slice(start, next === -1 ? undefined : next);
+};
+
+describe('en väljare per dialog', () => {
+  for (const dialog of ['NewProjectDialog', 'EditProjectDialog']) {
+    it(`${dialog} har exakt en`, () => {
+      const body = dialogBody(dialog);
+      const count = (body.match(/<Label>Visibility<\/Label>/g) ?? []).length;
+      expect(count).toBe(1);
+    });
+  }
+
+  it('och båda skriver till samma fält', () => {
+    for (const dialog of ['NewProjectDialog', 'EditProjectDialog']) {
+      expect(dialogBody(dialog)).toMatch(/visibility: v as "shared" \| "private"/);
+    }
+  });
+});

--- a/src/pages/admin/ProjectsPage.tsx
+++ b/src/pages/admin/ProjectsPage.tsx
@@ -77,16 +77,6 @@ function NewProjectDialog({ open: controlledOpen, onOpenChange }: { open?: boole
               </SelectContent>
             </Select>
           </div>
-          <div>
-            <Label>Visibility</Label>
-            <Select value={form.visibility} onValueChange={(v) => setForm(f => ({ ...f, visibility: v as "shared" | "private" }))}>
-              <SelectTrigger><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="shared">Shared — visible to the whole team</SelectItem>
-                <SelectItem value="private">Private — only you and admins</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
           <div><Label>Description</Label><Textarea value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} rows={2} /></div>
           <div className="flex justify-end gap-2">
             <Button type="button" variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
@@ -134,6 +124,20 @@ function EditProjectDialog({ project, open, onOpenChange }: { project: Project; 
           <div><Label>Name *</Label><Input value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} required /></div>
           <div><Label>Client</Label><Input value={form.client_name} onChange={e => setForm(f => ({ ...f, client_name: e.target.value }))} /></div>
           <div><Label>Deadline</Label><Input type="date" value={form.deadline} onChange={e => setForm(f => ({ ...f, deadline: e.target.value }))} /></div>
+          <div>
+            {/* Redigeringen LÄSTE och SPARADE visibility men saknade kontroll
+                att ändra den: ett projekt kunde alltså aldrig göras privat i
+                efterhand. Spegelbilden av dubbletten i skapa-dialogen — samma
+                klipp-och-klistra, motsatt utfall (Magnus 2026-08-30). */}
+            <Label>Visibility</Label>
+            <Select value={form.visibility} onValueChange={(v) => setForm(f => ({ ...f, visibility: v as "shared" | "private" }))}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="shared">Shared — visible to the whole team</SelectItem>
+                <SelectItem value="private">Private — only you and admins</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
           <div><Label>Description</Label><Textarea value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} rows={2} /></div>
           <div className="flex items-center justify-between rounded-md border p-3">
             <div><Label>Active</Label><p className="text-xs text-muted-foreground">Inactive projects are marked as completed</p></div>


### PR DESCRIPTION
## Vad

Du hade rätt: **två identiska Visibility-väljare** i New Project, bundna till samma fält.

Och samma klipp-och-klistra hade motsatt utfall en funktion längre ned: `EditProjectDialog` **läste** `project.visibility` in i sitt formulär och **sparade** det vid submit — utan någon kontroll att ändra det. Ett projekt kunde alltså aldrig göras privat i efterhand.

Två gånger i den ena dialogen, noll i den andra. Mitt slarv från #322.

## Grind

Räknar väljare per dialog, eftersom det är just räkningen ögat missar i en lång formulärfil. Negativtestad.

## Verifierat

tsc, full vitest **3495 gröna**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)