### PR TITLE
feat(pages): sajten deklarerar sina språk — och kan byta standard

### DIFF
--- a/src/components/admin/settings/SiteLanguagesSettings.tsx
+++ b/src/components/admin/settings/SiteLanguagesSettings.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Languages, Plus, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { supabase } from '@/integrations/supabase/client';
+import { useSiteLanguages, useUpdateSiteLanguages } from '@/hooks/useSiteSettings';
+import { toast } from 'sonner';
+
+const TAG = /^[a-z]{2}(-[a-z0-9]{2,8})?$/;
+
+/**
+ * Which languages the site publishes in, and which one a visitor gets first.
+ *
+ * This is the dial that did not exist. The set used to be computed by scanning
+ * which pages happened to carry a locale, so adding a language was a side
+ * effect of creating a page and the default could not be changed at all.
+ *
+ * English is not added for free. For the product's own chrome it genuinely is
+ * the floor — every string in the code carries English and it cannot be
+ * removed — but a page has no English version unless somebody wrote one, and
+ * listing a language nobody has published would put a door in the visitor's
+ * switcher that opens onto nothing.
+ */
+export function SiteLanguagesSettings() {
+  const { defaultLanguage, languages } = useSiteLanguages();
+  const update = useUpdateSiteLanguages();
+  const [adding, setAdding] = useState('');
+
+  // What removing a language would actually cost. A count is the difference
+  // between "are you sure?" and "this would hide 7 published pages".
+  const { data: pagesPerLanguage = {} } = useQuery({
+    queryKey: ['pages-per-language'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('pages')
+        .select('locale')
+        .is('deleted_at', null);
+      if (error) throw error;
+      const counts: Record<string, number> = {};
+      for (const row of data ?? []) {
+        const code = String(row.locale ?? '').toLowerCase();
+        if (code) counts[code] = (counts[code] ?? 0) + 1;
+      }
+      return counts;
+    },
+    staleTime: 1000 * 60,
+  });
+
+  const sorted = useMemo(
+    () => [...languages].sort((a, b) => (a === defaultLanguage ? -1 : b === defaultLanguage ? 1 : a.localeCompare(b))),
+    [languages, defaultLanguage],
+  );
+
+  const save = (next: { default: string; enabled: string[] }) => update.mutate(next);
+
+  const add = () => {
+    const tag = adding.trim().toLowerCase();
+    if (!TAG.test(tag)) {
+      toast.error('Use a language tag like "en", "de" or "en-GB".');
+      return;
+    }
+    if (languages.includes(tag)) { setAdding(''); return; }
+    setAdding('');
+    save({ default: defaultLanguage, enabled: [...languages, tag] });
+  };
+
+  const remove = (tag: string) => {
+    if (tag === defaultLanguage) {
+      toast.error('This is the default language. Make another language the default first.');
+      return;
+    }
+    const count = pagesPerLanguage[tag] ?? 0;
+    if (count > 0) {
+      toast.error(
+        `${count} page${count === 1 ? '' : 's'} are written in ${tag}. They would stay live but disappear from the language switcher — move or delete them first.`,
+      );
+      return;
+    }
+    save({ default: defaultLanguage, enabled: languages.filter((l) => l !== tag) });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="font-serif flex items-center gap-2">
+          <Languages className="h-5 w-5" />
+          Languages
+        </CardTitle>
+        <CardDescription>
+          The languages this site publishes content in. Visitors get the default unless they
+          choose another; the product's own interface is always English.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-2">
+          <Label>Published languages</Label>
+          <div className="flex flex-wrap items-center gap-2">
+            {sorted.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-sm"
+              >
+                <span className="font-medium uppercase">{tag}</span>
+                <span className="text-xs text-muted-foreground">
+                  {tag === defaultLanguage ? 'default' : `${pagesPerLanguage[tag] ?? 0} pages`}
+                </span>
+                {tag !== defaultLanguage && (
+                  <button
+                    type="button"
+                    onClick={() => remove(tag)}
+                    aria-label={`Remove ${tag}`}
+                    className="text-muted-foreground hover:text-destructive"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-end gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="add-language">Add a language</Label>
+            <div className="flex gap-2">
+              <Input
+                id="add-language"
+                value={adding}
+                onChange={(e) => setAdding(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); add(); } }}
+                placeholder="en, de, en-GB"
+                className="w-36"
+              />
+              <Button type="button" variant="outline" onClick={add} disabled={!adding.trim()}>
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="default-language">Visitors get</Label>
+            <Select
+              value={defaultLanguage}
+              onValueChange={(value) => save({ default: value, enabled: languages })}
+            >
+              <SelectTrigger id="default-language" className="w-44">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {sorted.map((tag) => (
+                  <SelectItem key={tag} value={tag}>{tag.toUpperCase()}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          Changing the default decides which version a visitor lands on. It does not move any
+          page — every language keeps its own address, so existing links go on working.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/public/SeoHead.tsx
+++ b/src/components/public/SeoHead.tsx
@@ -1,5 +1,5 @@
 import { Helmet } from 'react-helmet-async';
-import { useSeoSettings, usePerformanceSettings, useCustomScriptsSettings, useAeoSettings, usePlatformLocaleSettings } from '@/hooks/useSiteSettings';
+import { useSeoSettings, usePerformanceSettings, useCustomScriptsSettings, useAeoSettings, useSiteLanguages } from '@/hooks/useSiteSettings';
 import { renderToHtml } from '@/lib/tiptap-utils';
 
 interface ContentBlock {
@@ -233,7 +233,7 @@ export function SeoHead({
   articleTags
 }: SeoHeadProps) {
   const { data: seoSettings } = useSeoSettings();
-  const { data: platformLocale } = usePlatformLocaleSettings();
+  const { defaultLanguage } = useSiteLanguages();
   const { data: performanceSettings } = usePerformanceSettings();
   const { data: scriptsSettings } = useCustomScriptsSettings();
   const { data: aeoSettings } = useAeoSettings();
@@ -323,16 +323,13 @@ export function SeoHead({
 
   // <html lang> was hardcoded to "en" in index.html, on every page of every
   // instance — while four of the five live sites publish Swedish. A screen
-  // reader therefore pronounced Swedish with an English voice, and search
-  // engines were told the wrong thing.
+  // reader therefore pronounced Swedish with an English voice.
   //
-  // The page's own locale wins when it has one; the language belongs to the
-  // page (that is what pages.locale is for). Absent that, the instance's
-  // platform locale is the only signal that exists. It is strictly a
-  // FORMATTING setting, so using it here is an inference, not a definition —
-  // but inferring "sv-SE" on a Swedish site beats asserting "en" on all of
-  // them, and any page that states its locale overrides it.
-  const htmlLang = (lang || platformLocale?.default_locale || 'en').trim() || 'en';
+  // The page's own locale wins; the language belongs to the page. Absent that
+  // — a route that is not a CMS page — the site's DECLARED default answers.
+  // That used to be read off platform_locale, which governs number format and
+  // was only ever an inference.
+  const htmlLang = (lang || defaultLanguage || 'en').trim() || 'en';
 
   return (
     <Helmet htmlAttributes={{ lang: htmlLang }}>

--- a/src/hooks/useSiteSettings.tsx
+++ b/src/hooks/useSiteSettings.tsx
@@ -633,6 +633,49 @@ export function useUpdateSalesPipelineSettings() {
   return useUpdateSiteSettings<SalesPipelineSettings>('sales_pipeline', 'Pipeline settings updated.');
 }
 
+export interface SiteLanguages {
+  /** The language a visitor gets when they have not asked for another. */
+  default: string;
+  /** Every language the site publishes content in, including the default. */
+  enabled: string[];
+}
+
+const FALLBACK: SiteLanguages = { default: 'en', enabled: ['en'] };
+
+/**
+ * The languages this site publishes in, declared rather than inferred.
+ *
+ * Before this existed, the set was computed by scanning which pages happened to
+ * carry a locale, and the default was read off `platform_locale` — a setting
+ * that governs number and date FORMAT. Three things followed, all the same
+ * mistake: adding a language was a side effect of creating a page, the default
+ * could not be changed because there was no dial, and `pages.locale` defaulted
+ * to 'en' in the schema, so every reader had to guess whether an 'en' meant
+ * English or meant nobody chose.
+ *
+ * A note on what is NOT here: English is not automatically enabled. For the
+ * product's own chrome English genuinely is the floor — every `t()` call site
+ * carries it and it cannot be removed. But a page has no free English version;
+ * one exists only if somebody wrote it. Listing a language nobody has published
+ * would put a door in the switcher that opens onto nothing.
+ */
+export function useSiteLanguages() {
+  const query = useSiteSettings<SiteLanguages>('site_languages', FALLBACK);
+  const value = query.data ?? FALLBACK;
+  const enabled = value.enabled?.length ? value.enabled : [value.default || 'en'];
+  return {
+    ...query,
+    defaultLanguage: (value.default || 'en').toLowerCase(),
+    languages: enabled.map((l) => l.toLowerCase()),
+    /** True when the site publishes in more than one language. */
+    isMultilingual: enabled.length > 1,
+  };
+}
+
+export function useUpdateSiteLanguages() {
+  return useUpdateSiteSettings<SiteLanguages>('site_languages', 'Languages updated.');
+}
+
 export function usePlatformLocaleSettings() {
   return useSiteSettings<PlatformLocaleSettings>('platform_locale', defaultPlatformLocaleSettings);
 }

--- a/src/hooks/useWorkingLanguage.tsx
+++ b/src/hooks/useWorkingLanguage.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
-import { usePlatformLocaleSettings } from '@/hooks/useSiteSettings';
+import { useSiteLanguages } from '@/hooks/useSiteSettings';
 import { logger } from '@/lib/logger';
 
 const STORAGE_KEY = 'flowwink.admin.workingLanguage';
@@ -23,28 +21,9 @@ const STORAGE_KEY = 'flowwink.admin.workingLanguage';
  * server: it is a property of the person editing, not of the site.
  */
 export function useWorkingLanguage() {
-  const { data: platformLocale } = usePlatformLocaleSettings();
-  const siteLang = (platformLocale?.default_locale ?? 'en').toLowerCase().split('-')[0];
-
-  // Every language that actually has pages. A site with one language never
-  // sees the control at all — a switch that offers no choice is clutter.
-  const { data: languages = [] } = useQuery({
-    queryKey: ['admin-page-languages'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('pages')
-        .select('locale, translation_group_id')
-        .is('deleted_at', null)
-        .not('translation_group_id', 'is', null);
-      if (error) throw error;
-      const found = new Set<string>();
-      for (const row of data ?? []) {
-        if (row.locale) found.add(String(row.locale).toLowerCase());
-      }
-      return [...found].sort();
-    },
-    staleTime: 1000 * 60 * 5,
-  });
+  // Declared, not inferred. Scanning pages for locales made adding a language
+  // a side effect of creating a page; the set now says what the site publishes.
+  const { defaultLanguage: siteLang, languages: declared, isMultilingual } = useSiteLanguages();
 
   const [lang, setLangState] = useState<string | null>(null);
 
@@ -74,8 +53,8 @@ export function useWorkingLanguage() {
     /** null until the site language has loaded. */
     lang: lang ?? siteLang,
     setLang,
-    /** Languages that have pages. Fewer than two means: do not offer a choice. */
-    languages: languages.length > 1 ? languages : [],
+    /** Fewer than two means: do not offer a choice. */
+    languages: isMultilingual ? declared : [],
     siteLang,
   };
 }

--- a/src/pages/PublicPage.tsx
+++ b/src/pages/PublicPage.tsx
@@ -254,18 +254,12 @@ export default function PublicPage() {
   const pageLocale = rawPageData?.locale ?? null;
   const translationGroupId = rawPageData?.translation_group_id ?? null;
 
-  // pages.locale DEFAULTAR till 'en' i schemat. Varje sida på varje instans bär
-  // därför redan 'en' utan att någon människa valt det — och fyra av fem
-  // livesajter publicerar svenska. Att lita blint på kolumnen vore alltså att
-  // byta ut en hårdkodad lögn ("en" i index.html) mot en likadan lögn ur
-  // databasen.
-  //
-  // Två signaler skiljer ett VAL från kolumnens tystnad: sidan ingår i en
-  // översättningsgrupp (då har någon tilldelat språk medvetet), eller värdet är
-  // något annat än defaulten. I övriga fall vet vi ingenting, och då är
-  // instansens locale ett ärligare svar än att påstå engelska.
-  const localeWasChosen = !!translationGroupId || (!!pageLocale && pageLocale !== 'en');
-  const declaredLang = localeWasChosen ? pageLocale : null;
+  // Kolumnen bär sanningen sedan sajten deklarerar sina språk: nya sidor får
+  // sajtens standardspråk av en trigger, och de gamla riktades in vid samma
+  // migrering. Heuristiken som fanns här — "tro kolumnen bara om sidan ingår i
+  // en grupp eller värdet skiljer sig från defaulten" — var ett plåster på att
+  // sanningen saknades, och behövs inte längre.
+  const declaredLang = pageLocale;
 
   // Chrome follows content. Without this the visitor reads an English page
   // wrapped in Swedish buttons — the half-translated site the ui_text pack was

--- a/src/pages/admin/SiteSettingsPage.tsx
+++ b/src/pages/admin/SiteSettingsPage.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { VisitorTextSettings } from '@/components/admin/settings/VisitorTextSettings';
+import { SiteLanguagesSettings } from '@/components/admin/settings/SiteLanguagesSettings';
 import { Textarea } from '@/components/ui/textarea';
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -419,7 +420,7 @@ export default function SiteSettingsPage() {
             </TabsTrigger>
             <TabsTrigger value="visitor-text" className="flex items-center gap-2">
               <Languages className="h-4 w-4" />
-              <span className="hidden sm:inline">Visitor text</span>
+              <span className="hidden sm:inline">Language &amp; text</span>
             </TabsTrigger>
           </TabsList>
 
@@ -1566,6 +1567,9 @@ export default function SiteSettingsPage() {
               button: it merges into site_settings.ui_text and must not be
               flattened by the page's global save, which writes other keys. */}
           <TabsContent value="visitor-text" className="space-y-6">
+            {/* Which languages exist comes first: the text editor below edits
+                one layer per language, so the set has to be decided here. */}
+            <SiteLanguagesSettings />
             <VisitorTextSettings />
           </TabsContent>
 

--- a/supabase/migrations/20260903030000_sajten-deklarerar-sina-sprak.sql
+++ b/supabase/migrations/20260903030000_sajten-deklarerar-sina-sprak.sql
@@ -1,0 +1,120 @@
+-- Sajten deklarerar sina språk.
+--
+-- Fram till nu FANNS inte sajtens språk någonstans. De räknades fram genom att
+-- skanna vilka sidor som råkade ha en locale, och vilket språk som var standard
+-- härleddes ur `platform_locale` — en inställning som egentligen styr
+-- sifferformat.
+--
+-- Konsekvenserna var tre, och alla tre är samma fel:
+--   * Att lägga till ett språk blev en BIEFFEKT av att skapa en sida
+--   * Det gick inte att BYTA standardspråk, för det fanns ingen ratt
+--   * `pages.locale` defaultade till 'en' i schemat, så en läsare tvingades
+--     gissa: "tro kolumnen bara om sidan ingår i en översättningsgrupp eller
+--     värdet skiljer sig från defaulten"
+--
+-- Den gissningen var ett plåster på att sanningen saknades. Nu finns den:
+--
+--     site_settings.site_languages = {"default": "sv", "enabled": ["sv","en"]}
+--
+-- Ordningen blir den en människa faktiskt tänker sig: installera, lägg till
+-- svenska, bygg sidorna, gör svenska till standard och låt engelska bli
+-- valbar. Att kunna BYTA standard efteråt är detaljen som avslöjar att modellen
+-- stämmer — den ratten fanns inte förut.
+
+-- ── Inställningen seedas, och kan seedas om ────────────────────────────────
+-- En re-asserterbar FUNKTION, inte en engångs-INSERT: en instans som föds efter
+-- den här migreringen ska få samma sanning som en som redan finns.
+CREATE OR REPLACE FUNCTION public.ensure_site_languages()
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_existing jsonb;
+  v_default text;
+  v_enabled text[];
+BEGIN
+  SELECT value INTO v_existing FROM site_settings WHERE key = 'site_languages';
+
+  -- Standardspråket ärvs från formatinställningen FÖRSTA gången, för det är
+  -- den enda signal som finns om vad instansen faktiskt skriver på. Därefter
+  -- är site_languages sin egen sanning och rör aldrig platform_locale igen.
+  SELECT lower(split_part(coalesce(value ->> 'default_locale', 'en'), '-', 1))
+    INTO v_default FROM site_settings WHERE key = 'platform_locale';
+  v_default := coalesce(v_existing ->> 'default', nullif(v_default, ''), 'en');
+
+  -- Varje språk som FAKTISKT används av en sida hör hemma i listan, oavsett hur
+  -- det hamnade där. Att tappa ett skulle göra en publicerad sida onåbar ur
+  -- växlaren.
+  SELECT array_agg(DISTINCT x) INTO v_enabled FROM (
+    SELECT v_default AS x
+    UNION SELECT jsonb_array_elements_text(coalesce(v_existing -> 'enabled', '[]'::jsonb))
+    UNION SELECT lower(p.locale) FROM pages p
+           WHERE p.locale IS NOT NULL AND p.deleted_at IS NULL
+             AND p.translation_group_id IS NOT NULL
+  ) s WHERE x IS NOT NULL AND x <> '';
+
+  INSERT INTO site_settings (key, value)
+  VALUES ('site_languages', jsonb_build_object(
+            'default', v_default,
+            'enabled', to_jsonb(coalesce(v_enabled, ARRAY[v_default]))))
+  ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+
+  RETURN jsonb_build_object('default', v_default, 'enabled', coalesce(v_enabled, ARRAY[v_default]));
+END $$;
+
+REVOKE ALL ON FUNCTION public.ensure_site_languages() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.ensure_site_languages() TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.ensure_site_languages() IS
+  'Seedar site_settings.site_languages. Standardspråket ärvs från '
+  'platform_locale FÖRSTA gången; därefter är site_languages sin egen sanning.';
+
+DO $$ BEGIN
+  PERFORM set_config('request.jwt.claims', '{"role":"service_role"}', true);
+  PERFORM public.ensure_site_languages();
+END $$;
+
+-- ── En ny sida föds i sajtens språk ────────────────────────────────────────
+-- Kolumndefaulten 'en' var en lögn: den påstod engelska om varje sida på varje
+-- instans, inklusive de fyra svenska. Den tas bort, och triggern fyller i
+-- sanningen i stället.
+ALTER TABLE public.pages ALTER COLUMN locale DROP DEFAULT;
+
+CREATE OR REPLACE FUNCTION public.pages_default_locale()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF NEW.locale IS NULL OR trim(NEW.locale) = '' THEN
+    SELECT lower(coalesce(value ->> 'default', 'en')) INTO NEW.locale
+      FROM site_settings WHERE key = 'site_languages';
+    NEW.locale := coalesce(NEW.locale, 'en');
+  ELSE
+    NEW.locale := lower(trim(NEW.locale));
+  END IF;
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS pages_set_locale ON public.pages;
+CREATE TRIGGER pages_set_locale
+  BEFORE INSERT ON public.pages
+  FOR EACH ROW EXECUTE FUNCTION public.pages_default_locale();
+
+COMMENT ON FUNCTION public.pages_default_locale() IS
+  'Ger en ny sida sajtens standardspråk. Ersätter kolumndefaulten ''en'', som '
+  'påstod engelska om varje sida på varje instans.';
+
+-- ── Historiken riktas in ───────────────────────────────────────────────────
+-- En sida UTAN översättningsgrupp har inget annat språk att vara skriven på än
+-- sajtens eget — det följer av att den är ensam. Sidor som ingår i en grupp
+-- rörs INTE: där har någon uttryckligen tilldelat språk.
+DO $$
+DECLARE v_default text; v_n int;
+BEGIN
+  SELECT lower(coalesce(value ->> 'default', 'en')) INTO v_default
+    FROM site_settings WHERE key = 'site_languages';
+
+  UPDATE pages SET locale = v_default
+   WHERE translation_group_id IS NULL
+     AND coalesce(lower(locale), '') IS DISTINCT FROM v_default;
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  RAISE NOTICE 'pages.locale: % ungrouped page(s) aligned to the site language "%"', v_n, v_default;
+END $$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260903010000",
-      "migrations_count": 553,
+      "migration_head": "20260903030000",
+      "migrations_count": 554,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2217,6 +2217,10 @@
         {
           "version": "20260903010000",
           "name": "fakturan-som-foddes-bokford"
+        },
+        {
+          "version": "20260903030000",
+          "name": "sajten-deklarerar-sina-sprak"
         }
       ]
     },


### PR DESCRIPTION
Fram till nu **fanns** sajtens språk ingenstans. De räknades fram genom att skanna vilka sidor som råkade ha en locale, och standardspråket härleddes ur `platform_locale` — en inställning som egentligen styr sifferformat.

Tre konsekvenser, alla samma fel:
- Att lägga till ett språk blev en **bieffekt** av att skapa en sida
- Det gick inte att **byta** standardspråk, för det fanns ingen ratt
- `pages.locale` defaultade till `'en'` i schemat, så varje läsare tvingades gissa om ett `'en'` betydde engelska eller betydde *att ingen valt*

```json
site_settings.site_languages = { "default": "sv", "enabled": ["sv", "en"] }
```

## Vad som ändras
- **`ensure_site_languages()`** — re-asserterbar seed-*funktion*, inte en engångs-`INSERT`. Standardspråket ärvs från `platform_locale` **första** gången (den enda signal som finns om vad instansen skriver på); därefter är `site_languages` sin egen sanning. Språk som faktiskt används av en sida läggs alltid till — annars vore en publicerad sida onåbar ur växlaren.
- **Kolumndefaulten `'en'` är borta.** En trigger ger nya sidor sajtens språk i stället, och normaliserar ett uttryckligt värde till gemener.
- **Historiken riktades in:** sidor utan översättningsgrupp fick sajtens språk — en ensam sida har inget annat språk att vara skriven på. Sidor *i* en grupp rörs inte; där har någon uttryckligen tilldelat språk.
- **Adminratt** under Webbplatsinställningar → *Language & text*. Att ta bort standardspråket vägras; att ta bort ett språk som har sidor säger **hur många** i stället för "är du säker?".

Heuristiken i `PublicPage` — *"tro kolumnen bara om sidan ingår i en grupp eller värdet skiljer sig från defaulten"* — försvinner helt. Den var ett plåster på att sanningen saknades.

## Engelska läggs inte till gratis
För produktens eget **skal** är engelska golvet: varje `t()`-anropsplats bär den och den går inte att ta bort. Men en **sida** har ingen engelsk version om ingen skrivit den, och att lista ett språk ingen publicerat vore en dörr i besökarens växlare som inte leder någonstans.

## Verifierat
| | |
|---|---|
| Ny sida utan angivet språk | föds `sv` |
| Uttryckligt `EN` | respekteras, normaliseras till `en` |
| Standard bytt till `de` | nästa sida föds `de` |
| Migreringen körd två gånger | idempotent |
| tsc / 3573 tester / forward-dating | gröna |

🤖 Generated with [Claude Code](https://claude.com/claude-code)