### PR TITLE
feat(seo): hreflang — översättningarna blir synliga för sökmotorerna

### DIFF
--- a/docs/architecture/language.md
+++ b/docs/architecture/language.md
@@ -54,7 +54,10 @@ Any table holding translatable *documents* gets two columns:
 - **One row per language per group.** Enforced in `manage_page_translation`.
 - **Each language keeps its own address.** That is the whole reason to store it
   as separate rows rather than `{sv, en}` fields: one URL per language is what
-  lets a search engine index both and `hreflang` work at all.
+  lets a search engine index both and `hreflang` work at all. The declaration
+  itself lives in `src/lib/hreflang.ts` — every version lists every version
+  including itself, the hrefs are absolute, and `x-default` points at the site's
+  default language rather than at whichever version came first.
 - **A new row is born in the site's default language** (`pages_default_locale`
   trigger). Do not put a literal default on the column — `pages.locale` once
   defaulted to `'en'`, which asserted English about every page on every

--- a/src/components/public/SeoHead.tsx
+++ b/src/components/public/SeoHead.tsx
@@ -25,6 +25,8 @@ interface SeoHeadProps {
    * Omitted, it falls back to the instance's platform locale — see below.
    */
   lang?: string;
+  /** <link rel="alternate" hreflang> — the other language versions of this page. */
+  alternates?: Array<{ hreflang: string; href: string }>;
   keywords?: string[];
   // New props for structured data
   pageType?: 'page' | 'article' | 'kb-article';
@@ -223,6 +225,7 @@ export function SeoHead({
   noIndex = false,
   noFollow = false,
   lang,
+  alternates,
   keywords,
   pageType = 'page',
   contentBlocks = [],
@@ -382,6 +385,14 @@ export function SeoHead({
 
       {/* Canonical */}
       {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+
+      {/* Language versions. Publishing a translation without declaring it is
+          most of the way to wasting it — a search engine that cannot see that
+          two URLs are the same page in two languages picks one and may treat
+          the other as duplicate content in the wrong market. */}
+      {(alternates ?? []).map((alt) => (
+        <link key={alt.hreflang} rel="alternate" hrefLang={alt.hreflang} href={alt.href} />
+      ))}
 
       {/* Performance hints */}
       {performanceSettings?.prefetchLinks && (

--- a/src/lib/__tests__/hreflang.guardrails.test.ts
+++ b/src/lib/__tests__/hreflang.guardrails.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { buildHreflangAlternates } from '../hreflang';
+
+const BASE = 'https://optictunnels.se';
+const PAIR = [
+  { slug: 'home', locale: 'sv' },
+  { slug: 'home-en', locale: 'en' },
+];
+
+/**
+ * hreflang är hela utdelningen av att lagra en sida per språk.
+ *
+ * Utan deklarationen väljer sökmotorn EN av versionerna och kan behandla den
+ * andra som dubblettinnehåll på fel marknad — översättningen är publicerad men
+ * osynlig. Tre regler går tyst fel, och alla tre pinnas här.
+ */
+describe('hreflang', () => {
+  it('en enspråkig sida deklarerar INGENTING — inte en uppsättning om ett', () => {
+    expect(buildHreflangAlternates({
+      translations: [{ slug: 'about', locale: 'sv' }],
+      baseUrl: BASE, homepageSlug: 'home', defaultLanguage: 'sv',
+    })).toEqual([]);
+  });
+
+  it('varje version listas, den nuvarande INKLUDERAD', () => {
+    // Självreferensen är kravet som oftast missas: en uppsättning som utelämnar
+    // sidan man står på ignoreras i sin helhet.
+    const alts = buildHreflangAlternates({
+      translations: PAIR, baseUrl: BASE, homepageSlug: 'ingen', defaultLanguage: 'sv',
+    });
+    expect(alts.filter((a) => a.hreflang !== 'x-default')).toEqual([
+      { hreflang: 'sv', href: `${BASE}/home` },
+      { hreflang: 'en', href: `${BASE}/home-en` },
+    ]);
+  });
+
+  it('adresserna är absoluta — relativa hedras inte', () => {
+    const alts = buildHreflangAlternates({
+      translations: PAIR, baseUrl: BASE, homepageSlug: 'home', defaultLanguage: 'sv',
+    });
+    for (const alt of alts) expect(alt.href.startsWith('https://')).toBe(true);
+  });
+
+  it('startsidan får den bara origin, inte /home', () => {
+    const alts = buildHreflangAlternates({
+      translations: PAIR, baseUrl: BASE, homepageSlug: 'home', defaultLanguage: 'sv',
+    });
+    expect(alts.find((a) => a.hreflang === 'sv')?.href).toBe(`${BASE}/`);
+    expect(alts.find((a) => a.hreflang === 'en')?.href).toBe(`${BASE}/home-en`);
+  });
+
+  it('x-default pekar på SAJTENS språk, inte på den första i listan', () => {
+    const alts = buildHreflangAlternates({
+      translations: PAIR, baseUrl: BASE, homepageSlug: 'ingen', defaultLanguage: 'en',
+    });
+    expect(alts.find((a) => a.hreflang === 'x-default')?.href).toBe(`${BASE}/home-en`);
+  });
+
+  it('x-default matchar även på grundtaggen', () => {
+    const alts = buildHreflangAlternates({
+      translations: PAIR, baseUrl: BASE, homepageSlug: 'ingen', defaultLanguage: 'sv-SE',
+    });
+    expect(alts.find((a) => a.hreflang === 'x-default')?.href).toBe(`${BASE}/home`);
+  });
+
+  it('utan version i sajtens språk utelämnas x-default hellre än gissas', () => {
+    const alts = buildHreflangAlternates({
+      translations: PAIR, baseUrl: BASE, homepageSlug: 'ingen', defaultLanguage: 'de',
+    });
+    expect(alts.some((a) => a.hreflang === 'x-default')).toBe(false);
+    expect(alts).toHaveLength(2);
+  });
+
+  it('en trailing slash i basadressen ger inte dubbla snedstreck', () => {
+    const alts = buildHreflangAlternates({
+      translations: PAIR, baseUrl: `${BASE}/`, homepageSlug: 'ingen', defaultLanguage: 'sv',
+    });
+    expect(alts[0].href).toBe(`${BASE}/home`);
+  });
+
+  it('halva rader ignoreras i stället för att bli trasiga länkar', () => {
+    expect(buildHreflangAlternates({
+      translations: [{ slug: 'home', locale: 'sv' }, { slug: '', locale: 'en' }],
+      baseUrl: BASE, homepageSlug: 'ingen', defaultLanguage: 'sv',
+    })).toEqual([]);
+  });
+});

--- a/src/lib/hreflang.ts
+++ b/src/lib/hreflang.ts
@@ -1,0 +1,76 @@
+import { baseSubtag } from './pick-locale';
+
+export interface TranslatedPage {
+  slug: string;
+  locale: string;
+}
+
+export interface HreflangAlternate {
+  hreflang: string;
+  href: string;
+}
+
+export interface BuildHreflangInput {
+  /** Every PUBLISHED language version of this page, including the current one. */
+  translations: TranslatedPage[];
+  /** Origin without a trailing slash, e.g. https://optictunnels.se */
+  baseUrl: string;
+  /** The slug served at "/" — its alternate must be the bare origin. */
+  homepageSlug: string;
+  /** The site's declared default language, which x-default points at. */
+  defaultLanguage: string;
+}
+
+/**
+ * The `<link rel="alternate" hreflang>` set for a translated page.
+ *
+ * Publishing a translation and not declaring it is most of the way to wasting
+ * it: a search engine that cannot see that /priser and /pricing are the same
+ * page in two languages will pick one, and may treat the other as duplicate
+ * content in the wrong market. That is the whole reason FlowWink stores a page
+ * per language instead of two strings in one row — this is where the reason
+ * pays off.
+ *
+ * Three rules that are easy to get silently wrong:
+ *
+ *   1. SELF-REFERENCE. Every version must list every version, itself included.
+ *      A set that omits the current page is ignored.
+ *   2. ABSOLUTE URLs. Relative hrefs are not honoured.
+ *   3. x-default. Points at the version a visitor with no better match should
+ *      get — the site's default language, not "the first one".
+ *
+ * Returns an empty array when there is nothing to declare, so a single-language
+ * site emits no tags at all rather than a set of one.
+ */
+export function buildHreflangAlternates({
+  translations,
+  baseUrl,
+  homepageSlug,
+  defaultLanguage,
+}: BuildHreflangInput): HreflangAlternate[] {
+  const origin = String(baseUrl ?? '').replace(/\/+$/, '');
+  const usable = (translations ?? []).filter((t) => t?.slug && t?.locale);
+  // One version is not a set of alternates — it is just the page.
+  if (!origin || usable.length < 2) return [];
+
+  const href = (slug: string) => (slug === homepageSlug ? `${origin}/` : `${origin}/${slug}`);
+
+  const alternates: HreflangAlternate[] = usable.map((t) => ({
+    hreflang: t.locale.toLowerCase(),
+    href: href(t.slug),
+  }));
+
+  const wanted = baseSubtag(defaultLanguage);
+  const fallbackVersion =
+    usable.find((t) => t.locale.toLowerCase() === String(defaultLanguage ?? '').toLowerCase())
+    ?? usable.find((t) => baseSubtag(t.locale) === wanted);
+
+  // No version in the site's own language means we cannot say which one a
+  // stranger should get, and guessing would send the wrong market to the wrong
+  // page. Better to declare the pairs and let the engine choose.
+  if (fallbackVersion) {
+    alternates.push({ hreflang: 'x-default', href: href(fallbackVersion.slug) });
+  }
+
+  return alternates;
+}

--- a/src/pages/PublicPage.tsx
+++ b/src/pages/PublicPage.tsx
@@ -1,5 +1,7 @@
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { useUiText, useSetUiTextLang } from '@/lib/ui-text';
+import { buildHreflangAlternates } from '@/lib/hreflang';
+import { useSiteLanguages } from '@/hooks/useSiteSettings';
 import { logger } from '@/lib/logger';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
@@ -264,6 +266,7 @@ export default function PublicPage() {
   // Chrome follows content. Without this the visitor reads an English page
   // wrapped in Swedish buttons — the half-translated site the ui_text pack was
   // built to avoid in the first place.
+  const { defaultLanguage: siteDefaultLanguage } = useSiteLanguages();
   const setUiTextLang = useSetUiTextLang();
   useEffect(() => { setUiTextLang(declaredLang); }, [declaredLang, setUiTextLang]);
   const { data: translations } = useQuery({
@@ -432,6 +435,16 @@ export default function PublicPage() {
   // Build canonical URL
   const baseUrl = window.location.origin;
   const canonicalUrl = `${baseUrl}/${pageSlug === homepageSlug ? '' : pageSlug}`;
+
+  // Språkversionerna deklareras för sökmotorerna. `translations` innehåller
+  // sidan själv, vilket krävs — en uppsättning som utelämnar den nuvarande
+  // sidan ignoreras.
+  const alternates = buildHreflangAlternates({
+    translations: (translations ?? []).map((t) => ({ slug: t.slug, locale: t.locale })),
+    baseUrl,
+    homepageSlug,
+    defaultLanguage: siteDefaultLanguage,
+  });
   
   // Build breadcrumbs for structured data
   const breadcrumbs = [
@@ -454,6 +467,7 @@ export default function PublicPage() {
         contentBlocks={pageData.content_json}
         breadcrumbs={breadcrumbs}
         lang={declaredLang ?? undefined}
+        alternates={alternates}
       />
       <HeadScripts />
       <BodyScripts position="start" />


### PR DESCRIPTION
Optic har sju publicerade språkpar sedan i går, och **ingen sökmotor kan se att de hör ihop**. Utan deklarationen väljer motorn en version och kan behandla den andra som dubblettinnehåll på fel marknad — översättningen är publicerad men osynlig.

Det är hela utdelningen av att lagra en sida per språk i stället för två strängar i en rad, och den låg outtagen.

## Tre regler som går tyst fel
1. **Självreferens.** Varje version måste lista varje version, sig själv inkluderad. En uppsättning som utelämnar den nuvarande sidan ignoreras *i sin helhet*.
2. **Absoluta adresser.** Relativa hedras inte.
3. **`x-default` pekar på sajtens språk**, inte på den första i listan.

Saknas en version i sajtens språk **utelämnas** `x-default` hellre än gissas: att skicka fel marknad till fel sida är värre än att låta motorn välja.

## Detaljer som är lätta att missa
- Startsidan deklareras som bara origin, inte `/home`
- En enspråkig sida sänder **ingenting** — en uppsättning om ett är inte alternativ, det är bara sidan
- Endast **publicerade** syskon deklareras; `get_page_translations` returnerar redan bara dem, så ett utkast kan inte läcka ut
- En trailing slash i basadressen ger inte dubbla snedstreck

## Verifierat
| | |
|---|---|
| 9 tester på den rena funktionen | gröna |
| Mutation: självreferensen borttagen | fäller 4 |
| Mutation: `x-default` tar första bästa | fäller 2 |
| tsc / 3604 tester / doc-drift | gröna |

Verifieras skarpt på optictunnels.se när deployen landar — de sju paren finns redan publicerade där.

🤖 Generated with [Claude Code](https://claude.com/claude-code)