### PR TITLE
fix(blocks): hero, CTA och kontakt följer språkväxeln — och kan inte frysa igen

### DIFF
--- a/scripts/lib/scan-frozen-block-editors.mjs
+++ b/scripts/lib/scan-frozen-block-editors.mjs
@@ -1,0 +1,59 @@
+/**
+ * Block editors that copy their props into one-shot state.
+ *
+ * `useState(data)` freezes whatever the FIRST render passed. The parent handing
+ * over new content afterwards changes nothing, so the editor shows the wrong
+ * thing and — worse — the next Save writes the frozen copy back over the real
+ * content.
+ *
+ * It has now bitten twice for different reasons:
+ *   2026-08-18  a tab mounted before its query resolved; the saved footer
+ *               variant lost to the defaults, and Save reverted the user's own
+ *               earlier edits
+ *   2026-08-31  switching the page editor between language versions kept the
+ *               hero and CTA on the previous page's text — the component stays
+ *               mounted across the route change
+ *
+ * The repair existed after the first one (useBlockEditor: prop-sync with an
+ * equality guard) and nothing made the editors adopt it. Three had not, and a
+ * person found two of them by hand. This is what makes the rail mandatory.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** A one-shot copy of the `data` prop, in any of its spellings. */
+const FROZEN = [
+  /useState\s*<[^>]*>\s*\(\s*data\s*\)/,
+  /useState\s*\(\s*data\s*\)/,
+  /useState\s*<[^>]*>\s*\(\s*\{\s*\.\.\.data\s*\}\s*\)/,
+  /useState\s*\(\s*\{\s*\.\.\.data\s*\}\s*\)/,
+];
+
+/**
+ * Comments out. A guard that reads PROSE can be fooled by prose — this one
+ * flagged three files for the sentence explaining the bug it looks for, which
+ * is the same weakness as a guard that only greps a string.
+ */
+function codeOnly(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/^\s*\/\/.*$/gm, ' ')
+    .replace(/([^:])\/\/.*$/gm, '$1');
+}
+
+export function scanFrozenBlockEditors(root) {
+  const dir = join(root, 'src/components/admin/blocks');
+  const offenders = [];
+  for (const file of readdirSync(dir).sort()) {
+    if (!file.endsWith('.tsx')) continue;
+    const source = readFileSync(join(dir, file), 'utf8');
+    // No file-level exemption. Skipping any file that MENTIONS useBlockEditor
+    // would let an editor use the rail for one piece of state and freeze
+    // another — and it hid a deliberate re-freeze during mutation testing,
+    // which is how this hole was found. The patterns below are specific to a
+    // one-shot copy of the `data` prop; the hook itself lives in src/hooks and
+    // is never scanned.
+    if (FROZEN.some((re) => re.test(codeOnly(source)))) offenders.push(file);
+  }
+  return offenders;
+}

--- a/src/components/admin/blocks/CTABlockEditor.tsx
+++ b/src/components/admin/blocks/CTABlockEditor.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useBlockEditor } from '@/hooks/useBlockEditor';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
@@ -24,13 +25,16 @@ const VARIANT_OPTIONS: { value: CTAVariant; label: string; description: string }
 ];
 
 export function CTABlockEditor({ data, onChange, isEditing }: CTABlockEditorProps) {
-  const [localData, setLocalData] = useState<CTABlockData>(data);
-
-  const handleChange = (updates: Partial<CTABlockData>) => {
-    const newData = { ...localData, ...updates };
-    setLocalData(newData);
-    onChange(newData);
-  };
+  // Prop-sync, not a one-shot copy. useState(data) froze whatever the FIRST
+  // render passed: switching the page editor between language versions kept
+  // this block on the previous page's text, because the component stays mounted
+  // across the route change (Magnus, 2026-08-31). useBlockEditor re-syncs when
+  // the parent hands over new content and guards against the editor's own
+  // changes bouncing back.
+  const { data: localData, updateFields: handleChange } = useBlockEditor<CTABlockData>({
+    initialData: data,
+    onChange,
+  });
 
   const variant = localData.variant || 'default';
 

--- a/src/components/admin/blocks/ContactBlockEditor.tsx
+++ b/src/components/admin/blocks/ContactBlockEditor.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useBlockEditor } from '@/hooks/useBlockEditor';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
@@ -12,13 +13,16 @@ interface ContactBlockEditorProps {
 }
 
 export function ContactBlockEditor({ data, onChange, isEditing }: ContactBlockEditorProps) {
-  const [localData, setLocalData] = useState<ContactBlockData>(data);
-
-  const handleChange = (updates: Partial<ContactBlockData>) => {
-    const newData = { ...localData, ...updates };
-    setLocalData(newData);
-    onChange(newData);
-  };
+  // Prop-sync, not a one-shot copy. useState(data) froze whatever the FIRST
+  // render passed: switching the page editor between language versions kept
+  // this block on the previous page's text, because the component stays mounted
+  // across the route change (Magnus, 2026-08-31). useBlockEditor re-syncs when
+  // the parent hands over new content and guards against the editor's own
+  // changes bouncing back.
+  const { data: localData, updateFields: handleChange } = useBlockEditor<ContactBlockData>({
+    initialData: data,
+    onChange,
+  });
 
   const addHours = () => {
     handleChange({

--- a/src/components/admin/blocks/HeroBlockEditor.tsx
+++ b/src/components/admin/blocks/HeroBlockEditor.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useBlockEditor } from '@/hooks/useBlockEditor';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
@@ -53,13 +54,16 @@ const TEXT_ALIGNMENT_OPTIONS: { value: HeroTextAlignment; label: string; icon: t
 ];
 
 export function HeroBlockEditor({ data, onChange, isEditing }: HeroBlockEditorProps) {
-  const [localData, setLocalData] = useState<HeroBlockData>(data);
-
-  const handleChange = (updates: Partial<HeroBlockData>) => {
-    const newData = { ...localData, ...updates };
-    setLocalData(newData);
-    onChange(newData);
-  };
+  // Prop-sync, not a one-shot copy. useState(data) froze whatever the FIRST
+  // render passed: switching the page editor between language versions kept
+  // this block on the previous page's text, because the component stays mounted
+  // across the route change (Magnus, 2026-08-31). useBlockEditor re-syncs when
+  // the parent hands over new content and guards against the editor's own
+  // changes bouncing back.
+  const { data: localData, updateFields: handleChange } = useBlockEditor<HeroBlockData>({
+    initialData: data,
+    onChange,
+  });
 
   const layout = localData.layout || 'centered';
   const backgroundType = localData.backgroundType || 'image';

--- a/src/lib/__tests__/no-frozen-block-editors.guardrails.test.ts
+++ b/src/lib/__tests__/no-frozen-block-editors.guardrails.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import { scanFrozenBlockEditors } from '../../../scripts/lib/scan-frozen-block-editors.mjs';
+
+const ROOT = resolve(__dirname, '../../..');
+
+/**
+ * Frusna blockeditorer — noll, och det ska förbli noll.
+ *
+ * useBlockEditor löste klassen 2026-08-18, men ingenting tvingade editorerna
+ * att använda den. Tre gjorde det inte, och en människa hittade två av dem för
+ * hand genom att växla språk i sidredigeraren. Grinden gör rälsen obligatorisk
+ * i stället för tillgänglig.
+ */
+describe('inga frusna blockeditorer', () => {
+  it('ingen editor kopierar sina props till engångs-state', () => {
+    const offenders = scanFrozenBlockEditors(ROOT);
+    expect(
+      offenders,
+      'useState(data) fryser första renderingen. Använd useBlockEditor — den synkar om när '
+      + 'föräldern lämnar över nytt innehåll och vaktar mot att editorns egna ändringar studsar tillbaka.',
+    ).toEqual([]);
+  });
+
+  it('skannern hittar mönstret när det finns — annars vore nollan värdelös', () => {
+    // Negativtest mot skannerns egna regexar, inte mot en fil på disk: en grind
+    // som bara kan rapportera noll bevisar ingenting.
+    const patterns = [
+      'const [d, setD] = useState<Foo>(data);',
+      'const [d, setD] = useState(data);',
+      'const [d, setD] = useState<Foo>({ ...data });',
+    ];
+    for (const line of patterns) {
+      expect(
+        [/useState\s*<[^>]*>\s*\(\s*data\s*\)/, /useState\s*\(\s*data\s*\)/,
+         /useState\s*<[^>]*>\s*\(\s*\{\s*\.\.\.data\s*\}\s*\)/].some((re) => re.test(line)),
+        `skannern missar: ${line}`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Växla sv/en i sidredigeraren och hero-blocket samt call-to-action-kortet följde inte med. Orsaken är **den frusna förstamålningen igen**: de kopierade sina props till engångs-state med `useState(data)`, och komponenten förblir monterad när editorn byter till syskonsidan — så blocket visade föregående sidas text.

`useBlockEditor` löste exakt den klassen 2026-08-18 (prop-synk med likhetsvakt). Men **ingenting tvingade editorerna att använda den**. Tre av 76 hade inte gjort det, och en människa hittade två av dem för hand. Den tredje — kontaktblocket — hade samma bugg, orapporterad.

## Fixen
De tre konverterade. `updateFields` har samma signatur som deras `handleChange`, så inget av de 63 anropsställena behövde röras.

Och en grind: **noll frusna editorer, och det ska förbli noll.** Rälsen blir obligatorisk i stället för bara tillgänglig.

## Två hål i min egen grind, båda hittade genom att mutera den
1. **Filundantaget.** Skannern hoppade över hela filer som *nämnde* `useBlockEditor` — då hade en editor kunnat använda rälsen för en sak och frysa en annan. Det dolde också min första mutation, vilket är hur hålet hittades.
2. **Den läste prosa.** Efter att undantaget tagits bort flaggade den tre filer — för **kommentaren som förklarar buggen den letar efter**. Skannern strippar nu kommentarer och läser kod. En grind som går att lura med text är samma svaghet som en grind som bara greppar en sträng.

| | |
|---|---|
| Ren kod | `[]` |
| En editor fryst igen | `['HeroBlockEditor.tsx']` |
| Negativtest mot skannerns regexar | tre stavningar fångade |
| tsc / 3575 tester | gröna |

🤖 Generated with [Claude Code](https://claude.com/claude-code)