### PR TITLE
fix(ui): dialogens flex förlorade mot basens grid — därför räckte inte #346

### DIFF
--- a/src/components/admin/ImageCropper.tsx
+++ b/src/components/admin/ImageCropper.tsx
@@ -335,7 +335,7 @@ export function ImageCropper({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col">
+      <DialogContent className="max-w-4xl max-h-[90vh] !flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <CropIcon className="h-5 w-5" />

--- a/src/components/admin/MediaLibraryPicker.tsx
+++ b/src/components/admin/MediaLibraryPicker.tsx
@@ -282,7 +282,7 @@ export function MediaLibraryPicker({ open, onOpenChange, onSelect }: MediaLibrar
   return (
     <>
       <Dialog open={open && !showCropper} onOpenChange={handleClose}>
-        <DialogContent className="max-w-4xl max-h-[85vh] flex flex-col overflow-hidden z-[100]">
+        <DialogContent className="max-w-4xl max-h-[85vh] !flex flex-col overflow-hidden z-[100]">
           <DialogHeader>
             <DialogTitle>Select image</DialogTitle>
           </DialogHeader>

--- a/src/components/admin/UnsplashPicker.tsx
+++ b/src/components/admin/UnsplashPicker.tsx
@@ -125,7 +125,7 @@ export function UnsplashPicker({ open, onOpenChange, onSelect }: UnsplashPickerP
   return (
     <>
       <Dialog open={open && !showCropper} onOpenChange={handleClose}>
-        <DialogContent className="max-w-4xl max-h-[85vh] flex flex-col overflow-hidden z-[100]">
+        <DialogContent className="max-w-4xl max-h-[85vh] !flex flex-col overflow-hidden z-[100]">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <ImageIcon className="h-5 w-5" />

--- a/src/components/admin/chat/VisitorSessionsTab.tsx
+++ b/src/components/admin/chat/VisitorSessionsTab.tsx
@@ -223,7 +223,7 @@ export function VisitorSessionsTab() {
       </CardContent>
 
       <Dialog open={!!activeId} onOpenChange={(o) => !o && setActiveId(null)}>
-        <DialogContent className="max-w-3xl max-h-[80vh] flex flex-col">
+        <DialogContent className="max-w-3xl max-h-[80vh] !flex flex-col">
           <DialogHeader>
             <DialogTitle className="truncate">
               {activeSession?.title || 'Session'}

--- a/src/components/admin/federation/A2ATestChat.tsx
+++ b/src/components/admin/federation/A2ATestChat.tsx
@@ -156,7 +156,7 @@ export function A2ATestChat({ peer }: A2ATestChatProps) {
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="sm:max-w-lg max-h-[80vh] flex flex-col p-0">
+        <DialogContent className="sm:max-w-lg max-h-[80vh] !flex flex-col p-0">
           <DialogHeader className="px-4 pt-4 pb-2">
             <DialogTitle className="flex items-center gap-2 text-sm">
               <MessageCircle className="h-4 w-4 text-primary" />

--- a/src/components/admin/templates/TemplateImportDialog.tsx
+++ b/src/components/admin/templates/TemplateImportDialog.tsx
@@ -182,7 +182,7 @@ export function TemplateImportDialog({ trigger, onImport }: TemplateImportDialog
         )}
       </DialogTrigger>
       
-      <DialogContent className="max-w-2xl max-h-[85vh] overflow-hidden flex flex-col">
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-hidden !flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <FileJson className="h-5 w-5 text-primary" />

--- a/src/components/admin/templates/TemplatePreviewDialog.tsx
+++ b/src/components/admin/templates/TemplatePreviewDialog.tsx
@@ -308,7 +308,7 @@ export function TemplatePreviewDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] min-h-0 flex flex-col overflow-hidden">
+      <DialogContent className="max-w-2xl max-h-[90vh] min-h-0 !flex flex-col overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Eye className="h-5 w-5 text-primary" />

--- a/src/components/admin/tickets/CannedResponsesDialog.tsx
+++ b/src/components/admin/tickets/CannedResponsesDialog.tsx
@@ -93,7 +93,7 @@ export function CannedResponsesDialog() {
           Canned responses
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[720px] p-0 max-h-[85vh] flex flex-col">
+      <DialogContent className="sm:max-w-[720px] p-0 max-h-[85vh] !flex flex-col">
         <DialogHeader className="px-6 pt-6 pb-2">
           <DialogTitle>Canned responses</DialogTitle>
         </DialogHeader>

--- a/src/lib/__tests__/dialog-flex-beats-grid.guardrails.test.ts
+++ b/src/lib/__tests__/dialog-flex-beats-grid.guardrails.test.ts
@@ -1,0 +1,54 @@
+/**
+ * En dialog som ska vara en flexkolumn måste säga det med eftertryck.
+ *
+ * Fyndet (Magnus 2026-08-30, efter att #346 INTE räckte): "jag kan inte se hela
+ * meddelandetråden i pop-upen". Rätt diagnos var bara halva sanningen.
+ *
+ * shadcns DialogContent har `grid` i sin bas. En konsument som skriver
+ * `flex flex-col` i sin className får INTE flex: Tailwind genererar `.grid`
+ * EFTER `.flex` i stilmallen, och vid samma specificitet vinner den senare
+ * regeln — oavsett ordningen i class-attributet. Uppmätt i den byggda CSS:en:
+ * `.flex` på position 46552, `.grid` på 46658.
+ *
+ * Följden: `flex-1` på scrollområdet betyder ingenting (det är inget flexbarn),
+ * och min-h-0 från #346 hade inget att verka på. Dialogen växte förbi sin
+ * maxhöjd och klippte slutet av tråden.
+ *
+ * `!flex` genererar `display:flex!important` och vinner. SheetContent har
+ * ingen display i basen och behöver därför inget utropstecken — det är just
+ * skillnaden som gör att bara dialoger står här.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const files = execSync(
+  'grep -rl \'DialogContent className="\' src || true',
+  { encoding: 'utf-8' },
+).split('\n').filter(Boolean);
+
+describe('flex på en DialogContent måste vara !flex', () => {
+  it('svepet hittar dialoger — annars mäter grinden ingenting', () => {
+    expect(files.length).toBeGreaterThan(5);
+  });
+
+  it('ingen DialogContent förlitar sig på ett vanligt flex', () => {
+    const offenders: string[] = [];
+    for (const f of files) {
+      for (const line of readFileSync(f, 'utf-8').split('\n')) {
+        const m = line.match(/DialogContent className="([^"]*)"/);
+        if (m && /\bflex flex-col\b/.test(m[1]) && !/!flex/.test(m[1])) {
+          offenders.push(`${f}: ${m[1]}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('basen sätter fortfarande grid — det är hela skälet regeln finns', () => {
+    // Skulle basen någon gång byta till flex blir regeln onödig, och då ska
+    // den här raden tvinga fram en omprövning i stället för att tyst bestå.
+    const base = readFileSync('src/components/ui/dialog.tsx', 'utf-8');
+    expect(base).toMatch(/z-50 grid w-full max-w-lg/);
+  });
+});


### PR DESCRIPTION
## Varför #346 inte räckte

Rätt diagnos, halv sanning. `min-h-0` var nödvändigt men verkningslöst, för **dialogen var aldrig en flexkolumn**.

shadcns `DialogContent` har `grid` i basen. En konsument som skriver `flex flex-col` i sin className får inte flex: Tailwind genererar `.grid` **efter** `.flex`, och vid samma specificitet vinner den senare regeln — oavsett ordningen i class-attributet.

Uppmätt i den byggda stilmallen:

```
.flex  vid position 46552
.grid  vid position 46658   ← vinner
```

Följden: `flex-1` på scrollområdet betydde ingenting (det var inget flexbarn), `min-h-0` hade inget att verka på, dialogen växte förbi sin maxhöjd och klippte slutet av tråden.

## Fixen

`!flex` → `display:flex!important`, verifierat genererad i den byggda CSS:en. **Åtta dialoger** rättade: sessionstranskriptet, mallimport och -förhandsvisning, mediabibliotek, Unsplash-väljare, bildbeskärare, standardsvar, A2A-testchatt.

`SheetContent` sätter ingen display i basen — drawers och sheets behövde inget utropstecken. Det är just den skillnaden som gör att bara dialoger står i grinden.

## Verifierat

tsc, full vitest **3508 gröna** (3 nya påståenden), negativtestad. Ett av påståendena kräver att basen **fortfarande** sätter `grid` — byter den till flex ska regeln omprövas, inte tyst bestå.

🤖 Generated with [Claude Code](https://claude.com/claude-code)