### PR TITLE
feat(i18n): underhållssidan och footerns kända länkar följer språket

### DIFF
--- a/docs/architecture/language.md
+++ b/docs/architecture/language.md
@@ -102,6 +102,19 @@ sites — the stored pack only holds what someone already translated, so an edit
 built on it could never show the untranslated keys, which are exactly the ones
 still showing English on a Swedish site.
 
+Two rules the generator imposes on the code:
+
+- **`t()` takes literals.** A key hidden behind a helper or a variable is
+  invisible to the generator, which means invisible in the editor — a
+  translatable string nobody can find. This has caught me three times.
+- **A setting that competes with the pack goes through `operatorText`.** Several
+  settings predate the language layer and hold ONE value: the blog's archive
+  title, the cookie banner's copy, the maintenance message, the known footer
+  legal links. The operator wrote them for THEIR language, so they act as the
+  base layer — they win for the site's own language and lose to the pack on any
+  other. Writing `settings.title || 'English'` bypasses that and puts Swedish on
+  an English page; `operator-text-adoption.guardrails.test.ts` refuses it.
+
 ## 4. The ladder, once
 
 Both halves of the system answer *"which version?"* the same way:
@@ -153,7 +166,7 @@ declaration and the fallback discipline are already built and already shared.
   to an explicit choice, and that is a separate decision.
 - **The blog archive has no translated address.** Its LABEL now follows the
   language (`nav.blog` in the pack, with the operator's `archiveTitle` acting as
-  the base layer for the site's own language — see `blog-link-label.ts`), but
+  the base layer for the site's own language — see `operator-text.ts`), but
   the destination stays `/blog`. The prefix is hardcoded in six places
   including canonical URLs and KB cross-links; moving it is its own piece of
   work, not a setting. The setting that pretended otherwise was removed.

--- a/src/components/public/PublicFooter.tsx
+++ b/src/components/public/PublicFooter.tsx
@@ -2,7 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Link } from 'react-router-dom';
 import { Phone, Mail, MapPin, Clock, Facebook, Instagram, Linkedin, Twitter, Youtube, Shield } from 'lucide-react';
-import { useUiText } from '@/lib/ui-text';
+import { useUiText, useUiTextLanguage } from '@/lib/ui-text';
+import { operatorText } from '@/lib/operator-text';
 import { useFooterBlock, defaultFooterData } from '@/hooks/useGlobalBlocks';
 import { useBranding } from '@/providers/BrandingProvider';
 import { useTheme } from 'next-themes';
@@ -44,6 +45,17 @@ export function PublicFooter() {
      medveten AV-ratt: rubriken och dess rad renderas inte alls — adressen
      kan stå för sig själv. (t() returnerar '' eftersom ?? bara hoppar
      null/undefined; det är avsiktligt och dokumenterat här.) */
+  /* Footerns JURIDISKA länkar. Produkten skickar två kända id:n; en länk
+     operatören själv lagt till har ett genererat id och behåller sin etikett —
+     den ärliga gränsen, för det finns ingen nyckel att översätta den under.
+     t() anropas med literaler: en nyckel bakom en variabel blir osynlig i
+     besökartext-editorn. */
+  const { lang, siteLang } = useUiTextLanguage();
+  const legalPack: Record<string, string> = {
+    privacy: t('footer.legal.privacy', 'Privacy Policy'),
+    accessibility: t('footer.legal.accessibility', 'Accessibility'),
+  };
+
   const quickLinksHeading = t('footer.quickLinks', 'Quick Links');
   const contactHeading = t('footer.contact', 'Contact');
   const hoursHeading = t('footer.hours', 'Opening Hours');
@@ -319,7 +331,7 @@ export function PublicFooter() {
                   to={link.url}
                   className="hover:text-primary-foreground transition-colors"
                 >
-                  {link.label}
+                  {operatorText(link.label, legalPack[link.id] ?? link.label, lang, siteLang)}
                 </Link>
               ))}
             </div>

--- a/src/components/public/PublicNavigation.tsx
+++ b/src/components/public/PublicNavigation.tsx
@@ -12,7 +12,7 @@ import { CartIndicator } from './CartIndicator';
 import { AccountIndicator } from './AccountIndicator';
 import { LanguageSwitcher, type PageTranslation } from './LanguageSwitcher';
 import { pickLocale } from '@/lib/pick-locale';
-import { blogLinkLabel } from '@/lib/operator-text';
+import { operatorText } from '@/lib/operator-text';
 import { SandboxBanner } from '@/components/SandboxBanner';
 import { useHeaderBlock, defaultHeaderData } from '@/hooks/useGlobalBlocks';
 import { useBlogSettings, useStoreSettings, useCustomerPortalSettings, useSiteLanguages } from '@/hooks/useSiteSettings';
@@ -121,7 +121,7 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
   // platta baslagret i ui_text-packet. På en sida i ett annat språk får det
   // därför inte vara fallbacken, annars står "Blogg" kvar i en engelsk meny.
   // Där svarar packets overlay, och annars kodens engelska.
-  const blogLabel = blogLinkLabel(
+  const blogLabel = operatorText(
     blogSettings?.archiveTitle,
     t('nav.blog', 'Blog'),
     currentLocale,

--- a/src/data/ui-text-catalog.json
+++ b/src/data/ui-text-catalog.json
@@ -216,6 +216,16 @@
       "fallback": "Opening Hours"
     },
     {
+      "key": "footer.legal.accessibility",
+      "group": "footer",
+      "fallback": "Accessibility"
+    },
+    {
+      "key": "footer.legal.privacy",
+      "group": "footer",
+      "fallback": "Privacy Policy"
+    },
+    {
       "key": "footer.quickLinks",
       "group": "footer",
       "fallback": "Quick Links"
@@ -239,6 +249,26 @@
       "key": "language.switch",
       "group": "language",
       "fallback": "Change language"
+    },
+    {
+      "key": "maintenance.adminSignIn",
+      "group": "maintenance",
+      "fallback": "Sign in (administrators)"
+    },
+    {
+      "key": "maintenance.expectedEnd",
+      "group": "maintenance",
+      "fallback": "Expected end time"
+    },
+    {
+      "key": "maintenance.message",
+      "group": "maintenance",
+      "fallback": "We are performing scheduled maintenance. The website will be available again shortly."
+    },
+    {
+      "key": "maintenance.title",
+      "group": "maintenance",
+      "fallback": "Website is under maintenance"
     },
     {
       "key": "nav.blog",

--- a/src/lib/__tests__/operator-text-adoption.guardrails.test.ts
+++ b/src/lib/__tests__/operator-text-adoption.guardrails.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../../..');
+const read = (p: string) => readFileSync(resolve(ROOT, 'src', p), 'utf8');
+
+/**
+ * Regeln räcker inte — den måste ANVÄNDAS.
+ *
+ * `operatorText` avgör vems ord som gäller när en operatörsinställning möter
+ * textpacket: operatörens ord för sajtens EGET språk, packet för de andra.
+ * Regeln är testad i operator-text.guardrails.test.ts. Men en anropsplats som
+ * skriver `settings.title || 'English'` går förbi den, och då är felet tillbaka
+ * — svensk text på en engelsk sida, tyst.
+ *
+ * Det har hänt två gånger (menyns "Blogg", cookie-bannerns svenska hälsning),
+ * så adoptionen ratchetas här i stället för att vara frivillig. Listan är
+ * ytorna där en operatörsägd sträng möter en besökare; växer den, växer listan.
+ */
+const CONSUMERS: Array<{ file: string; fields: string[] }> = [
+  { file: 'components/public/CookieBanner.tsx', fields: ['own.title', 'own.acceptAll', 'own.essentialOnly'] },
+  { file: 'components/public/PublicNavigation.tsx', fields: ['blogSettings?.archiveTitle'] },
+  { file: 'components/public/PublicFooter.tsx', fields: ['link.label'] },
+  { file: 'pages/PublicPage.tsx', fields: ['maintenanceSettings.title', 'maintenanceSettings.message'] },
+];
+
+describe('operatorText används där en operatörssträng möter en besökare', () => {
+  for (const { file, fields } of CONSUMERS) {
+    const src = read(file);
+
+    it(`${file} importerar regeln`, () => {
+      expect(src, 'ytan har operatörsägd text men går inte genom regeln').toContain('operatorText');
+    });
+
+    for (const field of fields) {
+      it(`${file}: ${field} går genom operatorText`, () => {
+        // Fältet måste vara FÖRSTA argumentet. Radbrytning är formatering, inte
+        // betydelse — grinden får inte fällas av en prettier-körning.
+        const passes = new RegExp(
+          `operatorText\\(\\s*${field.replace(/[.?*+^$[\]\\(){}|]/g, '\\$&')}\\s*,`,
+        );
+        expect(
+          passes.test(src),
+          `${field} passerar regeln — annars visas operatörens språk på sidor i ett annat språk`,
+        ).toBe(true);
+      });
+
+      it(`${file}: ${field} OR:as inte direkt med en literal`, () => {
+        // `x || 'English'` är exakt förbiledningen regeln finns för.
+        const bypass = new RegExp(`${field.replace(/[.?*+^$[\]\\(){}|]/g, '\\$&')}\\s*\\|\\|\\s*['"\`]`);
+        expect(bypass.test(src), `${field} kringgår regeln med ||`).toBe(false);
+      });
+    }
+  }
+});

--- a/src/lib/__tests__/operator-text.guardrails.test.ts
+++ b/src/lib/__tests__/operator-text.guardrails.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { blogLinkLabel } from '../operator-text';
+import { operatorText } from '../operator-text';
 
 /**
  * Bloggänkens etikett — precedensen som varit fel två gånger.
@@ -11,22 +11,22 @@ import { blogLinkLabel } from '../operator-text';
  */
 describe('bloggänkens etikett', () => {
   it('operatörens ord vinner på sajtens eget språk', () => {
-    expect(blogLinkLabel('Blogg', 'Blog', 'sv', 'sv')).toBe('Blogg');
-    expect(blogLinkLabel('Blogg', 'Blog', 'sv-SE', 'sv')).toBe('Blogg');
+    expect(operatorText('Blogg', 'Blog', 'sv', 'sv')).toBe('Blogg');
+    expect(operatorText('Blogg', 'Blog', 'sv-SE', 'sv')).toBe('Blogg');
   });
 
   it('en sida utan eget språk räknas som sajtens', () => {
-    expect(blogLinkLabel('Blogg', 'Blog', null, 'sv')).toBe('Blogg');
+    expect(operatorText('Blogg', 'Blog', null, 'sv')).toBe('Blogg');
   });
 
   it('på ett ANNAT språk gäller packet — aldrig operatörens ord', () => {
     // Kärnan. Utan det här står "Blogg" kvar i en engelsk meny.
-    expect(blogLinkLabel('Blogg', 'Blog', 'en', 'sv')).toBe('Blog');
-    expect(blogLinkLabel('Blogg', 'Nyheter', 'de', 'sv')).toBe('Nyheter');
+    expect(operatorText('Blogg', 'Blog', 'en', 'sv')).toBe('Blog');
+    expect(operatorText('Blogg', 'Nyheter', 'de', 'sv')).toBe('Nyheter');
   });
 
   it('utan operatörsord faller det tillbaka på packet', () => {
-    expect(blogLinkLabel(null, 'Blog', 'sv', 'sv')).toBe('Blog');
-    expect(blogLinkLabel('   ', 'Blog', 'sv', 'sv')).toBe('Blog');
+    expect(operatorText(null, 'Blog', 'sv', 'sv')).toBe('Blog');
+    expect(operatorText('   ', 'Blog', 'sv', 'sv')).toBe('Blog');
   });
 });

--- a/src/lib/operator-text.ts
+++ b/src/lib/operator-text.ts
@@ -32,6 +32,3 @@ export function operatorText(
   const chosen = String(own ?? '').trim();
   return chosen || packText;
 }
-
-/** The blog link's label — the first consumer of the rule above. */
-export const blogLinkLabel = operatorText;

--- a/src/pages/PublicPage.tsx
+++ b/src/pages/PublicPage.tsx
@@ -1,6 +1,7 @@
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { useUiText, useSetUiTextLang } from '@/lib/ui-text';
 import { buildHreflangAlternates } from '@/lib/hreflang';
+import { operatorText } from '@/lib/operator-text';
 import { useSiteLanguages } from '@/hooks/useSiteSettings';
 import { logger } from '@/lib/logger';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -345,24 +346,39 @@ export default function PublicPage() {
   if (maintenanceSettings?.enabled && !user) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
-        <SeoHead title={maintenanceSettings.title || 'Maintenance'} noIndex />
+        <SeoHead
+          title={operatorText(
+            maintenanceSettings.title,
+            t('maintenance.title', 'Website is under maintenance'),
+            declaredLang, siteDefaultLanguage,
+          )}
+          noIndex
+        />
         <div className="text-center max-w-md px-6">
           <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-muted mb-6">
             <Wrench className="h-8 w-8 text-muted-foreground" />
           </div>
           <h1 className="font-serif text-3xl font-bold mb-4">
-            {maintenanceSettings.title || 'Website is under maintenance'}
+            {operatorText(
+              maintenanceSettings.title,
+              t('maintenance.title', 'Website is under maintenance'),
+              declaredLang, siteDefaultLanguage,
+            )}
           </h1>
           <p className="text-muted-foreground mb-4">
-            {maintenanceSettings.message || 'We are performing scheduled maintenance. The website will be available again shortly.'}
+            {operatorText(
+              maintenanceSettings.message,
+              t('maintenance.message', 'We are performing scheduled maintenance. The website will be available again shortly.'),
+              declaredLang, siteDefaultLanguage,
+            )}
           </p>
           {maintenanceSettings.expectedEndTime && (
             <p className="text-sm text-muted-foreground mb-8">
-              Expected end time: {formatDateTime(maintenanceSettings.expectedEndTime)}
+              {t('maintenance.expectedEnd', 'Expected end time')}: {formatDateTime(maintenanceSettings.expectedEndTime)}
             </p>
           )}
           <Button variant="outline" onClick={() => navigate('/auth')} size="sm">
-            Sign in (administrators)
+            {t('maintenance.adminSignIn', 'Sign in (administrators)')}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
Två ytor till, samma regel.

**Underhållssidan** är den enda sida en besökare ser när allt annat är nere. Den bar två strängar som inte ens var inställbara — `Expected end time`, `Sign in (administrators)` — plus titel och meddelande som OR:ades med engelska.

**Footerns juridiska länkar:** produkten skickar två kända id:n (`privacy`, `accessibility`) och de får nycklar. En länk operatören själv lagt till har ett **genererat id** — Optics cookiepolicy är en sådan — och behåller sin etikett. Det är den ärliga gränsen: det finns ingen nyckel att översätta den under, och att uppfinna en hade fyllt editorn med nycklar ingen använder.

## Regeln har fått ett namn, och ett enda
`blogLinkLabel`-aliaset är borta. Den heter `operatorText`.

## Adoptionen ratchetas
Regeln var testad — men **anropsplatserna** var det inte. En yta som skriver `settings.title || 'English'` går förbi den och felet är tillbaka, tyst. Samma klass som de frusna blockeditorerna: rälsen finns, adoptionen frivillig.

Grinden hittade **två riktiga missar på första körningen**: navet använde aliaset, och `SeoHead`-titeln på underhållssidan OR:ades fortfarande med engelska.

Och den fällde sig själv en gång på rätt sätt: den kollade formatering i stället för betydelse och föll på ett flerradigt anrop. Den matchar nu första argumentet oavsett radbrytning — en prettier-körning får inte fälla en grind.

| | |
|---|---|
| Katalogen | 68 nycklar i 15 grupper |
| Mutation: `\|\|`-förbiledning i underhållssidan | fäller 2 |
| tsc / 3630 tester / doc-drift | gröna |

🤖 Generated with [Claude Code](https://claude.com/claude-code)