### PR TITLE
fix(footer): copyright-raden var hårdkodad engelska

### DIFF
--- a/src/components/public/PublicFooter.tsx
+++ b/src/components/public/PublicFooter.tsx
@@ -52,6 +52,16 @@ export function PublicFooter() {
   const brandTagline = branding?.brandTagline || '';
   const brandInitial = brandName.charAt(0);
 
+  // Copyright-raden stod hårdkodad på engelska under varje sida på varje
+  // instans — inklusive de svenska. Samma klass som <html lang="en">: en
+  // engelsk mening som ingen valt, bara ärvt. Platshållarna följer idiomet
+  // från chat.live.* så en översättare kan flytta dem: "Alla rättigheter
+  // förbehållna © {year} {brand}." är en giltig översättning.
+  const copyright = t('footer.copyright', '© {year} {brand}. All rights reserved.')
+    .replace('{year}', String(new Date().getFullYear()))
+    .replace('{brand}', brandName);
+
+
   // Determine which sections to show based on variant
   const showBrand = settings?.showBrand !== false;
   const showQuickLinks = variant !== 'minimal' && settings?.showQuickLinks !== false && pages.length > 0;
@@ -237,7 +247,7 @@ export function PublicFooter() {
         {/* Bottom bar */}
         <div className={`border-t border-primary-foreground/20 ${variant === 'minimal' ? 'mt-6 pt-4' : 'mt-10 pt-6'} flex flex-col md:flex-row justify-between items-center gap-4`}>
           <p className="text-sm text-primary-foreground/60">
-            © {new Date().getFullYear()} {brandName}. All rights reserved.
+            {copyright}
           </p>
           
           {/* Social Media Links */}

--- a/src/data/ui-text-catalog.json
+++ b/src/data/ui-text-catalog.json
@@ -166,6 +166,11 @@
       "fallback": "Contact"
     },
     {
+      "key": "footer.copyright",
+      "group": "footer",
+      "fallback": "© {year} {brand}. All rights reserved."
+    },
+    {
       "key": "footer.hours",
       "group": "footer",
       "fallback": "Opening Hours"


### PR DESCRIPTION
`© 2026 Optic Tunnels. All rights reserved.` stod som literal i `PublicFooter` under varje sida på varje instans — inklusive de fyra svenska. Samma klass som `<html lang="en">` och `'Blogg'`-defaulten: **en mening som ingen valt, bara ärvt.**

Går nu genom `ui_text` som `footer.copyright`.

## Platshållarna kan flyttas
`{year}` och `{brand}` följer idiomet från `chat.live.*`, så en översättare kan sätta dem var som helst i meningen:

> `Alla rättigheter förbehållna © {year} {brand}.`

Det hade inte gått med årtal och namn hopfogade i koden — och det är skillnaden mellan en översättbar sträng och en som bara går att översätta ordagrant.

Katalogen är uppe i **54 nycklar**; den nya dyker upp i besökartext-editorn.

tsc / hela sviten gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)