### PR TITLE
fix(blog): ratten som lovade en adress den inte kunde ge, och tre defaults för ett ord

### DIFF
--- a/src/components/admin/blog/BlogSettingsTab.tsx
+++ b/src/components/admin/blog/BlogSettingsTab.tsx
@@ -59,8 +59,7 @@ export default function BlogSettingsTab() {
               <div className="space-y-0.5"><Label>Enable Blog</Label><p className="text-sm text-muted-foreground">Show blog in public navigation</p></div>
               <Switch checked={localSettings.enabled} onCheckedChange={(checked) => updateField('enabled', checked)} />
             </div>
-            <div className="space-y-2"><Label htmlFor="archiveTitle">Archive Title</Label><Input id="archiveTitle" value={localSettings.archiveTitle} onChange={(e) => updateField('archiveTitle', e.target.value)} placeholder="Blogg" /></div>
-            <div className="space-y-2"><Label htmlFor="archiveSlug">Archive URL Slug</Label><Input id="archiveSlug" value={localSettings.archiveSlug} onChange={(e) => updateField('archiveSlug', e.target.value)} placeholder="blog" /><p className="text-xs text-muted-foreground">Blog will be accessible at /{localSettings.archiveSlug}</p></div>
+            <div className="space-y-2"><Label htmlFor="archiveTitle">Archive Title</Label><Input id="archiveTitle" value={localSettings.archiveTitle} onChange={(e) => updateField('archiveTitle', e.target.value)} placeholder="Blog" /></div>
             <div className="space-y-2"><Label htmlFor="postsPerPage">Posts Per Page</Label><Input id="postsPerPage" type="number" min={1} max={50} value={localSettings.postsPerPage} onChange={(e) => updateField('postsPerPage', parseInt(e.target.value) || 10)} /></div>
           </CardContent>
         </Card>

--- a/src/components/public/PublicNavigation.tsx
+++ b/src/components/public/PublicNavigation.tsx
@@ -541,8 +541,8 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
             {/* Blog link */}
             {blogModuleEnabled && blogSettings?.enabled && (
               <Link
-                to={`/${blogSettings.archiveSlug || 'blog'}`}
-                className={getLinkClasses(location.pathname.startsWith(`/${blogSettings.archiveSlug || 'blog'}`))}
+                to={'/blog'}
+                className={getLinkClasses(location.pathname.startsWith('/blog'))}
               >
                 {blogSettings.archiveTitle || 'Blog'}
               </Link>
@@ -602,12 +602,12 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
               ))}
               {blogModuleEnabled && blogSettings?.enabled && (
                 <Link
-                  to={`/${blogSettings.archiveSlug || 'blog'}`}
+                  to={'/blog'}
                   onClick={() => setMobileMenuOpen(false)}
                   className={cn(
                     'px-4 py-3 rounded-md text-base font-medium transition-colors',
                     'hover:bg-muted',
-                    location.pathname.startsWith(`/${blogSettings.archiveSlug || 'blog'}`)
+                    location.pathname.startsWith('/blog')
                       ? 'bg-primary/10 text-primary'
                       : 'text-muted-foreground'
                   )}
@@ -669,11 +669,11 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
               ))}
               {blogModuleEnabled && blogSettings?.enabled && (
                 <Link
-                  to={`/${blogSettings.archiveSlug || 'blog'}`}
+                  to={'/blog'}
                   onClick={() => setMobileMenuOpen(false)}
                   className={cn(
                     'text-2xl font-medium transition-colors',
-                    location.pathname.startsWith(`/${blogSettings.archiveSlug || 'blog'}`)
+                    location.pathname.startsWith('/blog')
                       ? 'text-primary'
                       : 'text-muted-foreground hover:text-foreground'
                   )}
@@ -731,12 +731,12 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
               ))}
               {blogModuleEnabled && blogSettings?.enabled && (
                 <Link
-                  to={`/${blogSettings.archiveSlug || 'blog'}`}
+                  to={'/blog'}
                   onClick={() => setMobileMenuOpen(false)}
                   className={cn(
                     'px-4 py-3 rounded-md text-base font-medium transition-colors',
                     'hover:bg-muted',
-                    location.pathname.startsWith(`/${blogSettings.archiveSlug || 'blog'}`)
+                    location.pathname.startsWith('/blog')
                       ? 'bg-primary/10 text-primary'
                       : 'text-muted-foreground'
                   )}

--- a/src/hooks/useSiteSettings.tsx
+++ b/src/hooks/useSiteSettings.tsx
@@ -707,7 +707,11 @@ const defaultBlogSettings: BlogSettings = {
   showAuthorBio: true,
   showReadingTime: true,
   showReviewer: false,
-  archiveTitle: 'Blogg',
+  // English, like every other default in the product. 'Blogg' sat here for
+  // months and was the reason an English page showed a Swedish menu item —
+  // nobody had chosen it, it was simply what the code fell back to. A Swedish
+  // site sets its own word; the product does not assume a country.
+  archiveTitle: 'Blog',
   archiveSlug: 'blog',
   rssEnabled: true,
   rssTitle: 'RSS Feed',

--- a/src/lib/__tests__/one-default-per-setting.guardrails.test.ts
+++ b/src/lib/__tests__/one-default-per-setting.guardrails.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../../..');
+const HOOKS = readFileSync(resolve(ROOT, 'src/hooks/useSiteSettings.tsx'), 'utf8');
+const RESET = readFileSync(resolve(ROOT, 'src/components/admin/ResetSiteDialog.tsx'), 'utf8');
+const BLOG_TAB = readFileSync(resolve(ROOT, 'src/components/admin/blog/BlogSettingsTab.tsx'), 'utf8');
+
+/**
+ * Ett defaultvärde per inställning.
+ *
+ * `blog.archiveTitle` hade TRE: kodfallbacken sa 'Blogg', reset-seeden 'Blog'
+ * och adminfältets platshållare 'Blogg'. Vilket en instans fick berodde på om
+ * raden råkade finnas — och eftersom ingen livesajt hade någon blog-rad alls
+ * körde alla på fallbacken. Det var därför Optics ENGELSKA sida visade
+ * "Blogg" i menyn: ingen hade valt ordet, det var bara vad koden föll tillbaka
+ * på.
+ *
+ * Klassen är inte "svenska i en engelsk produkt" — det är att samma fråga har
+ * flera svar på olika ställen, vilket gör beteendet beroende av vilken väg
+ * instansen råkade ta.
+ */
+describe('ett defaultvärde per inställning', () => {
+  const codeFallback = HOOKS.match(/archiveTitle:\s*'([^']*)'/)?.[1];
+  const resetSeed = RESET.match(/archiveTitle:\s*'([^']*)'/)?.[1];
+  const placeholder = BLOG_TAB.match(/id="archiveTitle"[\s\S]*?placeholder="([^"]*)"/)?.[1];
+
+  it('alla tre källorna finns kvar att jämföra', () => {
+    expect(codeFallback, 'kodfallbacken hittades inte').toBeTruthy();
+    expect(resetSeed, 'reset-seeden hittades inte').toBeTruthy();
+    expect(placeholder, 'platshållaren hittades inte').toBeTruthy();
+  });
+
+  it('kodfallback och reset-seed säger samma sak om archiveTitle', () => {
+    expect(codeFallback).toBe(resetSeed);
+  });
+
+  it('adminfältets platshållare lovar samma default som koden ger', () => {
+    // En platshållare är ett löfte om vad som händer om man lämnar fältet tomt.
+    expect(placeholder).toBe(codeFallback);
+  });
+
+  it('navet läser ingen slug som rutterna inte känner till', () => {
+    // archiveSlug byggde menylänken medan rutterna var hårdkodade /blog — den
+    // som skrev något i fältet fick en meny som pekade på en 404.
+    const NAV = readFileSync(resolve(ROOT, 'src/components/public/PublicNavigation.tsx'), 'utf8');
+    expect(NAV).not.toContain('archiveSlug');
+  });
+});


### PR DESCRIPTION
Två fel, samma klass: **en fråga med flera svar**, beroende på vilken väg instansen råkade ta.

## 1. En ratt som pekade på en 404
`archiveSlug` byggde **menylänken** medan rutterna i `App.tsx` är hårdkodade `/blog`. Den som skrev "nyheter" i fältet fick en meny som pekade på en 404 — medan texten under fältet lovade *"Blog will be accessible at /nyheter"*.

Jag lutade först åt att låta rutterna läsa slugen. **Mätningen ändrade det:** ingen av instanserna har ens en `blog`-inställningsrad, och `/blog/`-prefixet är hårdkodat på sex ställen inklusive canonical-URL:er och KB-korslänkar. Att flytta det är ett eget spår, inte en fix — och att lämna kvar en ratt som 404:ar är sämre än att inte ha den.

Fältet borttaget; navet läser `/blog`.

## 2. Tre defaultvärden för ett ord
`blog.archiveTitle` hade tre: kodfallbacken `'Blogg'`, reset-seeden `'Blog'`, adminfältets platshållare `'Blogg'`. Eftersom **ingen livesajt hade någon `blog`-rad** körde alla på fallbacken — och det var därför Optics **engelska** sida visade "Blogg" i menyn. Ingen hade valt ordet.

Alla tre säger `'Blog'` nu. En svensk sajt sätter sitt eget ord; produkten antar inget land.

## Grind
Kodfallback, reset-seed och platshållare måste säga **samma sak** — en platshållare är ett löfte om vad som händer om man lämnar fältet tomt. Och navet får inte läsa en slug som rutterna inte känner till.

Muterat: `'Blogg'` tillbaka i fallbacken fäller två tester.

tsc / 3591 tester gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)