### PR TITLE
fix: två blödande buggar av samma klass — svald 400 som ser ut som ett svar

### DIFF
--- a/src/components/admin/accounting/ExportTab.tsx
+++ b/src/components/admin/accounting/ExportTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useMemo } from 'react';
+import { resolveExportIdentity } from '@/lib/export-identity';
 import { AccountingTabHeader } from './AccountingTabHeader';
 import { useFiscalYear } from './FiscalYearContext';
 import { Button } from '@/components/ui/button';
@@ -85,16 +86,27 @@ export function ExportTab() {
       .order('entry_date');
     if (entryErr) throw entryErr;
 
-    // Site identity (best-effort)
-    const { data: settings } = await supabase
+    // The legal entity this export claims to be. site_settings is a key/value
+    // store — the old code read `site_name`/`org_number` as columns, got a
+    // swallowed 400, and shipped every customer's bookkeeping under the
+    // platform's own name. The identity lives in the company_profile row
+    // (Business Identity).
+    const { data: settingsRow, error: identityErr } = await supabase
       .from('site_settings')
-      .select('site_name, org_number')
+      .select('value')
+      .eq('key', 'company_profile')
       .maybeSingle();
+    if (identityErr) console.error('[export] company identity read failed:', identityErr.message);
+    const identity = resolveExportIdentity(settingsRow?.value);
+    if (!identity.complete) {
+      // Empty is honest and gets caught on import; a wrong name gets imported.
+      console.warn('[export] no legal entity in Business Identity — exporting without a company name');
+    }
 
     return {
       company: {
-        name: (settings as any)?.site_name ?? 'FlowWink',
-        org_number: (settings as any)?.org_number ?? null,
+        name: identity.name,
+        org_number: identity.org_number,
         currency: pack.currency.code,
       },
       fiscal_year: { start: from, end: to },

--- a/src/lib/__tests__/two-bleeding-swallowed-selects.guardrails.test.ts
+++ b/src/lib/__tests__/two-bleeding-swallowed-selects.guardrails.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Två blödande buggar av samma klass: en frågekolumn som inte finns, ett fel
+ * som sväljs, och ett fallback-värde som ser ut som ett svar.
+ *
+ * 1. `score-visitor-intent` frågade efter `leads.company` — en kolumn som
+ *    normaliserades bort till companies för länge sedan och inte finns i NÅGON
+ *    instans. PostgREST svarade 400, felet fångades aldrig, raden blev null,
+ *    nuvarande poäng lästes som 0 — och nästa rad SKREV regelns poäng över
+ *    historiken. Varje besökssignal nollställde leadets poäng.
+ *
+ * 2. SIE-exporten läste `site_name` och `org_number` som KOLUMNER på
+ *    site_settings, som är ett nyckel-värde-lager. Samma svalda 400, och
+ *    fallbacken skickade kundens bokföring under plattformens eget namn:
+ *    "FlowWink", organisationsnummer null. På optic låg rätt identitet en rad
+ *    bort hela tiden — Optic Tunnels Networks Nordic AB, 559532-3659.
+ *
+ * Grinden IMPORTERAR och KÖR båda besluten. Kvällens mutationsrevision visade
+ * mönstret utan undantag: varje grind som kör koden den skyddar dödade sin
+ * mutation, varje grind som letade efter en textsträng överlevde. Den här
+ * grinden härdade jag en gång på fel nivå redan; den här gången anropas
+ * funktionerna.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolveExportIdentity } from '@/lib/export-identity';
+
+describe('en poäng som inte kunde läsas får inte skrivas över', () => {
+  it('bumpen ADDERAR — den ersätter aldrig', async () => {
+    const { nextScore } = await import(
+      '../../../supabase/functions/_shared/scoring.ts'
+    );
+    expect(nextScore(40, 10)).toBe(50);
+    expect(nextScore(0, 10)).toBe(10);
+  });
+
+  it('okänd nuvarande poäng behandlas som noll — men bara som utgångspunkt', async () => {
+    const { nextScore } = await import(
+      '../../../supabase/functions/_shared/scoring.ts'
+    );
+    expect(nextScore(null, 10)).toBe(10);
+    expect(nextScore(undefined, 10)).toBe(10);
+  });
+
+  it('och en misslyckad läsning skriver ingenting alls', () => {
+    // Den delen bor i anroparen: fel eller saknad rad → continue, ingen UPDATE.
+    const src = readFileSync(
+      join(process.cwd(), 'supabase/functions/score-visitor-intent/index.ts'),
+      'utf-8',
+    );
+    const bump = src.slice(src.indexOf('// Bump lead score'), src.indexOf('signalsFired++'));
+    expect(bump).toMatch(/if \(leadErr \|\| !leadRow\) \{[\s\S]*?continue;/);
+    // Och kolumnen som inte finns får aldrig tillbaka.
+    expect(bump).not.toMatch(/select\('score, name, email, company'\)/);
+    expect(bump).toMatch(/company_id, companies\(name\)/);
+  });
+});
+
+describe('en bokföringsexport ljuger aldrig om vem den är', () => {
+  it('tar den juridiska personen ur Business Identity', () => {
+    const id = resolveExportIdentity({
+      legal_name: 'Optic Tunnels Networks Nordic AB',
+      company_name: 'Optic Tunnels',
+      org_number: '559532-3659',
+    });
+    expect(id).toEqual({
+      name: 'Optic Tunnels Networks Nordic AB',
+      org_number: '559532-3659',
+      complete: true,
+    });
+  });
+
+  it('faller tillbaka på varumärket bara när juridiskt namn saknas', () => {
+    expect(resolveExportIdentity({ company_name: 'Resta Gård' }).name).toBe('Resta Gård');
+  });
+
+  it('hittar ALDRIG på ett namn — tomt är ärligt, fel blir importerat', () => {
+    for (const input of [null, undefined, {}, { org_number: '559532-3659' }]) {
+      const id = resolveExportIdentity(input);
+      expect(id.name).toBe('');
+      expect(id.complete).toBe(false);
+      expect(id.name).not.toMatch(/FlowWink/);
+    }
+  });
+
+  it('och exporten läser rätt rad, inte påhittade kolumner', () => {
+    const src = readFileSync(
+      join(process.cwd(), 'src/components/admin/accounting/ExportTab.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/\.eq\('key', 'company_profile'\)/);
+    expect(src).not.toMatch(/select\('site_name, org_number'\)/);
+    expect(src).not.toMatch(/\?\? 'FlowWink'/);
+  });
+});

--- a/src/lib/export-identity.ts
+++ b/src/lib/export-identity.ts
@@ -1,0 +1,31 @@
+/**
+ * Which legal entity an accounting export claims to be.
+ *
+ * The bug (2026-08-30): the SIE exporter read `site_name` and `org_number` as
+ * COLUMNS on `site_settings`, which is a key/value store. PostgREST answered
+ * 400, the error was discarded, and the fallback shipped the customer's
+ * bookkeeping export under the platform's own name — "FlowWink", org number
+ * null — with nothing on screen saying so. On optic the real identity sat one
+ * row away the whole time: company_profile.legal_name = "Optic Tunnels
+ * Networks Nordic AB", org_number = "559532-3659".
+ *
+ * A wrong company name in an accounting file is worse than a missing one: the
+ * missing one is caught by whoever imports it, the wrong one is imported. So
+ * this returns empty rather than inventing a name, and says it is incomplete
+ * so the caller can warn.
+ */
+export interface ExportIdentity {
+  name: string;
+  org_number: string | null;
+  /** false when the profile could not supply a legal entity — the caller should say so. */
+  complete: boolean;
+}
+
+export function resolveExportIdentity(companyProfile: unknown): ExportIdentity {
+  const p = (companyProfile ?? {}) as Record<string, unknown>;
+  const str = (v: unknown) => (typeof v === 'string' ? v.trim() : '');
+  // legal_name first: an accounting export names the legal entity, not the brand.
+  const name = str(p.legal_name) || str(p.company_name);
+  const org = str(p.org_number);
+  return { name, org_number: org || null, complete: !!name };
+}

--- a/supabase/functions/_shared/scoring.ts
+++ b/supabase/functions/_shared/scoring.ts
@@ -1,0 +1,16 @@
+/**
+ * The one decision behind a score bump, extracted so a test can RUN it.
+ *
+ * The bug it encodes (2026-08-30): a failed read was indistinguishable from
+ * "the lead has no score", so the caller wrote the rule's value over whatever
+ * history existed. The rule is now explicit and testable — a score bump ADDS,
+ * and an unknown current score is only ever treated as 0 when the row really
+ * says so.
+ *
+ * Extracted rather than inlined because tonight's guardrail audit showed the
+ * pattern plainly: every guardrail that imports and executes the code it
+ * protects caught its mutation; every one that greps for a string did not.
+ */
+export function nextScore(current: number | null | undefined, delta: number): number {
+  return (typeof current === 'number' ? current : 0) + delta;
+}

--- a/supabase/functions/score-visitor-intent/index.ts
+++ b/supabase/functions/score-visitor-intent/index.ts
@@ -9,6 +9,7 @@
 //   - Meant to run via cron every 15 min (see runbook in the module file).
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { nextScore } from '../_shared/scoring.ts';
 import { corsHeaders } from 'npm:@supabase/supabase-js@2/cors';
 
 interface Rule {
@@ -150,24 +151,45 @@ Deno.serve(async (req) => {
         });
         if (sigErr) continue;
 
-        // Bump lead score
-        const { data: leadRow } = await supabase
-          .from('leads').select('score, name, email, company').eq('id', leadId).maybeSingle();
-        const currentScore = (leadRow?.score as number) ?? 0;
-        await supabase.from('leads').update({ score: currentScore + rule.score }).eq('id', leadId);
+        // Bump lead score.
+        //
+        // This read used to name `leads.company`, a column that exists in no
+        // instance (normalised to companies.company_id years ago). PostgREST
+        // answered 400, the error was never captured, `leadRow` came back null
+        // — and the line below then read the current score as 0 and WROTE the
+        // rule's score over it. Every visitor signal reset the lead's history
+        // instead of adding to it. Measured 2026-08-30.
+        //
+        // Two rules follow: name columns that exist, and never treat a failed
+        // read as "the value is zero". A score we could not read is a score we
+        // must not overwrite.
+        const { data: leadRow, error: leadErr } = await supabase
+          .from('leads')
+          .select('score, name, email, company_id, companies(name)')
+          .eq('id', leadId)
+          .maybeSingle();
+        if (leadErr || !leadRow) {
+          console.error(
+            '[score-visitor-intent] lead read failed — score left untouched:',
+            leadErr?.message ?? 'no such lead',
+          );
+          continue;
+        }
+        const currentScore = nextScore(leadRow.score as number | null, rule.score);
+        await supabase.from('leads').update({ score: currentScore }).eq('id', leadId);
         signalsFired++;
 
         // Optional email notification when a signal fires.
         // Config lives alongside rules: site_settings.visitor_intelligence_rules.notify = { enabled, email, min_score? }
         const notify = (config as unknown as { notify?: { enabled?: boolean; email?: string; min_score?: number } }).notify;
         if (notify?.enabled && notify.email && (!notify.min_score || rule.score >= notify.min_score)) {
-          const lead = leadRow as { name?: string; email?: string; company?: string } | null;
+          const lead = leadRow as { name?: string; email?: string; companies?: { name?: string } | null } | null;
           const subject = `🔔 Visitor signal: ${rule.name} — ${lead?.name || lead?.email || 'lead'}`;
           const html = `
             <h2 style="margin:0 0 12px">New visitor signal fired</h2>
             <p><strong>Signal:</strong> ${rule.name} (+${rule.score} points)</p>
-            <p><strong>Lead:</strong> ${lead?.name || '(no name)'} &lt;${lead?.email || 'n/a'}&gt;${lead?.company ? ` — ${lead.company}` : ''}</p>
-            <p><strong>New score:</strong> ${currentScore + rule.score}</p>
+            <p><strong>Lead:</strong> ${lead?.name || '(no name)'} &lt;${lead?.email || 'n/a'}&gt;${lead?.companies?.name ? ` — ${lead.companies.name}` : ''}</p>
+            <p><strong>New score:</strong> ${currentScore}</p>
             <p><strong>Evidence:</strong> <code>${JSON.stringify(evidence)}</code></p>
             <hr style="border:none;border-top:1px solid #eee"/>
             <p style="color:#666;font-size:12px">FlowWink Visitor Intelligence</p>

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2139,7 +2139,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:44c82b78fa54ce9a7d62a5664f81d2b2ec2dc667c14101d3da90e23df374600c",
+      "shared_hash": "sha256:0aa87ea01d01b0a8851e9b00dc686cb65c25bb949df87a3f178fd3865d52fc20",
       "functions": {
         "a2a": "sha256:33f9aa45f5a82d23f357aff397403b5b12a94dc3421984a1c883f23509c50f71",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
@@ -2199,7 +2199,7 @@
         "quote-sign": "sha256:6f0e0aabc65a4d5375753109a8cc94992b3c56785bd341db925d446891e45d46",
         "run-autonomy-tests": "sha256:c01a22c4a9851de86317f233dce04e24f1c11014df9f3810bed75a6d2c32122a",
         "run-platform-tests": "sha256:0428747b3103fb351d3332f7fab90bd908b7587300c4728f506b087d520ee8d0",
-        "score-visitor-intent": "sha256:c45442de0d34a5f9660a75a15c269aa5988ca7dbc2631e476418c66e58e6f79e",
+        "score-visitor-intent": "sha256:15e438b8dd9a8ba8a5348d23df7b28b071c66854dd667d86d33f81d4c185987a",
         "send-webhook": "sha256:a8748b5e344f2dee419bb739707e938d093a3cc5ed0a43f3b69cb9de7dc76741",
         "setup-database": "sha256:49f03dc85ea4d48cd53b7760b0a68f4e2a628a217207b0fe4590d931f594e56e",
         "signal-dispatcher": "sha256:a76e992430f13d05003a0e00ba622c239006fc853531400d88a1f238310c90dc",


### PR DESCRIPTION
Båda hittade av agentsvepet, båda verifierade mot live innan de fixades.

## 1. Besöksscoringen skrev över lead-poängen

`score-visitor-intent` frågade efter `leads.company` — **samma spöke som rensades ur frontend i #337**, kvar i en edge-funktion ingen rörde. Kolumnen finns i ingen instans → 400 → felet fångades aldrig → raden blev `null` → nuvarande poäng lästes som 0 → **regelns poäng skrevs över historiken**. Varje besökssignal nollställde leadet i stället för att räkna upp det.

Nu: kolumner som finns, felet fångas, och en misslyckad läsning skriver ingenting.

## 2. SIE-exporten bar fel bolag

`ExportTab` läste `site_name`/`org_number` som **kolumner** på `site_settings` — ett nyckel-värde-lager. Samma svalda 400, och fallbacken skickade kundens bokföring under plattformens eget namn: *"FlowWink", org.nr null*.

Rätt identitet låg en rad bort hela tiden: `company_profile` → **Optic Tunnels Networks Nordic AB / 559532-3659**.

Nu: juridiskt namn före varumärke, och **saknas identiteten blir namnet tomt, inte påhittat** — ett felaktigt bolagsnamn importeras av mottagaren, ett tomt fångas.

## Grinden kör koden den skyddar

Besluten är extraherade till rena funktioner (`nextScore`, `resolveExportIdentity`) för att kunna **anropas** i test. Kvällens mutationsrevision visade mönstret utan undantag: varje grind som kör koden dödade sin mutation, varje grind som letade efter en textsträng överlevde — inklusive en jag själv "härdade" en nivå för högt upp.

Tre mutationer testade, **alla röda**: påhittat FlowWink-namn, ersättande bump, borttagen felvakt.

## Verifierat

tsc, eslint rent, full vitest **3523 gröna**, manifest regenererat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)