### PR TITLE
refactor(i18n): en stege för språkval — och konventionen nedskriven

### DIFF
--- a/docs/architecture/language.md
+++ b/docs/architecture/language.md
@@ -1,0 +1,153 @@
+# Language — a light internationalization system
+
+FlowWink is an English product that publishes content in whatever language the
+operator writes. This document names the four layers that make that work, so
+the next translatable thing lands on the rail instead of inventing a fifth rule.
+
+## 0. TL;DR
+
+Four layers, four owners:
+
+| Layer | Owner | Shape |
+|---|---|---|
+| Product interface (admin) | the code | English, always. Not translated. |
+| Visitor chrome — buttons, empty states | `site_settings.ui_text` | one blob, `@<locale>` overlays |
+| Content — pages, and next: email templates | the row | `locale` + `translation_group_id` |
+| Number, date, currency format | `site_settings.platform_locale` | not language; never confuse the two |
+
+And one shared rule for *which version to show*: `pickLocale()` in TypeScript,
+`public.pick_locale()` in SQL.
+
+---
+
+## 1. The site declares its languages
+
+```json
+site_settings.site_languages = { "default": "sv", "enabled": ["sv", "en"] }
+```
+
+Before this existed the set was **computed** by scanning which pages happened to
+carry a locale, and the default was read off `platform_locale` — a formatting
+setting. Adding a language was therefore a side effect of creating a page, and
+the default could not be changed at all.
+
+`ensure_site_languages()` seeds it, re-assertably. An instance **with no pages**
+is born English; one with pages inherits from `platform_locale` once, because
+that is the only clue about what is already written there. A decision already
+made always beats the inference.
+
+**English is not enabled for free.** For the product's own chrome it genuinely is
+the floor — every `t()` call site carries English and it cannot be removed. But
+a page has no English version unless somebody wrote one, and listing a language
+nobody has published puts a door in the visitor's switcher that opens onto
+nothing.
+
+## 2. Content: a row per language
+
+Any table holding translatable *documents* gets two columns:
+
+- **`locale`** — the language this row is written in, BCP-47
+- **`translation_group_id`** — rows sharing it are versions of each other
+
+`pages` has them. The rules that follow are the convention:
+
+- **One row per language per group.** Enforced in `manage_page_translation`.
+- **Each language keeps its own address.** That is the whole reason to store it
+  as separate rows rather than `{sv, en}` fields: one URL per language is what
+  lets a search engine index both and `hreflang` work at all.
+- **A new row is born in the site's default language** (`pages_default_locale`
+  trigger). Do not put a literal default on the column — `pages.locale` once
+  defaulted to `'en'`, which asserted English about every page on every
+  instance and forced every reader to guess whether an `'en'` meant *English*
+  or meant *nobody chose*.
+- **Blocks know nothing about language.** A block is content; the page carries
+  the language. This is why 76 block editors needed no changes when the site
+  became bilingual.
+
+### Adding a language to an existing site
+
+`translate_site_into(locale)` copies every published page into drafts in the new
+language and adds it to `site_languages`. It **copies; it does not translate** —
+the drafts carry the source text. Idempotent: a page that already has a version
+is skipped.
+
+## 3. Chrome: one blob, `@<locale>` overlays
+
+`site_settings.ui_text` holds the strings *around* block content. The shape is
+additive:
+
+```json
+{
+  "chat.send": "Skicka",
+  "@en": { "chat.send": "Send" }
+}
+```
+
+Flat keys are the base layer, in the site's own language. `@<locale>` keys are
+overlays. Resolution for a page in language L:
+
+1. the `@L` overlay (exact tag, then the same language)
+2. the flat base layer — **only when L is the site's own language**
+3. the English written at the call site
+
+Step 2's condition is the point: on a Swedish site, an English page must not
+fall through to the Swedish base layer. Falling to the call-site English instead
+is both correct and free.
+
+The key list comes from `src/data/ui-text-catalog.json`, generated from the call
+sites — the stored pack only holds what someone already translated, so an editor
+built on it could never show the untranslated keys, which are exactly the ones
+still showing English on a Swedish site.
+
+## 4. The ladder, once
+
+Both halves of the system answer *"which version?"* the same way:
+
+1. **the exact tag** — `sv-SE` answers `sv-SE`
+2. **the same language** — `sv` answers `sv-SE`, and `en-GB` answers `en`
+3. **the site's default**
+4. **nothing** — the caller decides what an absence means
+
+Step 4 is deliberate and is why this is a function rather than a policy. A page
+with no version in the wanted language must **not** silently become another
+language (the admin list shows what exists, marked as such); a string with no
+translation must fall to the English in the code. Different answers to the same
+absence.
+
+- `pickLocale()` — `src/lib/pick-locale.ts`
+- `public.pick_locale(available[], wanted, fallback)` — same ladder, server side
+
+The shared cases are pinned twice: `pick-locale.guardrails.test.ts` for the
+TypeScript side, and a `DO` block in migration `20260903090000` that proves the
+SQL side **every time it is applied**, because no CI has a database.
+
+---
+
+## Next: email templates
+
+`email_templates` is selected by `name` (the kind: `booking_confirmation`,
+`invoice_email`, …). It should adopt §2, not invent anything:
+
+- add `locale`, make the key `(name, locale)`
+- the recipient's language is already known — `partner_language(partner_id)`,
+  since a party carries its own language
+- choose with `pick_locale(available_locales, recipient_language, site_default)`
+- and keep Law 4: a missing translation must fall back to a template that
+  exists, never to no email at all
+
+The reason this is a small step and not a project is that the ladder, the
+declaration and the fallback discipline are already built and already shared.
+
+## What is deliberately not here
+
+- **No message catalogue for the admin UI.** The product interface stays
+  English. That is what keeps this system light: the heavy half of i18n —
+  extraction, catalogues, `t()` everywhere, translator tooling — is the half we
+  do not need.
+- **No automatic language detection.** `Accept-Language` is not read. The
+  ladder for a visitor is: explicit URL → the page's own language → the site
+  default. Adding browser detection means deciding what happens to crawlers and
+  to an explicit choice, and that is a separate decision.
+- **No language-aware blog archive.** The archive link comes from blog settings,
+  not from a page, so it sits outside the translation groups. Its label and
+  destination stay in the site's own language.

--- a/src/components/public/PublicNavigation.tsx
+++ b/src/components/public/PublicNavigation.tsx
@@ -11,6 +11,7 @@ import { ThemeToggle } from './ThemeToggle';
 import { CartIndicator } from './CartIndicator';
 import { AccountIndicator } from './AccountIndicator';
 import { LanguageSwitcher, type PageTranslation } from './LanguageSwitcher';
+import { pickLocale } from '@/lib/pick-locale';
 import { SandboxBanner } from '@/components/SandboxBanner';
 import { useHeaderBlock, defaultHeaderData } from '@/hooks/useGlobalBlocks';
 import { useBlogSettings, useStoreSettings, useCustomerPortalSettings } from '@/hooks/useSiteSettings';
@@ -139,13 +140,16 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
   const siblingOf = useMemo(() => {
     if (!currentLocale || siblings.length === 0) return () => null as null | { slug: string; title: string };
     const bySlug = new Map(siblings.map((p) => [p.slug, p]));
-    const byGroupLocale = new Map(
-      siblings.filter((p) => p.locale).map((p) => [`${p.translation_group_id}:${p.locale}`, p]),
-    );
     return (slug: string) => {
       const source = bySlug.get(slug);
       if (!source?.translation_group_id) return null;
-      const target = byGroupLocale.get(`${source.translation_group_id}:${currentLocale}`);
+      const group = siblings.filter((p) => p.translation_group_id === source.translation_group_id);
+      const chosen = pickLocale({
+        available: group.map((p) => String(p.locale ?? '')),
+        wanted: currentLocale,
+      });
+      if (!chosen) return null;
+      const target = group.find((p) => String(p.locale ?? '') === chosen);
       return target && target.slug !== slug ? { slug: target.slug, title: target.title } : null;
     };
   }, [siblings, currentLocale]);

--- a/src/lib/__tests__/pick-locale.guardrails.test.ts
+++ b/src/lib/__tests__/pick-locale.guardrails.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { pickLocale, baseSubtag } from '../pick-locale';
+
+/**
+ * Stegen för språkval, pinnad.
+ *
+ * SAMMA fall står i migreringen 20260903090000, där public.pick_locale bevisar
+ * sig själv vid varje applicering. Två implementationer av en regel är
+ * oundvikligt när halva systemet svarar i webbläsaren och halva i databasen —
+ * men två BETEENDEN är det inte. Ändras den ena ska den andra ändras, och de
+ * här fallen är kontraktet mellan dem.
+ */
+describe('pickLocale — samma stege som public.pick_locale', () => {
+  const LADDER: Array<[string, string[], string | null, string | null, string | null]> = [
+    ['exakt tagg',            ['sv', 'en'],     'sv',    'en', 'sv'],
+    ['samma språk',           ['sv', 'en'],     'sv-SE', 'en', 'sv'],
+    ['en-GB svarar på en',    ['en', 'sv'],     'en-GB', 'sv', 'en'],
+    ['minst specifik vinner', ['en-GB', 'en'],  'en',    null, 'en'],
+    ['faller till standard',  ['sv', 'en'],     'de',    'en', 'en'],
+    ['ingen träff är null',   ['sv'],           'de',    'fr', null],
+    ['tom lista är null',     [],               'sv',    'en', null],
+  ];
+
+  for (const [name, available, wanted, fallback, expected] of LADDER) {
+    it(name, () => {
+      expect(pickLocale({ available, wanted, fallback })).toBe(expected);
+    });
+  }
+
+  it('returnerar taggen som den STAVAS i listan, inte som den efterfrågades', () => {
+    expect(pickLocale({ available: ['sv-SE'], wanted: 'SV-se' })).toBe('sv-SE');
+  });
+
+  it('en frånvaro rapporteras — den gissas aldrig till ett annat språk', () => {
+    // Det här är hela skälet att steget finns: en sida utan version i det
+    // önskade språket får inte tyst bli ett annat språk.
+    expect(pickLocale({ available: ['sv', 'de'], wanted: 'fr' })).toBeNull();
+  });
+
+  it('skräp i listan ignoreras i stället för att bli ett språk', () => {
+    expect(pickLocale({ available: ['', '  ', 'sv'], wanted: 'sv' })).toBe('sv');
+    expect(pickLocale({ available: ['', '  '], wanted: 'sv', fallback: 'en' })).toBeNull();
+  });
+
+  it('baseSubtag', () => {
+    expect(baseSubtag('sv-SE')).toBe('sv');
+    expect(baseSubtag('EN')).toBe('en');
+    expect(baseSubtag('')).toBe('');
+  });
+});

--- a/src/lib/page-language-grouping.ts
+++ b/src/lib/page-language-grouping.ts
@@ -9,6 +9,8 @@
  * A translation group is ONE page to the person editing. This picks which of
  * its rows to show.
  */
+import { pickLocale } from './pick-locale';
+
 export interface GroupablePage {
   locale?: string | null;
   translation_group_id?: string | null;
@@ -36,17 +38,17 @@ export function pagesInWorkingLanguage<T extends GroupablePage>(
     groups.get(group)!.push(page);
   }
 
-  const want = String(workingLang || '').toLowerCase();
   const picked = [...groups.values()].map((siblings) => {
-    const code = (p: T) => String(p.locale ?? '').toLowerCase();
-    return (
-      siblings.find((p) => code(p) === want)
-      // 'en-GB' should answer a request for 'en' rather than showing nothing.
-      ?? siblings.find((p) => code(p).split('-')[0] === want.split('-')[0])
-      // No version in this language yet. The group still appears — hiding it
-      // would look exactly like the page having been deleted.
-      ?? siblings[0]
-    );
+    // The ladder itself lives in one place; this only decides what an ABSENCE
+    // means here. A group with no version in the working language still
+    // appears, as whatever exists — hiding it would look exactly like the page
+    // having been deleted.
+    const chosen = pickLocale({
+      available: siblings.map((p) => String(p.locale ?? '')),
+      wanted: workingLang,
+    });
+    if (!chosen) return siblings[0];
+    return siblings.find((p) => String(p.locale ?? '') === chosen) ?? siblings[0];
   });
 
   return [...loose, ...picked];

--- a/src/lib/pick-locale.ts
+++ b/src/lib/pick-locale.ts
@@ -1,0 +1,73 @@
+/**
+ * Which version to show, given what exists and what was asked for.
+ *
+ * FlowWink now answers that question in four places — the visitor's page, the
+ * admin's working language, the `ui_text` pack, and next the email template
+ * chosen for a recipient. Each had started to grow its own spelling of the same
+ * ladder, which is how three implementations become three behaviours.
+ *
+ * The ladder, once:
+ *
+ *   1. the exact tag            'sv-SE' answers 'sv-SE'
+ *   2. the same language        'sv' answers 'sv-SE', and 'en-GB' answers 'en'
+ *   3. the site's default       whatever the operator declared
+ *   4. nothing                  the caller decides what an absence means
+ *
+ * Step 4 is deliberate. A page with no version in the wanted language must not
+ * silently become another language; a string with no translation must fall to
+ * the English in the code. Those are different answers to the same absence, so
+ * this function reports it rather than choosing.
+ *
+ * The twin `public.pick_locale()` in SQL follows the same ladder for the parts
+ * that resolve on the server. Change one, change both — the guardrail in
+ * pick-locale.guardrails.test.ts pins the shared cases.
+ */
+
+/** 'sv-SE' → 'sv'. A tag without a region is returned unchanged. */
+export function baseSubtag(tag: string): string {
+  return String(tag ?? '').trim().toLowerCase().split('-')[0];
+}
+
+export interface PickLocaleOptions {
+  /** Every locale that actually exists for this thing. */
+  available: Iterable<string>;
+  /** What the reader asked for, or is being served. */
+  wanted?: string | null;
+  /** The site's declared default, used when `wanted` has no version. */
+  fallback?: string | null;
+}
+
+/**
+ * @returns the locale to use, exactly as it appears in `available`, or null
+ *   when nothing matches — never a guess.
+ */
+export function pickLocale({ available, wanted, fallback }: PickLocaleOptions): string | null {
+  const options = [...available]
+    .map((l) => String(l ?? '').trim())
+    .filter(Boolean);
+  if (options.length === 0) return null;
+
+  const byExact = new Map<string, string>();
+  const byLanguage = new Map<string, string>();
+  for (const option of options) {
+    const lower = option.toLowerCase();
+    if (!byExact.has(lower)) byExact.set(lower, option);
+    const base = baseSubtag(option);
+    // The least specific spelling of a language wins as its representative, so
+    // a site with both 'en' and 'en-GB' answers a request for 'en' with 'en'.
+    if (!byLanguage.has(base) || option.length < byLanguage.get(base)!.length) {
+      byLanguage.set(base, option);
+    }
+  }
+
+  for (const candidate of [wanted, fallback]) {
+    const tag = String(candidate ?? '').trim().toLowerCase();
+    if (!tag) continue;
+    const exact = byExact.get(tag);
+    if (exact) return exact;
+    const sameLanguage = byLanguage.get(baseSubtag(tag));
+    if (sameLanguage) return sameLanguage;
+  }
+
+  return null;
+}

--- a/src/lib/ui-text.tsx
+++ b/src/lib/ui-text.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { pickLocale, baseSubtag } from '@/lib/pick-locale';
 import { logger } from '@/lib/logger';
 
 /**
@@ -60,11 +61,6 @@ import { logger } from '@/lib/logger';
 export type UiTextMap = Record<string, string | Record<string, string>>;
 
 const OVERLAY_PREFIX = '@';
-
-/** 'sv-SE' → 'sv'. A tag without a region is returned unchanged. */
-function baseSubtag(tag: string): string {
-  return String(tag || '').toLowerCase().split('-')[0];
-}
 
 interface UiTextValue {
   map: UiTextMap;
@@ -147,13 +143,21 @@ export function resolveUiText(
   lang: string,
   siteLang: string,
 ): (key: string, fallback: string) => string {
-  const overlay = (tag: string): Record<string, string> | null => {
+  const overlay = (tag: string | null): Record<string, string> | null => {
+    if (!tag) return null;
     const entry = map?.[OVERLAY_PREFIX + tag];
     return entry && typeof entry === 'object' ? entry as Record<string, string> : null;
   };
   const tag = String(lang || '').toLowerCase();
-  const exact = overlay(tag);
-  const base = tag === baseSubtag(tag) ? null : overlay(baseSubtag(tag));
+
+  // Same ladder as everywhere else — exact tag, then the same language — but
+  // deliberately WITHOUT a fallback: falling through to the site's own overlay
+  // is the flat base layer's job below, and only when the language matches.
+  const available = Object.keys(map ?? {})
+    .filter((k) => k.startsWith(OVERLAY_PREFIX) && typeof map[k] === 'object')
+    .map((k) => k.slice(OVERLAY_PREFIX.length));
+  const exact = overlay(pickLocale({ available, wanted: tag }));
+  const base = null;
   // The base layer is written in the site's own language. Falling through to it
   // from a DIFFERENT language would wrap English content in Swedish chrome.
   const useFlatLayer = baseSubtag(tag) === baseSubtag(siteLang);

--- a/supabase/migrations/20260903090000_en-stege-for-sprakval.sql
+++ b/supabase/migrations/20260903090000_en-stege-for-sprakval.sql
@@ -1,0 +1,92 @@
+-- En stege för språkval, i stället för fyra stavningar av samma sak.
+--
+-- FlowWink svarar nu på frågan "vilken version ska visas?" på fyra ställen:
+-- besökarens sida, adminens arbetsspråk, ui_text-packet, och härnäst
+-- e-postmallen som väljs åt en mottagare. Var och en hade börjat odla sin egen
+-- stavning av samma stege — vilket är hur tre implementationer blir tre
+-- beteenden.
+--
+-- Stegen, en gång:
+--   1. exakt tagg          'sv-SE' svarar på 'sv-SE'
+--   2. samma språk         'sv' svarar på 'sv-SE', och 'en-GB' svarar på 'en'
+--   3. sajtens standard    det operatören deklarerat
+--   4. ingenting           anroparen avgör vad en frånvaro betyder
+--
+-- Steg 4 är avsiktligt. En sida utan version i det önskade språket får INTE
+-- tyst bli ett annat språk; en sträng utan översättning ska falla till
+-- engelskan i koden. Det är olika svar på samma frånvaro, så funktionen
+-- rapporterar den i stället för att välja.
+--
+-- Tvillingen bor i src/lib/pick-locale.ts. Ändras den ena ska den andra ändras
+-- — de delade fallen är pinnade i pick-locale.guardrails.test.ts.
+CREATE OR REPLACE FUNCTION public.pick_locale(
+  p_available text[],
+  p_wanted    text DEFAULT NULL,
+  p_fallback  text DEFAULT NULL
+) RETURNS text
+LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+  v_candidate text;
+  v_tag text;
+  v_hit text;
+BEGIN
+  IF p_available IS NULL OR array_length(p_available, 1) IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  FOREACH v_candidate IN ARRAY ARRAY[p_wanted, p_fallback] LOOP
+    v_tag := lower(trim(coalesce(v_candidate, '')));
+    CONTINUE WHEN v_tag = '';
+
+    -- 1. Exakt tagg.
+    SELECT a INTO v_hit FROM unnest(p_available) AS a
+     WHERE lower(trim(a)) = v_tag LIMIT 1;
+    IF v_hit IS NOT NULL THEN RETURN v_hit; END IF;
+
+    -- 2. Samma språk. Den MINST specifika stavningen vinner, så en sajt med
+    --    både 'en' och 'en-GB' svarar på 'en' med 'en'.
+    SELECT a INTO v_hit FROM unnest(p_available) AS a
+     WHERE split_part(lower(trim(a)), '-', 1) = split_part(v_tag, '-', 1)
+     ORDER BY length(trim(a)), lower(trim(a)) LIMIT 1;
+    IF v_hit IS NOT NULL THEN RETURN v_hit; END IF;
+  END LOOP;
+
+  RETURN NULL;
+END $$;
+
+COMMENT ON FUNCTION public.pick_locale(text[], text, text) IS
+  'Vilken språkversion som ska användas: exakt tagg → samma språk → sajtens '
+  'standard → NULL. Returnerar aldrig en gissning. Tvilling till '
+  'src/lib/pick-locale.ts.';
+
+GRANT EXECUTE ON FUNCTION public.pick_locale(text[], text, text) TO authenticated, service_role, anon;
+
+-- ── Stegen bevisas där den körs ────────────────────────────────────────────
+-- Tvillingen i TypeScript pinnas av pick-locale.guardrails.test.ts. Den här
+-- sidan kan inte nås därifrån — ingen CI har en databas — så den bevisar sig
+-- själv vid varje applicering. Samma fall, samma ordning, båda språken.
+DO $$
+DECLARE
+  v_cases jsonb := jsonb_build_array(
+    jsonb_build_array('exact tag',            'sv,en',    'sv',    'en', 'sv'),
+    jsonb_build_array('same language',        'sv,en',    'sv-SE', 'en', 'sv'),
+    jsonb_build_array('en-GB answers en',     'en,sv',    'en-GB', 'sv', 'en'),
+    jsonb_build_array('least specific wins',  'en-GB,en', 'en',    '',   'en'),
+    jsonb_build_array('falls to the default', 'sv,en',    'de',    'en', 'en'),
+    jsonb_build_array('no match is NULL',     'sv',       'de',    'fr', ''),
+    jsonb_build_array('empty list is NULL',   '',         'sv',    'en', '')
+  );
+  c jsonb; v_got text; v_want text;
+BEGIN
+  FOR c IN SELECT * FROM jsonb_array_elements(v_cases) LOOP
+    v_got := public.pick_locale(
+      CASE WHEN c->>1 = '' THEN ARRAY[]::text[] ELSE string_to_array(c->>1, ',') END,
+      nullif(c->>2, ''), nullif(c->>3, ''));
+    v_want := nullif(c->>4, '');
+    IF v_got IS DISTINCT FROM v_want THEN
+      RAISE EXCEPTION 'pick_locale: % — expected %, got %',
+        c->>0, coalesce(v_want, 'NULL'), coalesce(v_got, 'NULL');
+    END IF;
+  END LOOP;
+  RAISE NOTICE 'pick_locale: % ladder case(s) hold', jsonb_array_length(v_cases);
+END $$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260903070000",
-      "migrations_count": 556,
+      "migration_head": "20260903090000",
+      "migrations_count": 557,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2229,6 +2229,10 @@
         {
           "version": "20260903070000",
           "name": "lagg-till-ett-sprak-fa-sajten-kopierad"
+        },
+        {
+          "version": "20260903090000",
+          "name": "en-stege-for-sprakval"
         }
       ]
     },


### PR DESCRIPTION
FlowWink svarar nu på *"vilken version ska visas?"* på fyra ställen: besökarens sida, adminens arbetsspråk, `ui_text`-packet, och härnäst e-postmallen som väljs åt en mottagare. Var och en hade börjat odla **sin egen stavning av samma stege** — vilket är hur tre implementationer blir tre beteenden.

## Stegen, en gång
1. **exakt tagg** — `sv-SE` svarar på `sv-SE`
2. **samma språk** — `sv` svarar på `sv-SE`, `en-GB` svarar på `en`
3. **sajtens standard**
4. **ingenting** — anroparen avgör vad en frånvaro betyder

Steg 4 är varför det är en *funktion* och inte en policy: en sida utan version i språket får **inte** tyst bli ett annat språk (adminlistan visar vad som finns, märkt som sådant), medan en sträng utan översättning **ska** falla till engelskan i koden. Olika svar på samma frånvaro.

- `pickLocale()` — `src/lib/pick-locale.ts`
- `public.pick_locale(available[], wanted, fallback)` — samma stege, serversidan
- Sidgrupperingen, navets syskonuppslag och `ui_text`-resolvern kopplade till den, annars vore den bara teoretisk

## Två implementationer, ett beteende
Halva systemet svarar i webbläsaren och halva i databasen, så två implementationer är oundvikligt. Två *beteenden* är det inte. Samma falltabell pinnar båda: ett guardrail-test för TypeScript, och ett `DO`-block i migreringen som bevisar SQL-sidan **vid varje applicering** — ingen CI har en databas.

## Konventionen nedskriven
`docs/architecture/language.md`: fyra lager med fyra ägare (produktens gränssnitt = engelska alltid; besökarens skal = `ui_text` med `@<locale>`-overlays; innehåll = `locale` + `translation_group_id`; format = `platform_locale`, som inte är språk).

Och exakt vad **e-postmallarna** ska göra i stället för att uppfinna en femte regel: `locale` med `(name, locale)` som nyckel, mottagarens språk ur `partner_language`, val via `pick_locale`, och Law 4 så mailet aldrig uteblir för att en översättning saknas.

Dokumentet säger också vad som medvetet **inte** finns: ingen meddelandekatalog för admin-UI:t (den tunga halvan av i18n som vi inte behöver), ingen automatisk språkdetektering, och ingen språkmedveten bloggarkivlänk.

tsc / 3586 tester / forward-dating / doc-drift gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)