### PR TITLE
feat(seo): sitemapen parar ihop språkversionerna

### DIFF
--- a/src/lib/__tests__/sitemap-alternates.guardrails.test.ts
+++ b/src/lib/__tests__/sitemap-alternates.guardrails.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { sitemapAlternates } from '../../../supabase/functions/_shared/sitemap-alternates.ts';
+
+const href = (slug: string) => (slug === 'home' ? 'https://x.se' : `https://x.se/${slug}`);
+const PAIR = [
+  { slug: 'product', locale: 'sv', translation_group_id: 'g1' },
+  { slug: 'product-en', locale: 'en', translation_group_id: 'g1' },
+];
+
+/**
+ * Sitemapen är den ENDA kanal en sökmotor läser utan att köra JavaScript:
+ * hreflang i huvudet kommer från react-helmet, och den här instansens
+ * prerender körs bara för SOCIALA crawlers. Utan detta ser Google fjorton
+ * orelaterade adresser, varav hälften liknar dubblettinnehåll på fel marknad.
+ */
+describe('sitemapens språkalternativ', () => {
+  it('en sida utan syskon får inga alternativ', () => {
+    const m = sitemapAlternates({
+      pages: [{ slug: 'villkor', locale: 'sv', translation_group_id: null }],
+      defaultLanguage: 'sv', href,
+    });
+    expect(m.size).toBe(0);
+  });
+
+  it('en ensam sida i en grupp räknas inte som en uppsättning', () => {
+    const m = sitemapAlternates({
+      pages: [{ slug: 'a', locale: 'sv', translation_group_id: 'g' }],
+      defaultLanguage: 'sv', href,
+    });
+    expect(m.size).toBe(0);
+  });
+
+  it('båda versionerna får SAMMA uppsättning, sig själva inkluderade', () => {
+    const m = sitemapAlternates({ pages: PAIR, defaultLanguage: 'sv', href });
+    const sv = m.get('product')!;
+    const en = m.get('product-en')!;
+    expect(sv).toEqual(en);
+    expect(sv.filter((a) => a.hreflang !== 'x-default')).toEqual([
+      { hreflang: 'sv', href: 'https://x.se/product' },
+      { hreflang: 'en', href: 'https://x.se/product-en' },
+    ]);
+  });
+
+  it('x-default pekar på sajtens språk', () => {
+    const m = sitemapAlternates({ pages: PAIR, defaultLanguage: 'sv-SE', href });
+    expect(m.get('product')!.find((a) => a.hreflang === 'x-default')?.href)
+      .toBe('https://x.se/product');
+  });
+
+  it('utan deklarerat språk utelämnas x-default hellre än gissas', () => {
+    const m = sitemapAlternates({ pages: PAIR, defaultLanguage: '', href });
+    expect(m.get('product')!.some((a) => a.hreflang === 'x-default')).toBe(false);
+  });
+
+  it('startsidan får bara origin — samma href-funktion som <loc>', () => {
+    const m = sitemapAlternates({
+      pages: [
+        { slug: 'home', locale: 'sv', translation_group_id: 'g' },
+        { slug: 'home-en', locale: 'en', translation_group_id: 'g' },
+      ],
+      defaultLanguage: 'sv', href,
+    });
+    expect(m.get('home')!.find((a) => a.hreflang === 'sv')?.href).toBe('https://x.se');
+  });
+
+  it('en sida utan locale hoppas över i stället för att bli hreflang=""', () => {
+    const m = sitemapAlternates({
+      pages: [
+        { slug: 'a', locale: 'sv', translation_group_id: 'g' },
+        { slug: 'b', locale: null, translation_group_id: 'g' },
+      ],
+      defaultLanguage: 'sv', href,
+    });
+    expect(m.size).toBe(0);
+  });
+});

--- a/supabase/functions/_shared/sitemap-alternates.ts
+++ b/supabase/functions/_shared/sitemap-alternates.ts
@@ -1,0 +1,78 @@
+/**
+ * Language alternates for the sitemap.
+ *
+ * The `<link rel="alternate" hreflang>` tags in the page head are emitted by
+ * react-helmet, which means a crawler only sees them after executing
+ * JavaScript. Google does that, but in a second pass — and this instance's
+ * prerender path (`api/og.ts`) runs only for SOCIAL crawlers, so there is no
+ * server-rendered head for a search engine at all.
+ *
+ * The sitemap is the channel that needs no JavaScript. Optic publishes seven
+ * language pairs and the sitemap listed all fourteen URLs with nothing to say
+ * that they belong together — fourteen unrelated pages, two of which look like
+ * duplicate content in the wrong market.
+ *
+ * The rules mirror src/lib/hreflang.ts, and for the same reasons:
+ *   * every version lists every version, itself included
+ *   * absolute URLs
+ *   * x-default points at the site's default language, and is OMITTED rather
+ *     than guessed when no version is written in it
+ *
+ * A page with no siblings gets no alternates at all — a set of one is not a set.
+ */
+export interface SitemapPage {
+  slug: string;
+  locale?: string | null;
+  translation_group_id?: string | null;
+}
+
+/** 'sv-SE' → 'sv' */
+function baseSubtag(tag: string): string {
+  return String(tag ?? '').trim().toLowerCase().split('-')[0];
+}
+
+export interface AlternatesInput {
+  pages: SitemapPage[];
+  /** The site's declared default language, or '' when it has not declared one. */
+  defaultLanguage: string;
+  /** Builds the absolute URL for a slug — shared with the <loc> so they agree. */
+  href: (slug: string) => string;
+}
+
+/**
+ * @returns slug → the alternates to nest inside that page's <url> entry.
+ *   A slug missing from the map has none.
+ */
+export function sitemapAlternates(
+  { pages, defaultLanguage, href }: AlternatesInput,
+): Map<string, Array<{ hreflang: string; href: string }>> {
+  const groups = new Map<string, SitemapPage[]>();
+  for (const page of pages ?? []) {
+    const group = page?.translation_group_id;
+    if (!group || !page.slug || !page.locale) continue;
+    if (!groups.has(group)) groups.set(group, []);
+    groups.get(group)!.push(page);
+  }
+
+  const out = new Map<string, Array<{ hreflang: string; href: string }>>();
+  const wanted = baseSubtag(defaultLanguage);
+
+  for (const siblings of groups.values()) {
+    if (siblings.length < 2) continue;
+
+    const alternates = siblings.map((s) => ({
+      hreflang: String(s.locale).toLowerCase(),
+      href: href(s.slug),
+    }));
+
+    const fallback = wanted
+      ? (siblings.find((s) => String(s.locale).toLowerCase() === String(defaultLanguage).toLowerCase())
+        ?? siblings.find((s) => baseSubtag(String(s.locale)) === wanted))
+      : undefined;
+    if (fallback) alternates.push({ hreflang: 'x-default', href: href(fallback.slug) });
+
+    for (const sibling of siblings) out.set(sibling.slug, alternates);
+  }
+
+  return out;
+}

--- a/supabase/functions/sitemap/index.ts
+++ b/supabase/functions/sitemap/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { sitemapAlternates, type SitemapPage } from '../_shared/sitemap-alternates.ts';
 import { getServiceClient } from '../_shared/supabase-clients.ts';
 
 /**
@@ -33,7 +34,7 @@ Deno.serve(async (req) => {
     // Fetch published pages
     const { data: pages } = await supabase
       .from('pages')
-      .select('slug, updated_at')
+      .select('slug, updated_at, locale, translation_group_id')
       .eq('status', 'published')
       .order('updated_at', { ascending: false });
 
@@ -44,18 +45,43 @@ Deno.serve(async (req) => {
       .eq('status', 'published')
       .order('updated_at', { ascending: false });
 
+    // Which language a stranger should get. The sitemap is the only channel a
+    // search engine reads without executing JavaScript — the hreflang tags in
+    // the head come from react-helmet, and this instance's prerender runs for
+    // SOCIAL crawlers only.
+    const { data: langRow, error: langErr } = await supabase
+      .from('site_settings').select('value').eq('key', 'site_languages').maybeSingle();
+    // Utan deklarationen utelämnas x-default — sitemapen ska ändå byggas, men
+    // tystnaden får inte se ut som ett svar.
+    if (langErr) console.warn('[sitemap] site_languages unreadable, omitting x-default:', langErr.message);
+    const siteDefaultLanguage = String(
+      (langRow?.value as { default?: string } | null)?.default ?? '',
+    ).toLowerCase();
+
+    // The SAME function that builds <loc>, so an alternate can never point
+    // somewhere the sitemap does not also list.
+    const pageHref = (slug: string) => (slug === 'home' ? baseUrl : `${baseUrl}/${slug}`);
+    const alternates = sitemapAlternates({
+      pages: (pages || []) as SitemapPage[],
+      defaultLanguage: siteDefaultLanguage,
+      href: pageHref,
+    });
+
     // Build XML
     const entries: string[] = [];
 
     // Pages
     for (const page of pages || []) {
-      const loc = page.slug === 'home' ? baseUrl : `${baseUrl}/${page.slug}`;
+      const loc = pageHref(page.slug);
       const lastmod = page.updated_at ? new Date(page.updated_at).toISOString().split('T')[0] : '';
+      const langLinks = (alternates.get(page.slug) ?? [])
+        .map((a) => `\n    <xhtml:link rel="alternate" hreflang="${escapeXml(a.hreflang)}" href="${escapeXml(a.href)}"/>`)
+        .join('');
       entries.push(`  <url>
     <loc>${escapeXml(loc)}</loc>
     ${lastmod ? `<lastmod>${lastmod}</lastmod>` : ''}
     <changefreq>weekly</changefreq>
-    <priority>${page.slug === 'home' ? '1.0' : '0.8'}</priority>
+    <priority>${page.slug === 'home' ? '1.0' : '0.8'}</priority>${langLinks}
   </url>`);
     }
 
@@ -72,7 +98,7 @@ Deno.serve(async (req) => {
     }
 
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 ${entries.join('\n')}
 </urlset>`;
 
@@ -85,7 +111,7 @@ ${entries.join('\n')}
     });
   } catch (err: any) {
     console.error('[sitemap] Error:', err);
-    return new Response(`<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>`, {
+    return new Response(`<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml"></urlset>`, {
       headers: { 'Content-Type': 'application/xml; charset=utf-8' },
     });
   }

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2251,7 +2251,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:74e85295e8dee0668e3a1dd901c3c33507f03120bd32a754a939844d5ba17f7d",
+      "shared_hash": "sha256:3be3a1a95cd7511901011a011e70d5d6b188ece40c0e7e19a14276bd5d577433",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
@@ -2316,7 +2316,7 @@
         "setup-database": "sha256:49f03dc85ea4d48cd53b7760b0a68f4e2a628a217207b0fe4590d931f594e56e",
         "signal-dispatcher": "sha256:a76e992430f13d05003a0e00ba622c239006fc853531400d88a1f238310c90dc",
         "signal-ingest": "sha256:b7bf9c636845229394e12d2cec9b78da6657b3a321775f65063e53794eb0ea3d",
-        "sitemap": "sha256:57bfd001304645f70cd359850af19f88d6960918f2dbe5795c8dda40f733daf1",
+        "sitemap": "sha256:cd836c71f091df075e0ddc1dd49d2334e7ad876a654f0e95e6ee563c0313e69a",
         "stripe-webhook": "sha256:7be2d24d1a70818815e6aa829d6f7b1ed83877172a2f8ed50c98af98ae180072",
         "subscription-billing-cron": "sha256:d3a4089951cbc82379b1f667b1d5b98503961e4364ab811617b4c5d5a6036663",
         "subscriptions": "sha256:d3ac2a631b793a4507315d92f144c69a3697ffc6a0186b6bbc3d7cda05a46a33",


### PR DESCRIPTION
Magnus klistrade in `index.html` och den avslöjade något jag inte visste: prerender-vägen (`api/og.ts`) körs **bara för sociala crawlers** — Facebook, LinkedIn, Slack, Discord. **Googlebot står inte i listan.** Den får `index.html` och måste köra JavaScript för att se hreflang-taggarna som react-helmet sätter.

Det fungerar, men i andra hand. Kanalen en sökmotor läser **utan JavaScript** är sitemapen — och Optics listade fjorton adresser utan ett ord om att `/product` och `/product-en` är samma sida på två språk.

## Vad som ändras
`<xhtml:link rel="alternate" hreflang>` i varje `<url>` för sidor i en översättningsgrupp, med samma regler som `src/lib/hreflang.ts`:

- alla versioner listar alla, **sig själva inkluderade**
- absoluta adresser
- `x-default` på sajtens språk, och **utelämnad** när ingen version är skriven i det

Två detaljer som gör det svårt att göra fel:
- Alternativen byggs med **samma `href`-funktion som `<loc>`**, så en alternativlänk kan aldrig peka någonstans sitemapen inte också listar.
- En sida utan syskon får inga alternativ. En uppsättning om ett är ingen uppsättning.

## Grinden tog mig igen
Förbudet mot svalda fel fångade min nya `site_settings`-läsning — tredje gången idag. Bunden och loggad: utan deklarationen utelämnas `x-default`, men tystnaden får inte se ut som ett svar.

| | |
|---|---|
| 7 tester på den rena funktionen | gröna |
| Mutation: bara första syskonet får uppsättningen | fäller |
| tsc / 3611 tester | gröna |

**Kräver edge-deploy av `sitemap` per instans** för att synas live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)