### PR TITLE
fix(projects): uppgiften kunde inte skapas — fältreferensen planerades ändå

### DIFF
--- a/src/lib/__tests__/project-ownership.guardrails.test.ts
+++ b/src/lib/__tests__/project-ownership.guardrails.test.ts
@@ -31,7 +31,23 @@ describe('ägarskapet finns innan filtret får finnas', () => {
 
   it('skaparen blir projektets ägare — men gissas aldrig åt en agent', () => {
     expect(sql).toMatch(/IF v_uid IS NULL THEN RETURN NEW; END IF;/);
-    expect(sql).toMatch(/TG_TABLE_NAME = 'projects' AND NEW\.owner_id IS NULL/);
+  });
+
+  it('fältet nämns bara i en sats som aldrig nås för uppgifter', () => {
+    // #338 skrev `TG_TABLE_NAME = 'projects' AND NEW.owner_id IS NULL`. PL/pgSQL
+    // skickar hela villkoret som ETT SQL-uttryck, så fältet slogs upp även när
+    // project_tasks triggade — och tabellen saknar det. Ingen kortslutning
+    // räddar en fältreferens som måste planeras; nästlad IF gör det, eftersom
+    // varje sats planeras först när den NÅS. Live-reproducerat 2026-08-30.
+    const raw = readFileSync(
+      join(process.cwd(), 'supabase/migrations/20260830130000_uppgiften-kunde-inte-skapas.sql'),
+      'utf-8',
+    );
+    // Kommentaren CITERAR det trasiga villkoret för att förklara det, så mät på
+    // koden. (Grinden fällde sig själv på sin egen förklaring först.)
+    const fix = raw.split('\n').filter((l) => !l.trim().startsWith('--')).join('\n');
+    expect(fix).not.toMatch(/TG_TABLE_NAME = 'projects' AND NEW\.owner_id/);
+    expect(fix).toMatch(/IF TG_TABLE_NAME = 'projects' THEN\s*\n\s*IF NEW\.owner_id IS NULL THEN/);
   });
 
   it('uppgifter tilldelas INTE automatiskt — annars finns ingen backlogg att fånga', () => {

--- a/supabase/migrations/20260830130000_uppgiften-kunde-inte-skapas.sql
+++ b/supabase/migrations/20260830130000_uppgiften-kunde-inte-skapas.sql
@@ -1,0 +1,49 @@
+-- Uppgiften kunde inte skapas: record "new" has no field "owner_id"
+-- (Magnus 2026-08-30, live på optic).
+--
+-- project_stamp_hands (#338) delas av projects och project_tasks. Bara
+-- projects har owner_id, så raden skyddades med
+--   IF TG_TABLE_NAME = 'projects' AND NEW.owner_id IS NULL THEN
+-- men PL/pgSQL skickar hela villkoret som ETT SQL-uttryck till planeraren.
+-- Fältet slås alltså upp oavsett vilken tabell som triggade — och på
+-- project_tasks finns det inte. Ingen kortslutning räddar en fältreferens som
+-- måste planeras.
+--
+-- Nästlad IF i stället: PL/pgSQL planerar varje sats först när den NÅS, så den
+-- inre satsen kompileras aldrig för uppgifter.
+--
+-- ── Varför det inte upptäcktes förrän i drift ────────────────────────────────
+-- Jag testade insert:en live innan #338 gick ut — men som `postgres`, där
+-- auth.uid() är NULL och funktionen returnerar tidigt, FÖRE den trasiga raden.
+-- Testet körde alltså den enda gren som inte kan smälla. Reproducerad först med
+-- SET LOCAL request.jwt.claims, alltså som en inloggad människa.
+--
+-- Idempotent + forward-daterad.
+
+CREATE OR REPLACE FUNCTION public.project_stamp_hands()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE v_uid uuid := auth.uid();
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    -- Under service_role är auth.uid() NULL: en agent gör inte anspråk på
+    -- vare sig författarskap eller ansvar.
+    IF v_uid IS NULL THEN RETURN NEW; END IF;
+    IF NEW.created_by IS NULL THEN NEW.created_by := v_uid; END IF;
+    -- Nästlad, inte AND: fältet får bara nämnas i en sats som aldrig nås för
+    -- en tabell som saknar det.
+    IF TG_TABLE_NAME = 'projects' THEN
+      IF NEW.owner_id IS NULL THEN
+        NEW.owner_id := v_uid;
+      END IF;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  NEW.updated_by := COALESCE(v_uid, OLD.updated_by);
+  RETURN NEW;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260830110000",
-      "migrations_count": 530,
+      "migration_head": "20260830130000",
+      "migrations_count": 531,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2125,6 +2125,10 @@
         {
           "version": "20260830110000",
           "name": "gallring-av-prospekt-som-aldrig-blev-kund"
+        },
+        {
+          "version": "20260830130000",
+          "name": "uppgiften-kunde-inte-skapas"
         }
       ]
     },


### PR DESCRIPTION
## Buggen (live på optic, från min #338)

`record "new" has no field "owner_id"` när en uppgift skapas på ett projekt.

`project_stamp_hands` delas av `projects` och `project_tasks`. Bara `projects` har `owner_id`, så raden skyddades med:

```sql
IF TG_TABLE_NAME = 'projects' AND NEW.owner_id IS NULL THEN
```

Men PL/pgSQL skickar hela villkoret som **ett** SQL-uttryck till planeraren — fältet slås upp oavsett vilken tabell som triggade. Ingen kortslutning räddar en fältreferens som måste planeras.

**Nästlad IF** i stället: varje sats planeras först när den nås, så den inre satsen kompileras aldrig för uppgifter.

## Varför det slank ut

Jag testade insert:en live innan #338 — men som `postgres`, där `auth.uid()` är NULL och funktionen returnerar tidigt, **före** den trasiga raden. Testet körde den enda gren som inte kunde smälla.

Reproducerad först med `SET LOCAL request.jwt.claims`, alltså som en inloggad människa:

```
INSERT SMÄLLDE: record "new" has no field "owner_id" (42703)
```

Efter fixen, samma villkor: uppgift skapas med `created_by` ✓ · uppdatering sätter `updated_by` ✓ · projekt får fortfarande ägare ✓

## Verifierat

tsc, full vitest **3509 gröna**, manifest regenererat, migrationen körd på optic. Negativtestad. Grinden fällde först **sig själv** på sin egen kommentar (som citerar det trasiga villkoret) — mäter nu på koden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)