### PR TITLE
fix(seo): x-default pekade på fel marknad — språkdeklarationen var osynlig för besökaren

### DIFF
--- a/src/hooks/useSiteSettings.tsx
+++ b/src/hooks/useSiteSettings.tsx
@@ -669,6 +669,19 @@ export function useSiteLanguages() {
     languages: enabled.map((l) => l.toLowerCase()),
     /** True when the site publishes in more than one language. */
     isMultilingual: enabled.length > 1,
+    /**
+     * Whether the site has actually DECLARED its languages, or we are looking
+     * at the fallback.
+     *
+     * The two are not the same answer and one caller must tell them apart:
+     * hreflang's `x-default` names the version a stranger should get, and
+     * naming the wrong one sends the wrong market to the wrong page. On
+     * optictunnels.se the fallback pointed x-default at the ENGLISH page of a
+     * Swedish site, because the row was unreadable to anonymous visitors and
+     * the query answered with zero rows rather than an error. A guess that
+     * looks like knowledge is the whole problem.
+     */
+    isDeclared: !!query.data,
   };
 }
 

--- a/src/pages/PublicPage.tsx
+++ b/src/pages/PublicPage.tsx
@@ -266,7 +266,7 @@ export default function PublicPage() {
   // Chrome follows content. Without this the visitor reads an English page
   // wrapped in Swedish buttons — the half-translated site the ui_text pack was
   // built to avoid in the first place.
-  const { defaultLanguage: siteDefaultLanguage } = useSiteLanguages();
+  const { defaultLanguage: siteDefaultLanguage, isDeclared: siteLanguageIsDeclared } = useSiteLanguages();
   const setUiTextLang = useSetUiTextLang();
   useEffect(() => { setUiTextLang(declaredLang); }, [declaredLang, setUiTextLang]);
   const { data: translations } = useQuery({
@@ -443,7 +443,9 @@ export default function PublicPage() {
     translations: (translations ?? []).map((t) => ({ slug: t.slug, locale: t.locale })),
     baseUrl,
     homepageSlug,
-    defaultLanguage: siteDefaultLanguage,
+    // Utan en DEKLARATION vet vi inte vilket språk en främling ska få, och då
+    // utelämnas x-default hellre än att peka åt ett håll vi gissat.
+    defaultLanguage: siteLanguageIsDeclared ? siteDefaultLanguage : '',
   });
   
   // Build breadcrumbs for structured data

--- a/supabase/migrations/20260903130000_sprakdeklarationen-hor-till-skyltfonstret.sql
+++ b/supabase/migrations/20260903130000_sprakdeklarationen-hor-till-skyltfonstret.sql
@@ -1,0 +1,64 @@
+-- Språkdeklarationen hör till skyltfönstret.
+--
+-- `site_languages` infördes i går som sanningen om vilka språk sajten publicerar
+-- i och vilket en besökare får. Sedan lästes den av tre publika ytor — <html
+-- lang>, hreflang-uppsättningen och ui_text-packets baslagerregel — utan att
+-- någon kollade om en ANONYM besökare kommer åt raden.
+--
+-- Det gör den inte. Nyckelknippan (20260823120000) är avsiktligt fail closed:
+-- en nyckel som inte står i listan är osynlig för anon, just så att nästa
+-- utvecklare inte råkar publicera en hemlighet genom att skriva en rad. Den
+-- disciplinen fungerade precis som den skulle — den fångade mig.
+--
+-- Symptomet var tyst och exakt så illa som en tyst sak brukar vara: på
+-- optictunnels.se pekade `x-default` på den ENGELSKA sidan trots att sajtens
+-- deklarerade standard är svenska. Hooken föll till sin inbyggda fallback
+-- ('en') eftersom frågan gav noll rader, inte fel. Ingen varning, inget i
+-- konsolen — bara fel marknad utpekad för sökmotorerna på en sajt som ska
+-- lanseras.
+--
+-- site_languages innehåller inga hemligheter: två språkkoder och en lista.
+-- Samma klass som platform_locale, som redan står i listan.
+DO $$
+DECLARE v_keys text[];
+BEGIN
+  SELECT array_agg(DISTINCT k ORDER BY k) INTO v_keys FROM (
+    SELECT unnest(ARRAY[
+      'aeo','blog','branding','chat','cookie_banner','cookie_consent_v2',
+      'custom_scripts','customer_portal','demo_mode','general','maintenance',
+      'modules','performance','platform_locale','quotes','sandbox_mode',
+      'seo','store','ui_text','site_languages'
+    ]) AS k
+  ) s;
+
+  DROP POLICY IF EXISTS "Public site config is readable" ON public.site_settings;
+  EXECUTE format(
+    'CREATE POLICY "Public site config is readable" ON public.site_settings '
+    'FOR SELECT TO public USING (key = ANY (%L))', v_keys);
+
+  RAISE NOTICE 'site_settings: % public keys', array_length(v_keys, 1);
+END $$;
+
+-- ── Bevisas där den körs ───────────────────────────────────────────────────
+-- Utan det här är den här migreringen bara ett påstående. Med den kan den inte
+-- appliceras på en instans där den inte håller.
+DO $$
+DECLARE v_visible boolean; v_secret boolean;
+BEGIN
+  PERFORM public.ensure_site_languages();
+
+  SET LOCAL ROLE anon;
+  SELECT EXISTS (SELECT 1 FROM public.site_settings WHERE key = 'site_languages') INTO v_visible;
+  -- Fail closed måste fortfarande gälla: en nyckel utanför listan får inte ha
+  -- blivit synlig på köpet.
+  SELECT EXISTS (SELECT 1 FROM public.site_settings WHERE key = 'integrations') INTO v_secret;
+  RESET ROLE;
+
+  IF NOT v_visible THEN
+    RAISE EXCEPTION 'site_languages is still invisible to anon — the public site cannot read its own languages';
+  END IF;
+  IF v_secret THEN
+    RAISE EXCEPTION 'the allowlist leaked: anon can now read "integrations", which is not public config';
+  END IF;
+  RAISE NOTICE 'anon sees site_languages, and still not integrations';
+END $$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260903110000",
-      "migrations_count": 558,
+      "migration_head": "20260903130000",
+      "migrations_count": 559,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2237,6 +2237,10 @@
         {
           "version": "20260903110000",
           "name": "mallen-far-ett-sprak"
+        },
+        {
+          "version": "20260903130000",
+          "name": "sprakdeklarationen-hor-till-skyltfonstret"
         }
       ]
     },


### PR DESCRIPTION
hreflang gick live på optictunnels.se och pekade `x-default` på den **engelska** sidan, trots att sajtens deklarerade standard är svenska. Fel marknad utpekad för sökmotorerna, på en sajt som ska lanseras.

## Orsaken
`site_languages` infördes i går som sanningen om sajtens språk, och lästes sedan av **tre publika ytor** — `<html lang>`, hreflang-uppsättningen och `ui_text`-packets baslagerregel — utan att någon kollade om en **anonym besökare** kommer åt raden.

Det gör den inte. Nyckelknippan (`20260823120000`) är avsiktligt *fail closed*: en nyckel som inte står i listan är osynlig för anon, just så att nästa utvecklare inte råkar publicera en hemlighet genom att skriva en rad. Den disciplinen fungerade precis som den skulle — **den fångade mig**.

## Två fel, inte ett
**1. Nyckeln saknades i listan.** Tillagd. `site_languages` innehåller två språkkoder och en lista — samma klass som `platform_locale`, som redan stod där. Migreringen **bevisar sig där den körs**: anon ser `site_languages`, och ser fortfarande **inte** `integrations`.

**2. Hooken gissade tyst.** Frågan gav noll rader, inte fel, så den föll till sin inbyggda `'en'` — och gissningen såg ut som kunskap. `useSiteLanguages` skiljer nu på **deklaration** och **fallback**, och utan deklaration **utelämnas** `x-default` hellre än att peka åt ett håll vi hittat på.

Det andra felet är det viktigare: RLS-hålet var en rad, men en fallback som inte går att skilja från ett svar hade producerat samma tysta fel igen på nästa instans som saknar raden.

## Vad felsökningen kostade, och varför
Dev-servern lurade mig **två gånger**: Helmet applicerar inte i dev men gör det i produktionsbygget. Jag bisekterade till och med mot en commit jag verifierat **live** samma morgon och drog fel slutsats av att den var tyst lokalt. Och två gånger mätte jag för tidigt — Helmet hade inte spolat efter 8 sekunder.

Det som till slut avgjorde var att bygga produktionsbygget lokalt och fråga Optics egen sida vad den ser med sina egna ögon.

| | |
|---|---|
| Migreringen | anon ser `site_languages`, inte `integrations` |
| Negativtest: nyckeln ur listan | migreringen vägrar |
| Idempotent | ✓ |
| tsc / 3604 tester / forward-dating | gröna |

🤖 Generated with [Claude Code](https://claude.com/claude-code)