### PR TITLE
refactor(projects): timesheets bredvid projekten, och uppgifter heter tasks

### DIFF
--- a/src/components/admin/adminNavigation.ts
+++ b/src/components/admin/adminNavigation.ts
@@ -215,7 +215,6 @@ export const navigationGroups: NavGroup[] = [
       { name: "POS Audit", href: "/admin/pos/audit", icon: ShieldCheck, moduleId: "pos" },
       { name: "Accounting", href: "/admin/accounting", icon: BookOpen, moduleId: "accounting" },
       { name: "Expenses", href: "/admin/expenses", icon: Wallet, moduleId: "expenses" },
-      { name: "Timesheets", href: "/admin/timesheets", icon: Timer, moduleId: "timesheets" },
       { name: "Approvals", href: "/admin/approvals", icon: ShieldCheck, moduleId: "approvals" },
       { name: "Reconciliation", href: "/admin/reconciliation", icon: RefreshCw, moduleId: "reconciliation" },
       { name: "Payroll", href: "/admin/payroll", icon: Wallet, moduleId: "payroll" },
@@ -264,6 +263,14 @@ export const navigationGroups: NavGroup[] = [
         icon: FolderKanban,
         moduleId: "projects",
       },
+      // Bredvid projekten, inte under Finance (Magnus 2026-08-30). En tidrapport
+      // skrivs av den som utfört arbetet, mot ett projekt och en uppgift — den
+      // hör hemma där arbetet finns. Att den SEDAN blir underlag för
+      // fakturering gör den inte till en ekonomifunktion, lika lite som en order
+      // hör under bokföring för att den slutar i en faktura. Under Finance låg
+      // den dessutom bakom en gruppering som ofta stänger ute just de människor
+      // som ska fylla i den.
+      { name: "Timesheets", href: "/admin/timesheets", icon: Timer, moduleId: "timesheets" },
       { name: "HR & Employees", href: "/admin/hr", icon: Users, moduleId: "hr" },
       {
         name: "Recruitment",

--- a/src/components/admin/projects/TasksView.tsx
+++ b/src/components/admin/projects/TasksView.tsx
@@ -29,7 +29,7 @@ type Row = {
 
 const DONE = new Set(["done", "completed", "cancelled"]);
 
-export function ActivitiesView({
+export function TasksView({
   projects,
   onOpenProject,
 }: {
@@ -104,10 +104,10 @@ export function ActivitiesView({
       </div>
 
       {isLoading ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">Loading activities…</p>
+        <p className="text-sm text-muted-foreground py-8 text-center">Loading tasks…</p>
       ) : rows.length === 0 ? (
         <p className="text-sm text-muted-foreground py-8 text-center">
-          No activities match — switch filters or create tasks inside a project.
+          No tasks match — switch filters or create tasks inside a project.
         </p>
       ) : (
         <div className="divide-y rounded-lg border">

--- a/src/lib/__tests__/project-ownership.guardrails.test.ts
+++ b/src/lib/__tests__/project-ownership.guardrails.test.ts
@@ -5,7 +5,7 @@
  * visade "Mine" i aktivitetsvyn ingenting. Filtret fungerade; det fanns ingen
  * data att filtrera på. Kontakterna räddades av ownership-on-create sedan
  * 2026-08-08; projekt och uppgifter hade aldrig fått motsvarande, och
- * ActivitiesView bar dessutom en EGEN All/Mine-växel vid sidan av CRM-linsen —
+ * Vyn (då ActivitiesView, nu TasksView) bar dessutom en EGEN All/Mine-växel —
  * en tredje sanning om vad "mitt" betyder.
  *
  * Magnus definition (hans beslut, inte en teknisk bekvämlighet): tilldelade mig
@@ -19,7 +19,7 @@ import { OWNERSHIP } from '@/lib/ownership';
 
 const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
 const sql = read('supabase/migrations/20260829230000_projekt-far-agare-och-handavtryck.sql');
-const view = read('src/components/admin/projects/ActivitiesView.tsx');
+const view = read('src/components/admin/projects/TasksView.tsx');
 const page = read('src/pages/admin/ProjectsPage.tsx');
 const crud = read('supabase/functions/agent-execute/index.ts');
 
@@ -73,7 +73,7 @@ describe('"Mina" betyder en sak, på alla tre ytorna', () => {
   });
 
   it('vyn får HELA projektlistan — en uppgift åt mig i någon annans projekt är min', () => {
-    expect(page).toMatch(/<ActivitiesView\s*\n\s*projects=\{rawProjects \?\? \[\]\}/);
+    expect(page).toMatch(/<TasksView\s*\n\s*projects=\{rawProjects \?\? \[\]\}/);
     // Projektlistan i rälsen ÄR däremot linsad — där betyder ägarskap urval.
     expect(page).toMatch(/<ProjectRail\s*\n\s*projects=\{projects\}/);
   });

--- a/src/lib/__tests__/task-not-activity.guardrails.test.ts
+++ b/src/lib/__tests__/task-not-activity.guardrails.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Uppgifter heter tasks — i projektmodulen, hela vägen.
+ *
+ * Fyndet (Magnus 2026-08-30): "eller task — vi kallar det både och tror jag".
+ * Precis: tabellen heter project_tasks, kanban säger task, dialogen heter
+ * TaskEditDialog — men tvärprojektvyn jag byggde hette Activities, i filnamn,
+ * i etikett och i URL:en.
+ *
+ * Ordet spelar roll utöver konsekvens: `lead_activities` i CRM:et ÄR en
+ * aktivitetslogg — en liggare över vad som hänt. Att låta samma ord betyda
+ * "sak att göra" i en modul och "sak som hänt" i en annan gör varje samtal
+ * mellan dem tvetydigt, för människor och för agenter.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+const page = read('src/pages/admin/ProjectsPage.tsx');
+
+describe('projektmodulen säger task', () => {
+  it('vyn heter TasksView, och den gamla filen är borta', () => {
+    expect(existsSync(join(process.cwd(), 'src/components/admin/projects/TasksView.tsx'))).toBe(true);
+    expect(existsSync(join(process.cwd(), 'src/components/admin/projects/ActivitiesView.tsx'))).toBe(false);
+  });
+
+  it('etiketten och läget säger task', () => {
+    expect(page).toMatch(/<ListTodo className="mr-2 h-3\.5 w-3\.5" \/> Tasks/);
+    expect(page).toMatch(/mode === "tasks"/);
+    expect(page).not.toMatch(/setMode\("activities"\)/);
+  });
+
+  it('men en sparad ?mode=activities landar rätt', () => {
+    // Vyn hette så i två dagar. En länk ska visa det den pekade på.
+    expect(page).toMatch(/rawMode === "activities" \? "tasks" : rawMode/);
+  });
+});
+
+describe('CRM:ets aktiviteter är något annat och behåller sitt ord', () => {
+  it('lead_activities är en logg över vad som HÄNT, inte saker att göra', () => {
+    const timeline = read('src/hooks/useUnifiedTimeline.ts');
+    expect(timeline).toMatch(/from\('lead_activities'\)/);
+    // Om projektmodulen någon gång återinför ordet ska det synas som en kollision.
+    expect(read('src/components/admin/projects/TasksView.tsx')).not.toMatch(/Activities/);
+  });
+});
+
+describe('timesheets ligger där arbetet finns', () => {
+  it('bredvid Projects i Operations, inte under Finance', () => {
+    const nav = read('src/components/admin/adminNavigation.ts');
+    const ops = nav.slice(nav.indexOf('label: "Operations"'), nav.indexOf('label: "Admin"'));
+    const fin = nav.slice(nav.indexOf('label: "Finance"'), nav.indexOf('label: "Commerce"'));
+    expect(ops).toMatch(/name: "Timesheets"/);
+    expect(fin).not.toMatch(/name: "Timesheets"/);
+  });
+
+  it('och står omedelbart efter Projects', () => {
+    const nav = read('src/components/admin/adminNavigation.ts');
+    const ops = nav.slice(nav.indexOf('label: "Operations"'), nav.indexOf('label: "Admin"'));
+    expect(ops.indexOf('name: "Projects"')).toBeLessThan(ops.indexOf('name: "Timesheets"'));
+    expect(ops.indexOf('name: "Timesheets"')).toBeLessThan(ops.indexOf('name: "HR & Employees"'));
+  });
+});

--- a/src/pages/admin/ProjectsPage.tsx
+++ b/src/pages/admin/ProjectsPage.tsx
@@ -25,7 +25,7 @@ import { ProjectSummaryStrip } from "@/components/admin/projects/ProjectSummaryS
 import { EmptyState } from "@/components/ui/empty-state";
 import { useTabParam } from "@/hooks/useTabParam";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { ActivitiesView } from "@/components/admin/projects/ActivitiesView";
+import { TasksView } from "@/components/admin/projects/TasksView";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Plus, FolderKanban, CheckCircle2, Clock, Circle, Pencil, Trash2, X , Lock, ListTodo } from "lucide-react";
 import { usePlatformFormat } from '@/hooks/usePlatformFormat';
@@ -482,7 +482,10 @@ export default function ProjectsPage() {
   const [newProjectOpen, setNewProjectOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [tab, setTab] = useTabParam("board", "view");
-  const [mode, setMode] = useTabParam("projects", "mode");
+  const [rawMode, setMode] = useTabParam("projects", "mode");
+  // ?mode=activities levde i två dagar innan vyn döptes om till Tasks. En
+  // sparad länk ska visa vyn den pekade på, inte tyst landa på projektlistan.
+  const mode = rawMode === "activities" ? "tasks" : rawMode;
   const del = useDeleteProject();
   // `?new=1` and `?new=task` both open the project create dialog — there is no
   // standalone "new task" flow at this level (tasks are created inside a project).
@@ -522,21 +525,21 @@ export default function ProjectsPage() {
           <>
           {/* Två INGÅNGAR, inte två flikar i ett projekt: kör man flera projekt
               vill man ibland utgå från projekten, ibland från aktiviteterna
-              (Magnus/Peter 2026-08-28). Aktiviteter = tvärprojektlistan. */}
+              (Magnus/Peter 2026-08-28). Tasks = tvärprojektlistan. */}
           <div className="flex rounded-md border p-0.5 w-fit">
             <Button size="sm" variant={mode === "projects" ? "secondary" : "ghost"} onClick={() => setMode("projects")}>
               <FolderKanban className="mr-2 h-3.5 w-3.5" /> Projects
             </Button>
-            <Button size="sm" variant={mode === "activities" ? "secondary" : "ghost"} onClick={() => setMode("activities")}>
-              <ListTodo className="mr-2 h-3.5 w-3.5" /> Activities
+            <Button size="sm" variant={mode === "tasks" ? "secondary" : "ghost"} onClick={() => setMode("tasks")}>
+              <ListTodo className="mr-2 h-3.5 w-3.5" /> Tasks
             </Button>
           </div>
 
-          {mode === "activities" ? (
+          {mode === "tasks" ? (
             // Hela listan, inte den linsade: en uppgift tilldelad mig i NÅGON
             // annans projekt är fortfarande min, så vyn gör sin egen
             // sammansatta filtrering i stället för att ärva urvalet.
-            <ActivitiesView
+            <TasksView
               projects={rawProjects ?? []}
               onOpenProject={(pid) => { setSelectedId(pid); setMode("projects"); setTab("board"); }}
             />


### PR DESCRIPTION
## Timesheets → Operations, direkt efter Projects

En tidrapport skrivs av den som utfört arbetet, mot ett projekt och en uppgift — den hör hemma där arbetet finns. Att den *sedan* blir underlag för fakturering gör den inte till en ekonomifunktion, lika lite som en order hör under bokföring för att den slutar i en faktura. Under Finance låg den dessutom i en gruppering som ofta stänger ute just de människor som ska fylla i den.

## Uppgifter heter tasks

Tabellen heter `project_tasks`, kanban säger task, dialogen heter `TaskEditDialog` — men tvärprojektvyn hette **Activities**, i filnamn, etikett och URL.

Ordet spelar roll utöver konsekvens: `lead_activities` i CRM:et **är** en aktivitetslogg — en liggare över vad som *hänt*. Samma ord för "sak att göra" i en modul och "sak som hänt" i en annan gör varje samtal mellan dem tvetydigt, för människor och för agenter.

`ActivitiesView` → `TasksView` · etikett → **Tasks** · `?mode=activities` → `?mode=tasks`, med de gamla länkarna omdirigerade: vyn hette så i två dagar, och en sparad länk ska visa det den pekade på i stället för att tyst falla tillbaka till projektlistan.

## Verifierat

tsc, full vitest **3516 gröna** (6 nya påståenden), negativtestade: borttagen bakåtkompatibilitet → rött, timesheets tillbaka i Finance → rött.

🤖 Generated with [Claude Code](https://claude.com/claude-code)