### PR TITLE
fix(agent): den generiska CRUD-vägen rättar också en felgissning

### DIFF
--- a/src/lib/__tests__/crud-error-hint.guardrails.test.ts
+++ b/src/lib/__tests__/crud-error-hint.guardrails.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyWriteError,
+  referencedTableFromConstraint,
+  buildCrudErrorHint,
+} from '../../../supabase/functions/_shared/crud-error-hint';
+
+/**
+ * Den generiska CRUD-vägen var den enda av tre databasvägar som inte
+ * berättade hur man rättar en felgissning. Testerna nedan pinnar de tre
+ * felformer som faktiskt bär en åtgärd — och att allt annat släpps igenom
+ * orört, så en berikning aldrig kan svälja ett fel den inte förstår.
+ */
+describe('CRUD-fel som rättar sig själva', () => {
+  const VENDOR_COLUMNS = ['id', 'invoice_number', 'subtotal_cents', 'tax_cents', 'total_cents', 'vendor_id'];
+
+  it('känner igen en okänd kolumn och pekar på den närmaste riktiga', () => {
+    const hint = buildCrudErrorHint({
+      table: 'vendor_invoices',
+      message: "Could not find the 'amount_cents' column of 'vendor_invoices' in the schema cache",
+      columns: VENDOR_COLUMNS,
+      sentKeys: ['amount_cents', 'invoice_number'],
+    });
+    expect(hint?.error).toContain('amount_cents');
+    expect(hint?.did_you_mean?.amount_cents).toContain('total_cents');
+    expect(hint?.valid_columns).toEqual(VENDOR_COLUMNS);
+  });
+
+  it('svarar ändå när kolumnerna inte gick att läsa — utan att påstå något', () => {
+    const hint = buildCrudErrorHint({
+      table: 'vendor_invoices',
+      message: "Could not find the 'amount_cents' column of 'vendor_invoices' in the schema cache",
+      columns: [],
+    });
+    expect(hint?.did_you_mean).toEqual({});
+    expect(hint?.hint).toContain('list existing rows');
+  });
+
+  it('namnger fältet som saknas vid not-null', () => {
+    const hint = buildCrudErrorHint({
+      table: 'contracts',
+      message: 'null value in column "counterparty_name" of relation "contracts" violates not-null constraint',
+      columns: ['id', 'counterparty_name', 'title'],
+      sentKeys: ['title'],
+    });
+    expect(hint?.error).toContain('counterparty_name is required');
+    expect(hint?.hint).toContain('title');
+  });
+
+  it('säger VILKEN tabell en främmande nyckel måste komma ur', () => {
+    const hint = buildCrudErrorHint({
+      table: 'purchase_orders',
+      message:
+        'insert or update on table "purchase_orders" violates foreign key constraint "purchase_orders_vendor_id_fkey"',
+      columns: [],
+      knownTables: ['purchase_orders', 'vendors', 'partners'],
+    });
+    expect(hint?.must_reference).toBe('vendors');
+    expect(hint?.hint).toContain('not automatically valid');
+  });
+
+  it('konventionen föreslår, katalogen verifierar', () => {
+    const tables = ['partners', 'companies', 'addresses', 'vendors'];
+    expect(referencedTableFromConstraint('orders_partner_id_fkey', tables)).toBe('partners');
+    expect(referencedTableFromConstraint('x_company_id_fkey', tables)).toBe('companies');
+    expect(referencedTableFromConstraint('x_address_id_fkey', tables)).toBe('addresses');
+  });
+
+  it('påstår ingen tabell som inte finns — hellre tyst än självsäkert fel', () => {
+    expect(referencedTableFromConstraint('x_gizmo_id_fkey', ['partners', 'vendors'])).toBeNull();
+    const hint = buildCrudErrorHint({
+      table: 'x',
+      message: 'violates foreign key constraint "x_gizmo_id_fkey"',
+      knownTables: ['partners'],
+    });
+    expect(hint?.must_reference).toBeUndefined();
+    expect(hint?.error).not.toContain('must be an id from');
+  });
+
+  it('släpper igenom ett fel den inte förstår', () => {
+    expect(classifyWriteError('deadlock detected')).toBeNull();
+    expect(buildCrudErrorHint({ table: 't', message: 'deadlock detected' })).toBeNull();
+  });
+});

--- a/supabase/functions/_shared/crud-error-hint.ts
+++ b/supabase/functions/_shared/crud-error-hint.ts
@@ -1,0 +1,165 @@
+/**
+ * Self-correcting errors for the generic CRUD path.
+ *
+ * FlowWink has three ways a skill reaches the database, and until now only two
+ * of them told an agent how to fix a wrong guess:
+ *
+ *   RPC        "missing required parameters: [customer_name, product_name…];
+ *               this skill requires […]; you sent […]"
+ *   staged     "vendor_name → did you mean \"vendor_id\"? Valid parameters: …"
+ *   generic    "Could not find the 'amount_cents' column of 'vendor_invoices'"
+ *
+ * The third is a dead end. It names the mistake and stops — and a model in a
+ * loop answers a dead end by looking for another door, which is exactly the
+ * failure the parameter-contract bounce was written to stop. Measured on a
+ * live instance: `register_vendor_invoice` with `amount_cents` (the column is
+ * `total_cents`) produced no list of valid columns, no nearest match, nothing.
+ *
+ * So the generic path gets the same courtesy, built from the SAME suggestion
+ * engine, and from the table's real columns rather than a hand-kept list —
+ * a list per table would be the thing nobody updates when a column is added.
+ *
+ * Three PostgREST write failures carry a fix an agent can act on:
+ *   PGRST204  unknown column       → the nearest real column, and the full set
+ *   23502     not-null violation   → the field that must be supplied
+ *   23503     foreign key          → WHICH table the value must come from,
+ *                                    which is the difference between a party id
+ *                                    and a vendors id
+ */
+import { suggestClosestNames } from './suggest-names.ts';
+
+export type WriteFailure =
+  | { kind: 'unknown_column'; column: string; table?: string }
+  | { kind: 'not_null'; column: string; table?: string }
+  | { kind: 'foreign_key'; constraint: string; table?: string }
+  | null;
+
+export interface CrudErrorHint {
+  error: string;
+  did_you_mean?: Record<string, string[]>;
+  valid_columns?: string[];
+  must_reference?: string;
+  hint?: string;
+}
+
+/**
+ * Read the shape of the failure out of the driver's message.
+ *
+ * Matching on TEXT is regrettable but it is what reaches this layer: the
+ * PostgREST client collapses the error into a message string by the time the
+ * generic handler catches it. Every pattern below is anchored on wording that
+ * comes from PostgreSQL or PostgREST itself, not from our own code, and an
+ * unrecognised message returns null so the original error passes through
+ * untouched — the enrichment can never swallow a failure it does not
+ * understand.
+ */
+export function classifyWriteError(message: string): WriteFailure {
+  const msg = String(message ?? '');
+
+  const unknownColumn = msg.match(/Could not find the '([^']+)' column of '([^']+)'/i);
+  if (unknownColumn) {
+    return { kind: 'unknown_column', column: unknownColumn[1], table: unknownColumn[2] };
+  }
+
+  const notNull = msg.match(/null value in column "([^"]+)" of relation "([^"]+)" violates not-null/i)
+    ?? msg.match(/null value in column "([^"]+)" violates not-null/i);
+  if (notNull) {
+    return { kind: 'not_null', column: notNull[1], table: notNull[2] };
+  }
+
+  const fk = msg.match(/violates foreign key constraint "([^"]+)"/i);
+  if (fk) {
+    const onTable = msg.match(/on table "([^"]+)"/i) ?? msg.match(/insert or update on table "([^"]+)"/i);
+    return { kind: 'foreign_key', constraint: fk[1], table: onTable?.[1] };
+  }
+
+  return null;
+}
+
+/**
+ * Which table a foreign key points at.
+ *
+ * The constraint name follows a convention (`<table>_<column>_fkey`, column
+ * `<thing>_id`), and a convention is a proposal, not a fact. So the guess is
+ * checked against the real table list when one is available: if no candidate
+ * exists, this returns null and the hint says nothing about the target rather
+ * than naming a table that isn't there. An agent told the wrong table with
+ * confidence is worse off than one told nothing.
+ */
+export function referencedTableFromConstraint(
+  constraint: string,
+  knownTables?: Iterable<string>,
+): string | null {
+  const m = constraint.match(/([a-z0-9]+)_id_fkey$/i);
+  if (!m) return null;
+  const base = m[1].toLowerCase();
+
+  const candidates = [
+    /[sxz]$|ch$|sh$/.test(base) ? `${base}es` : null,
+    base.endsWith('y') ? `${base.slice(0, -1)}ies` : null,
+    `${base}s`,
+    base,
+  ].filter((x): x is string => !!x);
+
+  const known = knownTables ? new Set(knownTables) : null;
+  if (!known || known.size === 0) return candidates[0];
+  return candidates.find((c) => known.has(c)) ?? null;
+}
+
+export interface BuildCrudHintInput {
+  table: string;
+  message: string;
+  /** Every column the table actually has. Empty when introspection failed. */
+  columns?: string[];
+  /** The keys the caller sent, used only to name what it should send instead. */
+  sentKeys?: string[];
+  /** Every table in the schema, so a foreign-key guess can be VERIFIED. */
+  knownTables?: string[];
+}
+
+/**
+ * Turn a raw driver message into an answer an agent can act on next turn.
+ * Returns null when the failure is not one of the three we can explain, so the
+ * caller keeps its original error.
+ */
+export function buildCrudErrorHint(input: BuildCrudHintInput): CrudErrorHint | null {
+  const { table, message, columns = [], sentKeys = [], knownTables } = input;
+  const failure = classifyWriteError(message);
+  if (!failure) return null;
+
+  if (failure.kind === 'unknown_column') {
+    const near = columns.length ? suggestClosestNames(failure.column, columns) : [];
+    return {
+      error:
+        `${table} has no column "${failure.column}"` +
+        (near.length ? ` — did you mean ${near.map((n) => `"${n}"`).join(' or ')}?` : '.'),
+      did_you_mean: near.length ? { [failure.column]: near } : {},
+      valid_columns: columns,
+      hint: columns.length
+        ? `Send the column names above verbatim. Nothing reads "${failure.column}", so the write would not have done what you intended.`
+        : `Could not read ${table}'s columns to suggest an alternative; call the skill with no arguments to list existing rows and copy a field name from one.`,
+    };
+  }
+
+  if (failure.kind === 'not_null') {
+    return {
+      error: `${table}.${failure.column} is required and was not supplied.`,
+      valid_columns: columns,
+      hint:
+        sentKeys.length
+          ? `You sent [${sentKeys.join(', ')}]. Add "${failure.column}" — a default cannot be invented for it.`
+          : `Add "${failure.column}" — a default cannot be invented for it.`,
+    };
+  }
+
+  const referenced = referencedTableFromConstraint(failure.constraint, knownTables);
+  return {
+    error:
+      `A value on ${table} points at a row that does not exist (${failure.constraint}).` +
+      (referenced ? ` It must be an id from "${referenced}".` : ''),
+    must_reference: referenced ?? undefined,
+    hint: referenced
+      ? `Ids are not interchangeable across registers: an id that is valid in one table is not automatically valid in "${referenced}". Look the counterparty up in "${referenced}" and use that id.`
+      : 'Look the referenced row up first and use its id.',
+  };
+}

--- a/supabase/functions/agent-execute/index.ts
+++ b/supabase/functions/agent-execute/index.ts
@@ -68,6 +68,7 @@ import { executeDescribeBlocks } from '../_shared/handlers/describe-blocks.ts';
 // describe_blocks' other half: "what can I build" ↔ "what did I build".
 import { executeInspectRenderedPage } from '../_shared/handlers/inspect-rendered-page.ts';
 import { executeAgentTrace } from '../_shared/handlers/agent-trace.ts';
+import { buildCrudErrorHint } from '../_shared/crud-error-hint.ts';
 
 // Former standalone functions whose serve() bodies moved verbatim. They still
 // read a Request and return a Response; this adapter closes the gap so the
@@ -13191,7 +13192,53 @@ async function executeGenericCrud(
         return { error: `Unknown action '${action}' for table ${table}. Supported: list, get, create, update, delete.` };
     }
   } catch (err: any) {
+    // The generic path used to stop at the driver's message. A model in a loop
+    // answers a dead end by looking for another door — the same failure the
+    // parameter-contract bounce exists to prevent — so the three write
+    // failures that carry an actionable fix now carry it.
+    const schema = await schemaColumns();
+    const hint = buildCrudErrorHint({
+      table,
+      message: err?.message ?? String(err),
+      columns: schema[table] ?? [],
+      knownTables: Object.keys(schema),
+      sentKeys: Object.keys(args ?? {}).filter((k) => !k.startsWith('_')),
+    });
+    if (hint) return hint;
     return { error: `Generic CRUD error on ${table}: ${err.message}` };
+  }
+}
+
+/**
+ * Every table and its real columns, read from PostgREST's own schema
+ * description.
+ *
+ * Deliberately not a hand-kept map: a list per table is the thing nobody
+ * updates when a column is added, and a stale list would make the hint lie.
+ * The table NAMES matter too — they are what turns a foreign-key guess from a
+ * confident assertion into a verified one. Fetched once per cold start; a
+ * failure here degrades the hint rather than the write, so it returns {} and
+ * the caller still answers with what it knows.
+ */
+let _schemaCache: Record<string, string[]> | null = null;
+async function schemaColumns(): Promise<Record<string, string[]>> {
+  if (_schemaCache) return _schemaCache;
+  try {
+    const url = Deno.env.get('SUPABASE_URL');
+    const key = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    if (!url || !key) return {};
+    const res = await fetch(`${url}/rest/v1/`, {
+      headers: { apikey: key, Authorization: `Bearer ${key}`, Accept: 'application/json' },
+    });
+    if (!res.ok) return {};
+    const spec = await res.json();
+    const defs = (spec?.definitions ?? {}) as Record<string, { properties?: Record<string, unknown> }>;
+    _schemaCache = Object.fromEntries(
+      Object.entries(defs).map(([name, def]) => [name, Object.keys(def?.properties ?? {})]),
+    );
+    return _schemaCache;
+  } catch {
+    return {};
   }
 }
 

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2227,11 +2227,11 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:713cd07de077334971eb4ee5a609214a5e1dc63428467e67b05f1885189e1059",
+      "shared_hash": "sha256:b7f35e337bea880e72c9b639737c16ef138f1baa1554e7cef3e4eaf97607805d",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
-        "agent-execute": "sha256:4570701d062059679e749d088d19b7d764c5116302a6b811d2d82053cdf1ec52",
+        "agent-execute": "sha256:ef23eba010d28a44e1f296574721971599550129b6a803e856fbbd19c9b744ac",
         "agent-operate": "sha256:9edc79c928f9920a74d8cfbba484aeabe7b21fba0018ae2ec813031593a74798",
         "ai-task": "sha256:35ae34d3748467b51f716cfef3d80af31b08e92e801905277b8460765b017169",
         "automation-dispatcher": "sha256:3cb8681d7acce65624bd7957a432b143a2d959d769845dc71696b95c2ea2012b",


### PR DESCRIPTION
Glapp 4 ur processvepet. Ren felväg — inget fungerande flöde ändras.

FlowWink har tre vägar från en skill till databasen. Två av dem berättar hur man rättar sig; den tredje är en återvändsgränd:

| Väg | Vad den svarar på en felgissning |
|---|---|
| RPC | *"missing required parameters: […]; this skill requires […]; you sent […]"* |
| staged | *"vendor_name → did you mean `vendor_id`? Valid parameters: …"* |
| **generisk CRUD** | *"Could not find the 'amount_cents' column of 'vendor_invoices'"* |

En modell i loop svarar på en återvändsgränd med att **leta efter en annan dörr** — exakt det beteende parameterkontraktets bounce skrevs för att stoppa. Mätt live under svepet: `register_vendor_invoice` med `amount_cents` (kolumnen heter `total_cents`) gav ingen kolumnlista, ingen närmaste träff, ingenting.

## Tre skrivfel som bär en åtgärd
- **Okänd kolumn** → närmaste riktiga, via *samma* suggest-motor som bouncen, plus hela kolumnuppsättningen
- **Not-null** → fältet som måste skickas, och vad anroparen faktiskt skickade
- **Främmande nyckel** → **vilken tabell** värdet måste komma ur. Det är hela skillnaden mellan ett parts-id och ett `vendors`-id, och därmed en direkt hjälp mot glapp 2 i svepet.

## Två designval
**Kolumnerna läses ur PostgREST egen schemabeskrivning**, inte ur en handhållen lista. En lista per tabell är precis det ingen uppdaterar när en kolumn tillkommer, och en inaktuell lista skulle få upplysningen att ljuga.

**Konventionen föreslår, katalogen verifierar.** FK-gissningen bygger på namnmönstret `<tabell>_<kolumn>_fkey`, men kandidaten kollas mot de riktiga tabellnamnen. Finns ingen träff säger upplysningen ingenting om målet i stället för att namnge en tabell som inte finns — en agent som fått fel tabell med självförtroende är sämre ute än en som inte fått något.

Ett fel som inte känns igen släpps igenom orört. Berikningen kan aldrig svälja ett fel den inte förstår.

## Verifierat
| | |
|---|---|
| 7 tester som importerar och kör hjälparen | gröna |
| Mutation: berikningen avstängd | fäller 5 |
| Mutation: FK-verifieringen borttagen | fäller 1 |
| tsc / 3555 tester / doc-drift | gröna |

Kräver en edge-deploy av `agent-execute` för att märkas på en instans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)