### PR TITLE
feat(settings): en redaktör för besökartexten — och en katalog som vet vilka nycklar som finns

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "fleet:status": "bun run scripts/fleet-status.ts",
     "local:smoke": "bun run scripts/local-smoke.ts",
     "flowpilot:sim": "bun run scripts/flowpilot-simulate.ts",
-    "manifest:json": "bun run scripts/generate-instance-manifest.ts"
+    "manifest:json": "bun run scripts/generate-instance-manifest.ts",
+    "ui-text:catalog": "node scripts/ui-text-catalog.mjs"
   },
   "dependencies": {
     "@codemirror/lang-html": "^6.4.11",

--- a/scripts/lib/extract-ui-text-keys.mjs
+++ b/scripts/lib/extract-ui-text-keys.mjs
@@ -1,0 +1,64 @@
+/**
+ * The visitor-text catalogue, read out of the code that actually uses it.
+ *
+ * `site_settings.ui_text` stores only what somebody has already translated. An
+ * editor built on the stored map alone can therefore show a site's Swedish
+ * strings and nothing else — it can never reveal the eleven keys nobody has
+ * touched yet, which are exactly the ones still showing English on a Swedish
+ * site. The keys live at the call sites (`t('kb.noResults', 'No results')`),
+ * so that is where the catalogue must come from.
+ *
+ * Only files that import `useUiText` are scanned. A bare `t(...)` elsewhere is
+ * somebody else's variable, and a catalogue that swept those in would offer an
+ * editor keys that nothing reads.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const SINGLE = /\bt\(\s*'([A-Za-z0-9_.]+)'\s*,\s*'((?:[^'\\]|\\.)*)'\s*\)/g;
+const DOUBLE = /\bt\(\s*"([A-Za-z0-9_.]+)"\s*,\s*"((?:[^"\\]|\\.)*)"\s*\)/g;
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      if (entry === 'node_modules' || entry === '__tests__') continue;
+      walk(path, out);
+    } else if (/\.(tsx|ts)$/.test(entry)) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+/**
+ * @param {string} root repository root
+ * @returns {{key: string, group: string, fallback: string}[]} sorted by key
+ */
+export function extractUiTextKeys(root) {
+  const found = new Map();
+  for (const file of walk(join(root, 'src'))) {
+    const source = readFileSync(file, 'utf8');
+    // The hook is the marker. Without it, `t` is not this `t`.
+    if (!source.includes('useUiText')) continue;
+    if (relative(root, file).includes('__tests__')) continue;
+    for (const re of [SINGLE, DOUBLE]) {
+      re.lastIndex = 0;
+      let m;
+      while ((m = re.exec(source)) !== null) {
+        const [, key, fallback] = m;
+        // First definition wins, and a later one that DISAGREES is a real
+        // problem: two call sites promising different English for one key.
+        const prior = found.get(key);
+        if (!prior) {
+          found.set(key, { key, group: key.split('.')[0], fallback });
+        } else if (prior.fallback !== fallback) {
+          prior.conflicts = prior.conflicts ?? [];
+          if (!prior.conflicts.includes(fallback)) prior.conflicts.push(fallback);
+        }
+      }
+    }
+  }
+  return [...found.values()].sort((a, b) => a.key.localeCompare(b.key));
+}

--- a/scripts/ui-text-catalog.mjs
+++ b/scripts/ui-text-catalog.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * Regenerates src/data/ui-text-catalog.json from the call sites.
+ * Run after adding or renaming a t('key', 'English') anywhere in src/.
+ */
+import { writeFileSync } from 'node:fs';
+import { extractUiTextKeys } from './lib/extract-ui-text-keys.mjs';
+
+const root = process.cwd();
+const keys = extractUiTextKeys(root);
+const conflicts = keys.filter((k) => k.conflicts?.length);
+
+writeFileSync(
+  'src/data/ui-text-catalog.json',
+  JSON.stringify({ keys: keys.map(({ key, group, fallback }) => ({ key, group, fallback })) }, null, 2) + '\n',
+);
+
+console.log(`✅ ui-text-catalog: ${keys.length} keys in ${new Set(keys.map((k) => k.group)).size} groups`);
+if (conflicts.length) {
+  console.log('\n⚠️  keys whose English differs between call sites — one of them is wrong:');
+  for (const c of conflicts) console.log(`   ${c.key}: "${c.fallback}" vs ${c.conflicts.map((x) => `"${x}"`).join(', ')}`);
+}

--- a/src/components/admin/settings/VisitorTextSettings.tsx
+++ b/src/components/admin/settings/VisitorTextSettings.tsx
@@ -1,0 +1,232 @@
+import { useMemo, useState } from 'react';
+import { Languages, Plus, RotateCcw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { useUiTextSettings, useUpdateUiTextSettings, usePlatformLocaleSettings } from '@/hooks/useSiteSettings';
+import catalogue from '@/data/ui-text-catalog.json';
+
+type Layer = Record<string, string>;
+type Pack = Record<string, string | Record<string, string>>;
+
+const OVERLAY = '@';
+const BASE = '__base__';
+
+const GROUP_LABELS: Record<string, string> = {
+  blog: 'Blog', booking: 'Booking', chat: 'Chat', comments: 'Comments',
+  common: 'Common', faq: 'FAQ', footer: 'Footer', kb: 'Knowledge base',
+  language: 'Language', nav: 'Navigation', page: 'Pages', pagination: 'Pagination',
+  shop: 'Shop',
+};
+
+/**
+ * Editor for the strings around block content — buttons, empty states, "Back
+ * to homepage" — the text a page editor cannot reach.
+ *
+ * The key list comes from src/data/ui-text-catalog.json, generated from the
+ * call sites in the code. That is the whole point: `site_settings.ui_text`
+ * only holds what someone has ALREADY translated, so an editor built on the
+ * stored map can never show the keys nobody has touched — which are exactly
+ * the ones still showing English on a Swedish site.
+ *
+ * One layer is edited at a time, because that is how translating actually
+ * happens. Saving MERGES: every other layer, and every key not in the
+ * catalogue, is carried through untouched.
+ */
+export function VisitorTextSettings() {
+  const { data: pack } = useUiTextSettings();
+  const { data: platformLocale } = usePlatformLocaleSettings();
+  const updatePack = useUpdateUiTextSettings();
+
+  const [layer, setLayer] = useState<string>(BASE);
+  const [draft, setDraft] = useState<Layer | null>(null);
+  const [newLocale, setNewLocale] = useState('');
+
+  const siteLang = platformLocale?.default_locale ?? 'en';
+  const stored: Pack = useMemo(() => (pack ?? {}) as Pack, [pack]);
+
+  const existingLocales = useMemo(
+    () => Object.keys(stored).filter((k) => k.startsWith(OVERLAY)).map((k) => k.slice(1)).sort(),
+    [stored],
+  );
+
+  /** What is stored in the layer being edited, before any local edits. */
+  const layerValues: Layer = useMemo(() => {
+    if (layer === BASE) {
+      return Object.fromEntries(
+        Object.entries(stored).filter(([k, v]) => !k.startsWith(OVERLAY) && typeof v === 'string'),
+      ) as Layer;
+    }
+    const overlay = stored[OVERLAY + layer];
+    return (overlay && typeof overlay === 'object' ? overlay : {}) as Layer;
+  }, [stored, layer]);
+
+  const values = draft ?? layerValues;
+  const dirty = draft !== null;
+
+  const baseValues: Layer = useMemo(
+    () => Object.fromEntries(
+      Object.entries(stored).filter(([k, v]) => !k.startsWith(OVERLAY) && typeof v === 'string'),
+    ) as Layer,
+    [stored],
+  );
+
+  const groups = useMemo(() => {
+    const out = new Map<string, Array<{ key: string; fallback: string }>>();
+    for (const entry of catalogue.keys) {
+      if (!out.has(entry.group)) out.set(entry.group, []);
+      out.get(entry.group)!.push({ key: entry.key, fallback: entry.fallback });
+    }
+    return [...out.entries()].sort(([a], [b]) => a.localeCompare(b));
+  }, []);
+
+  const translated = catalogue.keys.filter((k) => (values[k.key] ?? '').trim()).length;
+
+  const setValue = (key: string, value: string) =>
+    setDraft({ ...(draft ?? layerValues), [key]: value });
+
+  const save = async () => {
+    if (!draft) return;
+    // An empty box means "not translated", which the resolver already answers
+    // by falling through. Storing "" would only be noise that looks like data.
+    const cleaned = Object.fromEntries(
+      Object.entries(draft).filter(([, v]) => (v ?? '').trim() !== ''),
+    ) as Layer;
+
+    let next: Pack;
+    if (layer === BASE) {
+      // Keep every overlay, and any base key the catalogue does not know about
+      // — this editor owns the catalogue's keys, not the whole pack.
+      const overlays = Object.fromEntries(Object.entries(stored).filter(([k]) => k.startsWith(OVERLAY)));
+      const unknown = Object.fromEntries(
+        Object.entries(stored).filter(
+          ([k, v]) => !k.startsWith(OVERLAY) && typeof v === 'string' && !(k in draft),
+        ),
+      );
+      next = { ...unknown, ...cleaned, ...overlays };
+    } else {
+      next = { ...stored, [OVERLAY + layer]: cleaned };
+      if (Object.keys(cleaned).length === 0) delete next[OVERLAY + layer];
+    }
+    await updatePack.mutateAsync(next);
+    setDraft(null);
+  };
+
+  const addLocale = () => {
+    const tag = newLocale.trim().toLowerCase();
+    if (!tag || !/^[a-z]{2}(-[a-z0-9]{2,8})?$/.test(tag)) return;
+    setNewLocale('');
+    setLayer(tag);
+    setDraft({});
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="font-serif flex items-center gap-2">
+          <Languages className="h-5 w-5" />
+          Visitor text
+        </CardTitle>
+        <CardDescription>
+          The strings around your page content — buttons, empty states, search placeholders.
+          Anything left blank shows the English written into the product, so a partial
+          translation is safe.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="space-y-2">
+            <Label htmlFor="ui-text-layer">Editing</Label>
+            <Select value={layer} onValueChange={(v) => { setLayer(v); setDraft(null); }}>
+              <SelectTrigger id="ui-text-layer" className="w-64">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={BASE}>Site language ({siteLang})</SelectItem>
+                {existingLocales.map((tag) => (
+                  <SelectItem key={tag} value={tag}>{tag}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="ui-text-new-locale">Add a language</Label>
+            <div className="flex gap-2">
+              <Input
+                id="ui-text-new-locale"
+                value={newLocale}
+                onChange={(e) => setNewLocale(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addLocale(); } }}
+                placeholder="en, de, en-GB"
+                className="w-32"
+              />
+              <Button type="button" variant="outline" onClick={addLocale} disabled={!newLocale.trim()}>
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          <div className="ml-auto flex items-center gap-3">
+            <Badge variant="secondary">{translated} of {catalogue.keys.length} filled in</Badge>
+            {dirty && (
+              <Button type="button" variant="ghost" onClick={() => setDraft(null)}>
+                <RotateCcw className="h-4 w-4 mr-2" />
+                Discard
+              </Button>
+            )}
+            <Button type="button" onClick={save} disabled={!dirty || updatePack.isPending}>
+              {updatePack.isPending ? 'Saving…' : 'Save visitor text'}
+            </Button>
+          </div>
+        </div>
+
+        {layer !== BASE && (
+          <p className="text-sm text-muted-foreground">
+            Shown to visitors reading a page in <strong>{layer}</strong>. A blank box falls back to
+            the English in the product — never to your {siteLang} text, so an untranslated string
+            never appears in the wrong language.
+          </p>
+        )}
+
+        <div className="space-y-8">
+          {groups.map(([group, entries]) => (
+            <div key={group} className="space-y-4">
+              <h3 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+                {GROUP_LABELS[group] ?? group}
+              </h3>
+              <div className="space-y-4">
+                {entries.map(({ key, fallback }) => (
+                  <div key={key} className="grid gap-1.5 md:grid-cols-[16rem_1fr] md:items-start md:gap-4">
+                    <div className="space-y-0.5">
+                      <Label htmlFor={`ui-${key}`} className="font-mono text-xs">{key}</Label>
+                      <p className="text-xs text-muted-foreground">{fallback}</p>
+                    </div>
+                    <div className="space-y-1">
+                      <Input
+                        id={`ui-${key}`}
+                        value={values[key] ?? ''}
+                        placeholder={fallback}
+                        onChange={(e) => setValue(key, e.target.value)}
+                      />
+                      {layer !== BASE && baseValues[key] && (
+                        <p className="text-xs text-muted-foreground">
+                          {siteLang}: {baseValues[key]}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/data/ui-text-catalog.json
+++ b/src/data/ui-text-catalog.json
@@ -1,0 +1,264 @@
+{
+  "keys": [
+    {
+      "key": "blog.aboutAuthor",
+      "group": "blog",
+      "fallback": "About the author"
+    },
+    {
+      "key": "blog.categoryEmpty",
+      "group": "blog",
+      "fallback": "No posts in this category yet."
+    },
+    {
+      "key": "blog.empty",
+      "group": "blog",
+      "fallback": "No posts published yet."
+    },
+    {
+      "key": "blog.related",
+      "group": "blog",
+      "fallback": "Related posts"
+    },
+    {
+      "key": "booking.back",
+      "group": "booking",
+      "fallback": "Back"
+    },
+    {
+      "key": "booking.email",
+      "group": "booking",
+      "fallback": "Email"
+    },
+    {
+      "key": "booking.name",
+      "group": "booking",
+      "fallback": "Name"
+    },
+    {
+      "key": "booking.namePlaceholder",
+      "group": "booking",
+      "fallback": "Your name"
+    },
+    {
+      "key": "booking.notes",
+      "group": "booking",
+      "fallback": "Notes"
+    },
+    {
+      "key": "booking.notesPlaceholder",
+      "group": "booking",
+      "fallback": "Any additional information..."
+    },
+    {
+      "key": "booking.phone",
+      "group": "booking",
+      "fallback": "Phone"
+    },
+    {
+      "key": "booking.phonePlaceholder",
+      "group": "booking",
+      "fallback": "Your phone number"
+    },
+    {
+      "key": "booking.selectDateTime",
+      "group": "booking",
+      "fallback": "Select Date & Time"
+    },
+    {
+      "key": "booking.selectService",
+      "group": "booking",
+      "fallback": "Select a Service"
+    },
+    {
+      "key": "booking.submitted",
+      "group": "booking",
+      "fallback": "Booking Request Submitted!"
+    },
+    {
+      "key": "chat.leadCapture.error",
+      "group": "chat",
+      "fallback": "Something went wrong. Please try again."
+    },
+    {
+      "key": "chat.leadCapture.placeholder",
+      "group": "chat",
+      "fallback": "you@example.com"
+    },
+    {
+      "key": "chat.leadCapture.prompt",
+      "group": "chat",
+      "fallback": "Want us to follow up? Leave your email."
+    },
+    {
+      "key": "chat.leadCapture.send",
+      "group": "chat",
+      "fallback": "Send"
+    },
+    {
+      "key": "chat.live.sms",
+      "group": "chat",
+      "fallback": "{name} is replying by SMS"
+    },
+    {
+      "key": "chat.live.teammate",
+      "group": "chat",
+      "fallback": "a teammate"
+    },
+    {
+      "key": "chat.live.voice",
+      "group": "chat",
+      "fallback": "{name} is on the line"
+    },
+    {
+      "key": "chat.live.voicemail",
+      "group": "chat",
+      "fallback": "{name} will follow up on your voicemail"
+    },
+    {
+      "key": "chat.live.web",
+      "group": "chat",
+      "fallback": "You are now chatting with {name}"
+    },
+    {
+      "key": "chat.messageLabel",
+      "group": "chat",
+      "fallback": "Your message"
+    },
+    {
+      "key": "chat.send",
+      "group": "chat",
+      "fallback": "Send message"
+    },
+    {
+      "key": "comments.empty",
+      "group": "comments",
+      "fallback": "Be the first to comment."
+    },
+    {
+      "key": "comments.leave",
+      "group": "comments",
+      "fallback": "Leave a comment"
+    },
+    {
+      "key": "common.close",
+      "group": "common",
+      "fallback": "Close"
+    },
+    {
+      "key": "faq.answerTitle",
+      "group": "faq",
+      "fallback": "Assistant answer"
+    },
+    {
+      "key": "faq.askAssistant",
+      "group": "faq",
+      "fallback": "Ask the assistant"
+    },
+    {
+      "key": "faq.thinking",
+      "group": "faq",
+      "fallback": "Thinking…"
+    },
+    {
+      "key": "footer.contact",
+      "group": "footer",
+      "fallback": "Contact"
+    },
+    {
+      "key": "footer.hours",
+      "group": "footer",
+      "fallback": "Opening Hours"
+    },
+    {
+      "key": "footer.quickLinks",
+      "group": "footer",
+      "fallback": "Quick Links"
+    },
+    {
+      "key": "kb.allCategories",
+      "group": "kb",
+      "fallback": "All"
+    },
+    {
+      "key": "kb.noResults",
+      "group": "kb",
+      "fallback": "No results found"
+    },
+    {
+      "key": "kb.searchPlaceholder",
+      "group": "kb",
+      "fallback": "Search for questions or answers..."
+    },
+    {
+      "key": "language.switch",
+      "group": "language",
+      "fallback": "Change language"
+    },
+    {
+      "key": "nav.closeMenu",
+      "group": "nav",
+      "fallback": "Close menu"
+    },
+    {
+      "key": "page.backHome",
+      "group": "page",
+      "fallback": "Back to homepage"
+    },
+    {
+      "key": "page.empty",
+      "group": "page",
+      "fallback": "This page has no content yet."
+    },
+    {
+      "key": "page.notFound",
+      "group": "page",
+      "fallback": "Page could not be found"
+    },
+    {
+      "key": "pagination.next",
+      "group": "pagination",
+      "fallback": "Next page"
+    },
+    {
+      "key": "pagination.prev",
+      "group": "pagination",
+      "fallback": "Previous page"
+    },
+    {
+      "key": "shop.add",
+      "group": "shop",
+      "fallback": "Add"
+    },
+    {
+      "key": "shop.clearSearch",
+      "group": "shop",
+      "fallback": "Clear search"
+    },
+    {
+      "key": "shop.empty",
+      "group": "shop",
+      "fallback": "No products found"
+    },
+    {
+      "key": "shop.inCart",
+      "group": "shop",
+      "fallback": "In cart"
+    },
+    {
+      "key": "shop.searchPlaceholder",
+      "group": "shop",
+      "fallback": "Search products…"
+    },
+    {
+      "key": "shop.subtitle",
+      "group": "shop",
+      "fallback": "Browse our products and add what you need to your cart."
+    },
+    {
+      "key": "shop.title",
+      "group": "shop",
+      "fallback": "Shop"
+    }
+  ]
+}

--- a/src/lib/__tests__/ui-text-catalog.guardrails.test.ts
+++ b/src/lib/__tests__/ui-text-catalog.guardrails.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+// Delad ESM-hjälpare med scripts/ — testet IMPORTERAR och KÖR den, så
+// grinden kan inte överleva sin egen sabotage.
+import { extractUiTextKeys } from '../../../scripts/lib/extract-ui-text-keys.mjs';
+
+const ROOT = resolve(__dirname, '../../..');
+
+/**
+ * Katalogen är vad adminytan visar. Blir den inaktuell visar editorn nycklar
+ * som inte längre finns, och — värre — döljer nya som ingen översatt. En
+ * redaktör som ser en komplett lista litar på den.
+ */
+describe('ui_text-katalogen', () => {
+  const committed = JSON.parse(
+    readFileSync(resolve(ROOT, 'src/data/ui-text-catalog.json'), 'utf8'),
+  ) as { keys: Array<{ key: string; group: string; fallback: string }> };
+
+  it('speglar anropsplatserna i koden', () => {
+    const fresh = extractUiTextKeys(ROOT).map(({ key, group, fallback }: Record<string, string>) => ({ key, group, fallback }));
+    expect(
+      committed.keys,
+      'Inaktuell ui_text-katalog. Kör: npm run ui-text:catalog (och committa src/data/ui-text-catalog.json).',
+    ).toEqual(fresh);
+  });
+
+  it('varje nyckel bär en engelsk fallback', () => {
+    const empty = committed.keys.filter((k) => !k.fallback.trim());
+    expect(empty.map((k) => k.key), 'En nyckel utan fallback ger tom text när packet saknas.').toEqual([]);
+  });
+
+  it('nycklarna är punktade — annars kan de krocka med @<locale>-overlays', () => {
+    const bad = committed.keys.filter((k) => k.key.startsWith('@'));
+    expect(bad.map((k) => k.key)).toEqual([]);
+  });
+
+  it('hittar faktiskt något — en tom katalog vore en tyst regression', () => {
+    expect(committed.keys.length).toBeGreaterThan(20);
+  });
+});

--- a/src/pages/admin/SiteSettingsPage.tsx
+++ b/src/pages/admin/SiteSettingsPage.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
+import { VisitorTextSettings } from '@/components/admin/settings/VisitorTextSettings';
 import { Textarea } from '@/components/ui/textarea';
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -43,7 +44,7 @@ import {
 import { usePlatformFormat } from '@/hooks/usePlatformFormat';
 import { supabase } from '@/integrations/supabase/client';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Loader2, Save, Globe, Zap, ImageIcon, X, AlertTriangle, Code, Cookie, Info, Wrench, Home, Search, Lock, Clock, CheckCircle2, Circle, Bot, FileText, Building2, ExternalLink, Trash2, Sparkles, Server, Copy, Check } from 'lucide-react';
+import { Loader2, Save, Globe, Zap, ImageIcon, X, AlertTriangle, Code, Cookie, Info, Wrench, Home, Search, Lock, Clock, CheckCircle2, Circle, Bot, FileText, Building2, ExternalLink, Trash2, Sparkles, Server, Copy, Check, Languages } from 'lucide-react';
 import { SystemAiSettingsTab } from '@/components/admin/SystemAiSettingsTab';
 import { MediaLibraryPicker } from '@/components/admin/MediaLibraryPicker';
 import { CodeEditor } from '@/components/admin/CodeEditor';
@@ -387,7 +388,7 @@ export default function SiteSettingsPage() {
         </AdminPageHeader>
 
         <Tabs defaultValue="general" className="space-y-6">
-          <TabsList className="grid w-full grid-cols-7 max-w-6xl">
+          <TabsList className="grid w-full grid-cols-8 max-w-6xl">
             <TabsTrigger value="general" className="flex items-center gap-2">
               <Home className="h-4 w-4" />
               <span className="hidden sm:inline">General</span>
@@ -415,6 +416,10 @@ export default function SiteSettingsPage() {
             <TabsTrigger value="performance" className="flex items-center gap-2">
               <Zap className="h-4 w-4" />
               <span className="hidden sm:inline">Performance</span>
+            </TabsTrigger>
+            <TabsTrigger value="visitor-text" className="flex items-center gap-2">
+              <Languages className="h-4 w-4" />
+              <span className="hidden sm:inline">Visitor text</span>
             </TabsTrigger>
           </TabsList>
 
@@ -1555,6 +1560,13 @@ export default function SiteSettingsPage() {
                 </CardContent>
               </Card>
             </div>
+          </TabsContent>
+
+          {/* Visitor text — the strings around block content. Owns its own save
+              button: it merges into site_settings.ui_text and must not be
+              flattened by the page's global save, which writes other keys. */}
+          <TabsContent value="visitor-text" className="space-y-6">
+            <VisitorTextSettings />
           </TabsContent>
 
         </Tabs>


### PR DESCRIPTION
`ui_text` kunde bara redigeras av en agent. Nu finns en yta under **Webbplatsinställningar → Visitor text**, som redigerar ett lager i taget: sajtens eget språk, eller en `@<locale>`-overlay.

## Det svåra var inte formuläret — det var att veta vilka nycklar som finns

Nyckellistan kommer **inte** från det lagrade packet. Det håller bara det någon redan översatt, så en editor byggd på det kan aldrig visa de nycklar ingen rört — vilket är exakt de som fortfarande visar engelska på en svensk sajt. Optic har 36 lagrade nycklar; koden använder 52.

Listan genereras därför ur **anropsplatserna**: `scripts/lib/extract-ui-text-keys.mjs` skannar bara filer som importerar `useUiText` (ett bart `t(...)` någon annanstans är någon annans variabel) och skriver `src/data/ui-text-catalog.json` — 52 nycklar i 13 grupper.

Generatorn rapporterar också nycklar vars engelska **skiljer sig mellan anropsplatser**; då är en av dem fel.

## Sparandet kan inte tappa något
Merge, aldrig ersätt: andra språklager och nycklar utanför katalogen bärs igenom orörda. En tom ruta lagras inte — resolvern faller redan igenom till anropsplatsens engelska, och `""` hade sett ut som data.

För en overlay visas baslagrets text under rutan, så den som översätter ser vad den svenska säger.

## Verifierat
| | |
|---|---|
| Färskhetsgrind som **importerar och kör** extraheraren | grön |
| Varje nyckel bär en fallback; ingen nyckel börjar med `@` | grönt |
| Mutation: katalogen tre nycklar kortare | fäller |
| tsc / 3567 tester | gröna |

🤖 Generated with [Claude Code](https://claude.com/claude-code)