### PR TITLE
feat(pages): sidan bär sitt språk — html lang och en språkväljare som syns bara när den behövs

### DIFF
--- a/src/components/public/LanguageSwitcher.tsx
+++ b/src/components/public/LanguageSwitcher.tsx
@@ -1,0 +1,104 @@
+import { Globe } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+import { useUiText } from '@/lib/ui-text';
+
+export interface PageTranslation {
+  slug: string;
+  locale: string;
+  title: string;
+}
+
+interface LanguageSwitcherProps {
+  /** Published sibling pages in this page's translation group, including this one. */
+  translations?: PageTranslation[];
+  /** The locale of the page currently being shown. */
+  currentLocale?: string | null;
+  className?: string;
+}
+
+/**
+ * Lets a visitor move between the published language versions of a page.
+ *
+ * The translation rail (pages.locale + pages.translation_group_id, the
+ * get_page_translations RPC, and PublicPage's ?lang= resolution) has existed
+ * since July and was unreachable: nothing in the site ever put ?lang= in the
+ * address, so a visitor could not find the other language even when it was
+ * published. This is the missing control, not a new mechanism.
+ *
+ * Two deliberate choices:
+ *
+ * 1. It renders NOTHING unless this page actually has another published
+ *    language. Every live instance is single-language today, so the switcher
+ *    must be invisible there — a control that offers no choice is clutter, and
+ *    shipping one to five running sites would be a visible regression.
+ *
+ * 2. The options are real <a> links carrying hrefLang, not router navigation.
+ *    A crawler can follow them (the whole point of publishing translations is
+ *    that they get indexed), and a full load is the honest behaviour for a
+ *    language change: the chrome, the ui_text pack and the formatting all
+ *    re-resolve instead of being half-swapped in place.
+ */
+export function LanguageSwitcher({ translations, currentLocale, className }: LanguageSwitcherProps) {
+  const t = useUiText();
+
+  const options = (translations ?? []).filter((x) => x.slug && x.locale);
+  if (options.length < 2) return null;
+
+  const current = options.find((x) => x.locale === currentLocale) ?? null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className={cn(
+          'flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm transition-colors',
+          'hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          className,
+        )}
+        aria-label={t('language.switch', 'Change language')}
+      >
+        <Globe className="h-4 w-4" aria-hidden="true" />
+        <span className="font-medium uppercase">{(current?.locale ?? options[0].locale).slice(0, 2)}</span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[10rem]">
+        {options.map((option) => {
+          const isCurrent = option.locale === currentLocale;
+          return (
+            <DropdownMenuItem key={option.locale} asChild>
+              <a
+                href={`/${option.slug}`}
+                hrefLang={option.locale}
+                lang={option.locale}
+                aria-current={isCurrent ? 'true' : undefined}
+                className={cn('w-full cursor-pointer', isCurrent && 'font-semibold')}
+              >
+                {languageName(option.locale)}
+              </a>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/**
+ * A language is named in its OWN language — "Svenska", not "Swedish". Someone
+ * who cannot read the current page still has to recognise their own.
+ * Intl.DisplayNames throws on a malformed tag, so an unknown locale falls back
+ * to its uppercased code rather than taking the page down.
+ */
+function languageName(locale: string): string {
+  try {
+    const name = new Intl.DisplayNames([locale], { type: 'language' }).of(locale);
+    if (!name) return locale.toUpperCase();
+    return name.charAt(0).toLocaleUpperCase(locale) + name.slice(1);
+  } catch {
+    return locale.toUpperCase();
+  }
+}

--- a/src/components/public/PublicNavigation.tsx
+++ b/src/components/public/PublicNavigation.tsx
@@ -10,6 +10,7 @@ import { useBranding } from '@/providers/BrandingProvider';
 import { ThemeToggle } from './ThemeToggle';
 import { CartIndicator } from './CartIndicator';
 import { AccountIndicator } from './AccountIndicator';
+import { LanguageSwitcher, type PageTranslation } from './LanguageSwitcher';
 import { SandboxBanner } from '@/components/SandboxBanner';
 import { useHeaderBlock, defaultHeaderData } from '@/hooks/useGlobalBlocks';
 import { useBlogSettings, useStoreSettings, useCustomerPortalSettings } from '@/hooks/useSiteSettings';
@@ -23,7 +24,17 @@ interface NavPage {
   menu_order: number;
 }
 
-export function PublicNavigation() {
+interface PublicNavigationProps {
+  /**
+   * Published language versions of the page being shown, when it has any.
+   * Only PublicPage passes these — every other public page keeps calling
+   * <PublicNavigation /> with no props and behaves exactly as before.
+   */
+  translations?: PageTranslation[];
+  currentLocale?: string | null;
+}
+
+export function PublicNavigation({ translations, currentLocale }: PublicNavigationProps = {}) {
   const t = useUiText();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [openMegaMenu, setOpenMegaMenu] = useState<string | null>(null);
@@ -467,6 +478,7 @@ export function PublicNavigation() {
             {/* Custom nav items - with mega menu support */}
             {customNavItems.map((item) => renderNavItem(item))}
             {branding?.allowThemeToggle !== false && <ThemeToggle />}
+            <LanguageSwitcher translations={translations} currentLocale={currentLocale} />
             {accountEnabled && <AccountIndicator />}
             {cartEnabled && <CartIndicator />}
           </nav>
@@ -474,6 +486,7 @@ export function PublicNavigation() {
           {/* Mobile Menu Button */}
           <div className="flex items-center gap-2 md:hidden">
             {branding?.allowThemeToggle !== false && <ThemeToggle />}
+            <LanguageSwitcher translations={translations} currentLocale={currentLocale} />
             {accountEnabled && <AccountIndicator />}
             {cartEnabled && <CartIndicator />}
             <button

--- a/src/components/public/SeoHead.tsx
+++ b/src/components/public/SeoHead.tsx
@@ -1,5 +1,5 @@
 import { Helmet } from 'react-helmet-async';
-import { useSeoSettings, usePerformanceSettings, useCustomScriptsSettings, useAeoSettings } from '@/hooks/useSiteSettings';
+import { useSeoSettings, usePerformanceSettings, useCustomScriptsSettings, useAeoSettings, usePlatformLocaleSettings } from '@/hooks/useSiteSettings';
 import { renderToHtml } from '@/lib/tiptap-utils';
 
 interface ContentBlock {
@@ -20,6 +20,11 @@ interface SeoHeadProps {
   canonicalUrl?: string;
   noIndex?: boolean;
   noFollow?: boolean;
+  /**
+   * BCP-47 tag for <html lang>. Pass the page's own locale when it has one.
+   * Omitted, it falls back to the instance's platform locale — see below.
+   */
+  lang?: string;
   keywords?: string[];
   // New props for structured data
   pageType?: 'page' | 'article' | 'kb-article';
@@ -217,6 +222,7 @@ export function SeoHead({
   canonicalUrl,
   noIndex = false,
   noFollow = false,
+  lang,
   keywords,
   pageType = 'page',
   contentBlocks = [],
@@ -227,6 +233,7 @@ export function SeoHead({
   articleTags
 }: SeoHeadProps) {
   const { data: seoSettings } = useSeoSettings();
+  const { data: platformLocale } = usePlatformLocaleSettings();
   const { data: performanceSettings } = usePerformanceSettings();
   const { data: scriptsSettings } = useCustomScriptsSettings();
   const { data: aeoSettings } = useAeoSettings();
@@ -314,8 +321,21 @@ export function SeoHead({
 
   const structuredData = generateStructuredData();
 
+  // <html lang> was hardcoded to "en" in index.html, on every page of every
+  // instance — while four of the five live sites publish Swedish. A screen
+  // reader therefore pronounced Swedish with an English voice, and search
+  // engines were told the wrong thing.
+  //
+  // The page's own locale wins when it has one; the language belongs to the
+  // page (that is what pages.locale is for). Absent that, the instance's
+  // platform locale is the only signal that exists. It is strictly a
+  // FORMATTING setting, so using it here is an inference, not a definition —
+  // but inferring "sv-SE" on a Swedish site beats asserting "en" on all of
+  // them, and any page that states its locale overrides it.
+  const htmlLang = (lang || platformLocale?.default_locale || 'en').trim() || 'en';
+
   return (
-    <Helmet>
+    <Helmet htmlAttributes={{ lang: htmlLang }}>
       {/* Basic Meta */}
       <title>{finalTitle}</title>
       {finalDescription && <meta name="description" content={finalDescription} />}

--- a/src/components/public/__tests__/language-switcher.guardrails.test.tsx
+++ b/src/components/public/__tests__/language-switcher.guardrails.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LanguageSwitcher } from '../LanguageSwitcher';
+
+/**
+ * Språkväljaren får INTE synas på en enspråkig sajt.
+ *
+ * Alla fem livesajter är enspråkiga i dag. En växlare som ändå dyker upp i
+ * navigationen vore en synlig regression på var och en av dem — och den sortens
+ * kontroll ("välj mellan ett alternativ") är dessutom meningslös. Rälsen för
+ * översättningar har funnits sedan juli utan att någon kunde nå den; det som
+ * saknades var kontrollen, inte mekanismen, och kontrollen ska bara finnas där
+ * det faktiskt finns ett val.
+ */
+describe('LanguageSwitcher syns bara när det finns ett val', () => {
+  it('renderar ingenting utan översättningar', () => {
+    const { container } = render(<LanguageSwitcher />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renderar ingenting för en tom lista', () => {
+    const { container } = render(<LanguageSwitcher translations={[]} currentLocale="sv" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renderar ingenting när sidan är ensam i sin grupp', () => {
+    const { container } = render(
+      <LanguageSwitcher
+        translations={[{ slug: 'priser', locale: 'sv', title: 'Priser' }]}
+        currentLocale="sv"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('ignorerar rader utan slug eller locale — halv data är inget val', () => {
+    const { container } = render(
+      <LanguageSwitcher
+        translations={[
+          { slug: 'priser', locale: 'sv', title: 'Priser' },
+          { slug: '', locale: 'en', title: 'Pricing' },
+        ]}
+        currentLocale="sv"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('syns först när ett andra språk är publicerat, och visar det nuvarande', () => {
+    render(
+      <LanguageSwitcher
+        translations={[
+          { slug: 'priser', locale: 'sv', title: 'Priser' },
+          { slug: 'pricing', locale: 'en', title: 'Pricing' },
+        ]}
+        currentLocale="sv"
+      />,
+    );
+    const trigger = screen.getByLabelText('Change language');
+    expect(trigger).toBeTruthy();
+    expect(trigger.textContent).toContain('sv');
+  });
+});

--- a/src/pages/PublicPage.tsx
+++ b/src/pages/PublicPage.tsx
@@ -248,6 +248,25 @@ export default function PublicPage() {
   // Multi-language pages (pages parity: multilanguage) — ?lang=<locale> resolves
   // to the published translation in the page's translation group.
   const requestedLang = searchParams.get('lang')?.toLowerCase() || null;
+  // pages.locale / pages.translation_group_id kommer med i sidhämtningen
+  // (get-page och DB-fallbacken gör båda select('*')), men Page-typen är
+  // genererad före de kolumnerna fanns — därav casten, samma som nedan.
+  const pageLocale = (rawPageData as (Page & { locale?: string }) | undefined)?.locale ?? null;
+  const translationGroupId =
+    (rawPageData as (Page & { translation_group_id?: string }) | undefined)?.translation_group_id ?? null;
+
+  // pages.locale DEFAULTAR till 'en' i schemat. Varje sida på varje instans bär
+  // därför redan 'en' utan att någon människa valt det — och fyra av fem
+  // livesajter publicerar svenska. Att lita blint på kolumnen vore alltså att
+  // byta ut en hårdkodad lögn ("en" i index.html) mot en likadan lögn ur
+  // databasen.
+  //
+  // Två signaler skiljer ett VAL från kolumnens tystnad: sidan ingår i en
+  // översättningsgrupp (då har någon tilldelat språk medvetet), eller värdet är
+  // något annat än defaulten. I övriga fall vet vi ingenting, och då är
+  // instansens locale ett ärligare svar än att påstå engelska.
+  const localeWasChosen = !!translationGroupId || (!!pageLocale && pageLocale !== 'en');
+  const declaredLang = localeWasChosen ? pageLocale : null;
   const { data: translations } = useQuery({
     queryKey: ['page-translations', pageSlug],
     queryFn: async (): Promise<Array<{ slug: string; locale: string; title: string }>> => {
@@ -260,7 +279,7 @@ export default function PublicPage() {
         return [];
       }
     },
-    enabled: !!requestedLang && !!rawPageData,
+    enabled: !!translationGroupId || (!!requestedLang && !!rawPageData),
     staleTime: 5 * 60 * 1000,
     retry: false,
   });
@@ -435,12 +454,13 @@ export default function PublicPage() {
         pageType="page"
         contentBlocks={pageData.content_json}
         breadcrumbs={breadcrumbs}
+        lang={declaredLang ?? undefined}
       />
       <HeadScripts />
       <BodyScripts position="start" />
 
       <div className="min-h-screen bg-background">
-        <PublicNavigation />
+        <PublicNavigation translations={translations} currentLocale={pageLocale} />
 
         {/* Page Title - hide if showTitle is false OR first block is a hero */}
         {pageData.meta_json?.showTitle !== false && pageData.content_json?.[0]?.type !== 'hero' && (


### PR DESCRIPTION
Översättningsrälsen har funnits sedan juli och varit **oåtkomlig**: `pages.locale`, `translation_group_id`, `get_page_translations` och `?lang=`-upplösningen fanns alla, men ingenting i sajten satte någonsin `?lang=` i adressen. En besökare kunde inte hitta det andra språket ens när det var publicerat. Det som saknades var kontrollen, inte mekanismen.

## Vad som ändras

**`<html lang>` följer sidan.** Stod hårdkodat `"en"` i `index.html` på varje sida av varje instans — medan fyra av fem livesajter publicerar svenska. En skärmläsare uttalade alltså svenska med engelsk röst.

**En språkväljare i navigationen**, desktop och mobil. Den renderar `null` om sidan inte har ett andra publicerat språk: alla fem instanser är enspråkiga i dag, och en växlare utan val vore en synlig regression på var och en.

Två detaljer som är medvetna:
- Alternativen är riktiga `<a>` med `hreflang`, inte routernavigering. En crawler kan följa dem — hela poängen med att publicera översättningar är att de indexeras — och en hel omladdning är det ärliga beteendet vid språkbyte: skalet, `ui_text` och formateringen löses om i stället för att halvbytas.
- Varje språk skrivs på **sitt eget** språk ("Svenska", inte "Swedish"). Den som inte kan läsa sidan ska ändå känna igen sitt.

## Fällan som nästan gjorde fixen verkningslös

`pages.locale` **defaultar till `'en'`** i schemat. Varje sida på varje instans bär alltså redan `en` utan att någon människa valt det. Att lita blint på kolumnen hade bytt en hårdkodad lögn mot en likadan ur databasen — precis på de sajter fixen var till för.

Kolumnen tros nu bara när någon faktiskt valt: sidan ingår i en översättningsgrupp, eller värdet skiljer sig från defaulten. I övriga fall vet vi ingenting, och då är instansens locale ett ärligare svar än att påstå engelska.

## Kostar de befintliga instanserna noll

Syskonsidorna hämtas bara när sidan har en `translation_group_id`. Den är `NULL` på varje befintlig sida, så ingen extra fråga läggs till någon av de fem.

## Verifierat i webbläsaren, mot lokal Supabase

| | |
|---|---|
| Svensk sida | `<html lang="sv">`, växlaren visar **SV** |
| Menyn | English / Svenska, var och en på sitt språk |
| Klick på English | `/language-test`, `<html lang="en">`, växlaren visar **EN** |
| Sida utan översättningsgrupp | **ingen växlare** |
| Mutation: tröskeln sänkt till 1 | fäller två tester |
| tsc / 3548 tester | gröna |

## Två fynd på vägen, inte åtgärdade här
- Ett sidslug som krockar med en hårdkodad route (`/priser` → `PricingPage`) skuggas tyst av routen.
- `pages.locale`-defaulten `'en'` är i grunden fel form — den påstår ett språk där ingen sagt något. Att ändra den kräver att man kan skilja avsiktliga `en` från default-`en`, vilket inte går i efterhand. Hanterat i läsningen i stället.

🤖 Generated with [Claude Code](https://claude.com/claude-code)