### PR TITLE
feat(blog): bloggänkens etikett följer språket

### DIFF
--- a/docs/architecture/language.md
+++ b/docs/architecture/language.md
@@ -148,6 +148,9 @@ declaration and the fallback discipline are already built and already shared.
   ladder for a visitor is: explicit URL → the page's own language → the site
   default. Adding browser detection means deciding what happens to crawlers and
   to an explicit choice, and that is a separate decision.
-- **No language-aware blog archive.** The archive link comes from blog settings,
-  not from a page, so it sits outside the translation groups. Its label and
-  destination stay in the site's own language.
+- **The blog archive has no translated address.** Its LABEL now follows the
+  language (`nav.blog` in the pack, with the operator's `archiveTitle` acting as
+  the base layer for the site's own language — see `blog-link-label.ts`), but
+  the destination stays `/blog`. The prefix is hardcoded in six places
+  including canonical URLs and KB cross-links; moving it is its own piece of
+  work, not a setting. The setting that pretended otherwise was removed.

--- a/src/components/public/PublicNavigation.tsx
+++ b/src/components/public/PublicNavigation.tsx
@@ -12,9 +12,10 @@ import { CartIndicator } from './CartIndicator';
 import { AccountIndicator } from './AccountIndicator';
 import { LanguageSwitcher, type PageTranslation } from './LanguageSwitcher';
 import { pickLocale } from '@/lib/pick-locale';
+import { blogLinkLabel } from '@/lib/blog-link-label';
 import { SandboxBanner } from '@/components/SandboxBanner';
 import { useHeaderBlock, defaultHeaderData } from '@/hooks/useGlobalBlocks';
-import { useBlogSettings, useStoreSettings, useCustomerPortalSettings } from '@/hooks/useSiteSettings';
+import { useBlogSettings, useStoreSettings, useCustomerPortalSettings, useSiteLanguages } from '@/hooks/useSiteSettings';
 import { useIsModuleEnabled } from '@/hooks/useModules';
 import type { HeaderNavItem } from '@/types/cms';
 
@@ -69,6 +70,7 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
   
   // Blog settings
   const { data: blogSettings } = useBlogSettings();
+  const { defaultLanguage: siteDefaultLanguage } = useSiteLanguages();
 
   // Close mega menu when clicking outside
   useEffect(() => {
@@ -113,6 +115,18 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
     window.addEventListener('resize', set);
     return () => { window.removeEventListener('resize', set); root.style.removeProperty('--overlay-header-offset'); };
   }, [headerIsOverlay]);
+
+  // ── Bloggänkens etikett ────────────────────────────────────────────────
+  // archiveTitle är operatörens ord för SITT EGET språk — samma roll som det
+  // platta baslagret i ui_text-packet. På en sida i ett annat språk får det
+  // därför inte vara fallbacken, annars står "Blogg" kvar i en engelsk meny.
+  // Där svarar packets overlay, och annars kodens engelska.
+  const blogLabel = blogLinkLabel(
+    blogSettings?.archiveTitle,
+    t('nav.blog', 'Blog'),
+    currentLocale,
+    siteDefaultLanguage,
+  );
 
   // ── Navigationen följer besökarens språk ───────────────────────────────
   // Utan det här landar en engelsk besökare som klickar "Tjänster" på den
@@ -544,7 +558,7 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
                 to={'/blog'}
                 className={getLinkClasses(location.pathname.startsWith('/blog'))}
               >
-                {blogSettings.archiveTitle || 'Blog'}
+                {blogLabel}
               </Link>
             )}
             {/* Custom nav items - with mega menu support */}
@@ -612,7 +626,7 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
                       : 'text-muted-foreground'
                   )}
                 >
-                  {blogSettings.archiveTitle || 'Blog'}
+                  {blogLabel}
                 </Link>
               )}
               {customNavItems.map((item) => (
@@ -678,7 +692,7 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
                       : 'text-muted-foreground hover:text-foreground'
                   )}
                 >
-                  {blogSettings.archiveTitle || 'Blog'}
+                  {blogLabel}
                 </Link>
               )}
               {customNavItems.map((item) => (
@@ -741,7 +755,7 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
                       : 'text-muted-foreground'
                   )}
                 >
-                  {blogSettings.archiveTitle || 'Blog'}
+                  {blogLabel}
                 </Link>
               )}
               {customNavItems.map((item) => (

--- a/src/data/ui-text-catalog.json
+++ b/src/data/ui-text-catalog.json
@@ -196,6 +196,11 @@
       "fallback": "Change language"
     },
     {
+      "key": "nav.blog",
+      "group": "nav",
+      "fallback": "Blog"
+    },
+    {
       "key": "nav.closeMenu",
       "group": "nav",
       "fallback": "Close menu"

--- a/src/lib/__tests__/blog-link-label.guardrails.test.ts
+++ b/src/lib/__tests__/blog-link-label.guardrails.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { blogLinkLabel } from '../blog-link-label';
+
+/**
+ * Bloggänkens etikett — precedensen som varit fel två gånger.
+ *
+ * Först stod "Blogg" som kodens fallback, så varje sajt visade svenska utan att
+ * någon valt det. Sedan, när den blev 'Blog', var operatörens archiveTitle
+ * fortfarande fallback på ALLA språk — vilket hade satt tillbaka "Blogg" i en
+ * engelsk meny. archiveTitle är operatörens ord för sitt EGET språk.
+ */
+describe('bloggänkens etikett', () => {
+  it('operatörens ord vinner på sajtens eget språk', () => {
+    expect(blogLinkLabel('Blogg', 'Blog', 'sv', 'sv')).toBe('Blogg');
+    expect(blogLinkLabel('Blogg', 'Blog', 'sv-SE', 'sv')).toBe('Blogg');
+  });
+
+  it('en sida utan eget språk räknas som sajtens', () => {
+    expect(blogLinkLabel('Blogg', 'Blog', null, 'sv')).toBe('Blogg');
+  });
+
+  it('på ett ANNAT språk gäller packet — aldrig operatörens ord', () => {
+    // Kärnan. Utan det här står "Blogg" kvar i en engelsk meny.
+    expect(blogLinkLabel('Blogg', 'Blog', 'en', 'sv')).toBe('Blog');
+    expect(blogLinkLabel('Blogg', 'Nyheter', 'de', 'sv')).toBe('Nyheter');
+  });
+
+  it('utan operatörsord faller det tillbaka på packet', () => {
+    expect(blogLinkLabel(null, 'Blog', 'sv', 'sv')).toBe('Blog');
+    expect(blogLinkLabel('   ', 'Blog', 'sv', 'sv')).toBe('Blog');
+  });
+});

--- a/src/lib/blog-link-label.ts
+++ b/src/lib/blog-link-label.ts
@@ -1,0 +1,32 @@
+import { baseSubtag } from './pick-locale';
+
+/**
+ * What the blog link in the menu says.
+ *
+ * Three values compete, and the order has been wrong twice:
+ *
+ *   archiveTitle   the operator's own word, from blog settings
+ *   packLabel      ui_text — the base layer or a @<locale> overlay
+ *   'Blog'         the English in the code, carried by the t() call site
+ *
+ * `archiveTitle` is the operator's word for THEIR OWN language — exactly the
+ * role the flat base layer plays in the ui_text pack. So on a page in another
+ * language it must not win, or an English menu keeps saying "Blogg" (which is
+ * what happened: the code's fallback was the Swedish string, and no live site
+ * had ever set the value).
+ *
+ * On a page in the site's own language the operator's word beats the pack: they
+ * named their blog, and a generic entry should not override that.
+ */
+export function blogLinkLabel(
+  archiveTitle: string | null | undefined,
+  packLabel: string,
+  currentLocale: string | null | undefined,
+  siteLanguage: string,
+): string {
+  const inSiteLanguage = !currentLocale
+    || baseSubtag(currentLocale) === baseSubtag(siteLanguage);
+  if (!inSiteLanguage) return packLabel;
+  const own = String(archiveTitle ?? '').trim();
+  return own || packLabel;
+}


### PR DESCRIPTION
Sista enspråkiga posten i menyn. Etiketten går nu genom `ui_text` (`nav.blog`), så en `@en`-overlay ger "Blog" på engelska sidor medan svenska sidor behåller operatörens ord.

## Precedensen är det som varit fel två gånger
| | |
|---|---|
| `archiveTitle` | operatörens ord, ur blogginställningarna |
| `packLabel` | `ui_text` — baslagret eller en `@<locale>`-overlay |
| `'Blog'` | engelskan vid anropsplatsen |

`archiveTitle` är operatörens ord för **sitt eget** språk — exakt den roll det platta baslagret spelar i packet. På en sida i ett annat språk får det därför inte vinna, annars står "Blogg" kvar i en engelsk meny. På sajtens eget språk slår det packet: de har döpt sin blogg, och en generisk post ska inte köra över det.

Regeln är utbruten som ren funktion (`blog-link-label.ts`) just för att den varit fel förut.

## En detalj som avgjorde formen
`t('nav.blog', 'Blog')` står kvar **i komponenten** med sin litteral, så katalog-generatorn ser nyckeln och den dyker upp i besökartext-editorn (53 nycklar nu). Hade jag flyttat in anropet i hjälparen hade nyckeln blivit osynlig där — en död nyckel som ingen kunde översätta.

| | |
|---|---|
| Operatörens ord på sajtens språk | ✓ |
| Packet på ett annat språk, aldrig operatörens ord | ✓ |
| Sida utan eget språk räknas som sajtens | ✓ |
| Mutation: fallbacken gjord språkoberoende | fäller |
| tsc / 3595 tester / doc-drift | gröna |

🤖 Generated with [Claude Code](https://claude.com/claude-code)