### PR TITLE
feat(pages): ett språk i taget — arbetsspråk i listan, växel i editorn

### DIFF
--- a/src/components/admin/pages/PageLanguageSwitch.tsx
+++ b/src/components/admin/pages/PageLanguageSwitch.tsx
@@ -1,0 +1,85 @@
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Languages } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
+import { useWorkingLanguage } from '@/hooks/useWorkingLanguage';
+import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+interface PageLanguageSwitchProps {
+  /** The page currently open in the editor. */
+  pageId: string;
+  translationGroupId?: string | null;
+  locale?: string | null;
+}
+
+/**
+ * Moves the editor between the language versions of the page it is on.
+ *
+ * The same gesture as the language chooser in the pages list, carried into the
+ * editor so a translator never has to go back out to switch. Choosing a
+ * language here also sets the working language, so the list agrees when they
+ * return to it — one choice, not two that can disagree.
+ *
+ * Renders nothing when the page has no siblings, which is every page on a
+ * single-language site.
+ */
+export function PageLanguageSwitch({ pageId, translationGroupId, locale }: PageLanguageSwitchProps) {
+  const navigate = useNavigate();
+  const { setLang } = useWorkingLanguage();
+
+  const { data: siblings = [] } = useQuery({
+    queryKey: ['page-language-siblings', translationGroupId],
+    enabled: !!translationGroupId,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('pages')
+        .select('id, slug, title, locale, status')
+        .eq('translation_group_id', translationGroupId!)
+        .is('deleted_at', null)
+        .order('locale', { ascending: true });
+      if (error) throw error;
+      return (data ?? []) as Array<{ id: string; slug: string; title: string; locale: string | null; status: string }>;
+    },
+    staleTime: 1000 * 60,
+  });
+
+  if (siblings.length < 2) return null;
+
+  const current = String(locale ?? '').toLowerCase();
+
+  return (
+    <div className="flex items-center gap-1 rounded-md border p-0.5" role="group" aria-label="Page language">
+      <Languages className="h-4 w-4 mx-1.5 text-muted-foreground" aria-hidden="true" />
+      {siblings.map((sibling) => {
+        const code = String(sibling.locale ?? '').toLowerCase();
+        const isCurrent = sibling.id === pageId || code === current;
+        return (
+          <Tooltip key={sibling.id}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-current={isCurrent ? 'true' : undefined}
+                onClick={() => {
+                  if (isCurrent) return;
+                  if (code) setLang(code);
+                  navigate(`/admin/pages/${sibling.id}`);
+                }}
+                className={cn(
+                  'px-2 py-1 rounded text-xs font-medium uppercase transition-colors',
+                  isCurrent ? 'bg-primary text-primary-foreground' : 'hover:bg-muted text-muted-foreground',
+                )}
+              >
+                {code || '—'}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {sibling.title}
+              {sibling.status !== 'published' && ` — ${sibling.status}`}
+            </TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/hooks/useWorkingLanguage.tsx
+++ b/src/hooks/useWorkingLanguage.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { usePlatformLocaleSettings } from '@/hooks/useSiteSettings';
+import { logger } from '@/lib/logger';
+
+const STORAGE_KEY = 'flowwink.admin.workingLanguage';
+
+/**
+ * Which language the editor is working in right now.
+ *
+ * A page per language is the right storage model — it is what gives each
+ * language its own URL, which is the whole reason to publish a translation at
+ * all. But it made the admin list grow from twelve rows to nineteen, and a
+ * third language would have made it thirty-six. That is the model leaking into
+ * a surface it has no business being in.
+ *
+ * So the editor picks a language once, for the whole session, the way a
+ * translator actually works: today I am doing the English pass. The list then
+ * shows one row per page again, in that language.
+ *
+ * The choice is remembered per browser. It is deliberately NOT stored on the
+ * server: it is a property of the person editing, not of the site.
+ */
+export function useWorkingLanguage() {
+  const { data: platformLocale } = usePlatformLocaleSettings();
+  const siteLang = (platformLocale?.default_locale ?? 'en').toLowerCase().split('-')[0];
+
+  // Every language that actually has pages. A site with one language never
+  // sees the control at all — a switch that offers no choice is clutter.
+  const { data: languages = [] } = useQuery({
+    queryKey: ['admin-page-languages'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('pages')
+        .select('locale, translation_group_id')
+        .is('deleted_at', null)
+        .not('translation_group_id', 'is', null);
+      if (error) throw error;
+      const found = new Set<string>();
+      for (const row of data ?? []) {
+        if (row.locale) found.add(String(row.locale).toLowerCase());
+      }
+      return [...found].sort();
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const [lang, setLangState] = useState<string | null>(null);
+
+  // Read once the site language is known, so an unset preference lands on the
+  // language the operator actually writes in rather than on 'en'.
+  useEffect(() => {
+    if (lang !== null) return;
+    let stored: string | null = null;
+    try {
+      stored = window.localStorage.getItem(STORAGE_KEY);
+    } catch (err) {
+      logger.warn('[working-language] localStorage unavailable, using the site language', err);
+    }
+    setLangState(stored || siteLang);
+  }, [lang, siteLang]);
+
+  const setLang = useCallback((next: string) => {
+    setLangState(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch (err) {
+      logger.warn('[working-language] could not remember the choice', err);
+    }
+  }, []);
+
+  return {
+    /** null until the site language has loaded. */
+    lang: lang ?? siteLang,
+    setLang,
+    /** Languages that have pages. Fewer than two means: do not offer a choice. */
+    languages: languages.length > 1 ? languages : [],
+    siteLang,
+  };
+}

--- a/src/lib/__tests__/page-language-grouping.guardrails.test.ts
+++ b/src/lib/__tests__/page-language-grouping.guardrails.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { pagesInWorkingLanguage } from '../page-language-grouping';
+
+const p = (slug: string, locale?: string | null, group?: string | null) =>
+  ({ slug, locale, translation_group_id: group });
+
+describe('adminlistan visar ett språk i taget', () => {
+  const OPTIC = [
+    p('home', 'sv', 'g1'), p('home-en', 'en', 'g1'),
+    p('product', 'sv', 'g2'), p('product-en', 'en', 'g2'),
+    p('villkor', 'sv', null),
+  ];
+
+  it('en enspråkig sajt påverkas INTE alls', () => {
+    const single = [p('home', 'en', null), p('about', 'en', null)];
+    expect(pagesInWorkingLanguage(single, 'en', false)).toBe(single);
+    expect(pagesInWorkingLanguage(OPTIC, 'sv', false)).toBe(OPTIC);
+  });
+
+  it('en översättningsgrupp ger exakt en rad', () => {
+    const rows = pagesInWorkingLanguage(OPTIC, 'sv', true);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.slug).sort()).toEqual(['home', 'product', 'villkor']);
+  });
+
+  it('byter språk utan att antalet rader ändras', () => {
+    const rows = pagesInWorkingLanguage(OPTIC, 'en', true);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.slug).sort()).toEqual(['home-en', 'product-en', 'villkor']);
+  });
+
+  it('en sida utan grupp följer alltid med — den hör till alla språk', () => {
+    expect(pagesInWorkingLanguage(OPTIC, 'de', true).map((r) => r.slug)).toContain('villkor');
+  });
+
+  it('en grupp utan version i språket FÖRSVINNER INTE — den visas som den är', () => {
+    const rows = pagesInWorkingLanguage(OPTIC, 'de', true);
+    expect(rows).toHaveLength(3);
+    expect(rows.some((r) => r.slug === 'home' || r.slug === 'home-en')).toBe(true);
+  });
+
+  it('en-GB svarar på en begäran om en', () => {
+    const rows = pagesInWorkingLanguage(
+      [p('a', 'sv', 'g'), p('a-gb', 'en-GB', 'g')], 'en', true,
+    );
+    expect(rows.map((r) => r.slug)).toEqual(['a-gb']);
+  });
+});

--- a/src/lib/page-language-grouping.ts
+++ b/src/lib/page-language-grouping.ts
@@ -1,0 +1,53 @@
+/**
+ * One row per page in the admin list, in the language being worked in.
+ *
+ * A page per language is the right storage model — it is what gives each
+ * language its own URL. But it made Optic's admin list grow from twelve rows
+ * to nineteen, and a third language would have made it thirty-six. That is the
+ * storage model leaking into a surface it has no business being in.
+ *
+ * A translation group is ONE page to the person editing. This picks which of
+ * its rows to show.
+ */
+export interface GroupablePage {
+  locale?: string | null;
+  translation_group_id?: string | null;
+}
+
+/**
+ * @param pages every page the editor may see
+ * @param workingLang the language being worked in, e.g. 'sv'
+ * @param multilingual false on a single-language site, where grouping must be
+ *   a complete no-op — no reordering, no filtering, nothing to explain.
+ */
+export function pagesInWorkingLanguage<T extends GroupablePage>(
+  pages: T[],
+  workingLang: string,
+  multilingual: boolean,
+): T[] {
+  if (!multilingual) return pages;
+
+  const groups = new Map<string, T[]>();
+  const loose: T[] = [];
+  for (const page of pages) {
+    const group = page.translation_group_id;
+    if (!group) { loose.push(page); continue; }
+    if (!groups.has(group)) groups.set(group, []);
+    groups.get(group)!.push(page);
+  }
+
+  const want = String(workingLang || '').toLowerCase();
+  const picked = [...groups.values()].map((siblings) => {
+    const code = (p: T) => String(p.locale ?? '').toLowerCase();
+    return (
+      siblings.find((p) => code(p) === want)
+      // 'en-GB' should answer a request for 'en' rather than showing nothing.
+      ?? siblings.find((p) => code(p).split('-')[0] === want.split('-')[0])
+      // No version in this language yet. The group still appears — hiding it
+      // would look exactly like the page having been deleted.
+      ?? siblings[0]
+    );
+  });
+
+  return [...loose, ...picked];
+}

--- a/src/pages/PublicPage.tsx
+++ b/src/pages/PublicPage.tsx
@@ -251,9 +251,8 @@ export default function PublicPage() {
   // pages.locale / pages.translation_group_id kommer med i sidhämtningen
   // (get-page och DB-fallbacken gör båda select('*')), men Page-typen är
   // genererad före de kolumnerna fanns — därav casten, samma som nedan.
-  const pageLocale = (rawPageData as (Page & { locale?: string }) | undefined)?.locale ?? null;
-  const translationGroupId =
-    (rawPageData as (Page & { translation_group_id?: string }) | undefined)?.translation_group_id ?? null;
+  const pageLocale = rawPageData?.locale ?? null;
+  const translationGroupId = rawPageData?.translation_group_id ?? null;
 
   // pages.locale DEFAULTAR till 'en' i schemat. Varje sida på varje instans bär
   // därför redan 'en' utan att någon människa valt det — och fyra av fem
@@ -292,7 +291,7 @@ export default function PublicPage() {
 
   useEffect(() => {
     if (!requestedLang || !rawPageData || !translations) return;
-    const currentLocale = (rawPageData as Page & { locale?: string }).locale;
+    const currentLocale = rawPageData.locale;
     if (currentLocale === requestedLang) return;
     const target = translations.find((t) => t.locale === requestedLang);
     if (target && target.slug !== pageSlug) {

--- a/src/pages/admin/PageEditorPage.tsx
+++ b/src/pages/admin/PageEditorPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { PageLanguageSwitch } from '@/components/admin/pages/PageLanguageSwitch';
 import { ArrowLeft, Save, Send, Check, X, Loader2, ExternalLink, Eye, Clock, Undo2, Redo2, Monitor, Smartphone, Tablet } from 'lucide-react';
 import { format } from 'date-fns';
 import { enUS } from 'date-fns/locale';
@@ -247,6 +248,14 @@ export default function PageEditorPage() {
                 />
                 <p className="text-sm text-muted-foreground">/{page.slug}</p>
               </div>
+              {/* Same gesture as the pages list, carried in here so a translator
+                  never has to go back out to switch. Renders nothing unless the
+                  page actually has another language. */}
+              <PageLanguageSwitch
+                pageId={page.id}
+                translationGroupId={page.translation_group_id}
+                locale={page.locale}
+              />
             </div>
             <div className="flex items-center gap-3">
               {/* Preview mode toggle */}

--- a/src/pages/admin/PagesListPage.tsx
+++ b/src/pages/admin/PagesListPage.tsx
@@ -43,6 +43,8 @@ import {
 import { StatusBadge } from '@/components/StatusBadge';
 
 import { usePages, useDeletePage, useCreatePage } from '@/hooks/usePages';
+import { useWorkingLanguage } from '@/hooks/useWorkingLanguage';
+import { pagesInWorkingLanguage } from '@/lib/page-language-grouping';
 import { useAuth } from '@/hooks/useAuth';
 import { useGeneralSettings, useUpdateGeneralSettings } from '@/hooks/useSiteSettings';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -171,6 +173,7 @@ export default function PagesListPage() {
   const createPage = useCreatePage();
   const { isAdmin } = useAuth();
   const { data: generalSettings } = useGeneralSettings();
+  const { lang: workingLang, setLang: setWorkingLang, languages } = useWorkingLanguage();
   const updateGeneralSettings = useUpdateGeneralSettings();
 
   const homepageSlug = generalSettings?.homepageSlug || 'home';
@@ -178,7 +181,12 @@ export default function PagesListPage() {
   const displayPages = useMemo(() => {
     if (!pages) return [];
 
-    const filtered = pages.filter(page => {
+    // A translation group is ONE page to the person editing; that it is stored
+    // as several rows is what gives each language its own URL, and is not the
+    // editor's problem. See src/lib/page-language-grouping.ts.
+    const inWorkingLanguage = pagesInWorkingLanguage(pages, workingLang, languages.length > 0);
+
+    const filtered = inWorkingLanguage.filter(page => {
       const matchesSearch = page.title.toLowerCase().includes(search.toLowerCase()) ||
         page.slug.toLowerCase().includes(search.toLowerCase());
       const matchesStatus = statusFilter === 'all' || page.status === statusFilter;
@@ -203,7 +211,7 @@ export default function PagesListPage() {
       }
       return sortDirection === 'asc' ? comparison : -comparison;
     });
-  }, [pages, search, statusFilter, sortField, sortDirection]);
+  }, [pages, search, statusFilter, sortField, sortDirection, workingLang, languages]);
 
   const handleDuplicate = async (page: { title: string; slug: string }) => {
     const newSlug = `${page.slug}-copy-${Date.now()}`;
@@ -321,6 +329,19 @@ export default function PagesListPage() {
                       <SelectItem value="archived">Archived</SelectItem>
                     </SelectContent>
                   </Select>
+                  {languages.length > 1 && (
+                    <Select value={workingLang} onValueChange={setWorkingLang}>
+                      <SelectTrigger className="w-full sm:w-[170px]" aria-label="Working language">
+                        <Languages className="h-4 w-4 mr-2" />
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {languages.map((code) => (
+                          <SelectItem key={code} value={code}>{code.toUpperCase()}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
                   <Select
                     value={`${sortField}-${sortDirection}`}
                     onValueChange={(value) => {

--- a/src/types/cms.ts
+++ b/src/types/cms.ts
@@ -86,6 +86,14 @@ export interface Page {
   deleted_by: string | null;
   show_in_menu?: boolean;
   menu_order?: number;
+  /**
+   * BCP-47 tag for the language this page is written in. NOTE: the column
+   * DEFAULTS to 'en' in the schema, so a value of 'en' may mean "nobody chose"
+   * rather than "this page is English" — see src/pages/PublicPage.tsx.
+   */
+  locale?: string | null;
+  /** Pages sharing this id are language versions of each other. */
+  translation_group_id?: string | null;
 }
 
 export interface PageVersion {


### PR DESCRIPTION
En sida per språk är rätt **lagringsmodell** — det är den som ger varje språk sin egen adress, vilket är hela skälet att publicera en översättning. Men den läckte in i en yta där den inte hörde hemma: Optics adminlista växte från **tolv rader till nitton**, och ett tredje språk hade gjort trettiosex.

Nu väljer redigeraren språk **en gång**, som en översättare faktiskt arbetar — *idag gör jag engelskan*. Listan visar då en rad per sida igen.

## Två ytor, ett val
- **Arbetsspråk i sidlistans verktygsrad.** Syns bara när instansen faktiskt har mer än ett sidspråk.
- **`PageLanguageSwitch` i editorns huvud** — samma gest buren in dit arbetet sker. Att välja språk där sätter också arbetsspråket, så listan är överens när man kommer tillbaka. Ett val, inte två som kan säga emot varandra.

Valet minns per webbläsare, aldrig på servern: det är en egenskap hos personen som redigerar, inte hos sajten.

## Vad grupperingen inte får göra
`pagesInWorkingLanguage` är utbruten som ren funktion och provad:

| | |
|---|---|
| Enspråkig sajt | returnerar **samma array-referens** — ingen omsortering, inget att förklara |
| Grupp utan version i språket | **försvinner inte** — att gömma den vore oskiljbart från att sidan raderats |
| Sida utan grupp | följer alltid med; den hör till alla språk |
| `en-GB` | svarar på en begäran om `en` |
| Mutation: grupperingen förbikopplad | fäller 4 tester |

## En typ som ljög
`Page` bär nu `locale` och `translation_group_id`. Kolumnerna fanns och appen läste dem redan — genom castar. Fyra castar borta. Kommentaren varnar för att `'en'` kan betyda *"ingen valde"*, eftersom kolumnen defaultar dit.

tsc / 3573 tester gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)