### PR TITLE
fix(pages): "Duplicate" kopierade en tom sida — och menyn dedupar per språkgrupp

### DIFF
--- a/src/components/public/PublicNavigation.tsx
+++ b/src/components/public/PublicNavigation.tsx
@@ -180,13 +180,23 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
 
   // The menu is built from ALREADY localised data, so every renderer below —
   // desktop, mobile, mega-menu — stays exactly as it was.
-  const pages = useMemo(
-    () => sourcePages.map((page) => {
+  const pages = useMemo(() => {
+    const localized = sourcePages.map((page) => {
       const sibling = siblingOf(page.slug);
       return sibling ? { ...page, slug: sibling.slug, title: sibling.title } : page;
-    }),
-    [sourcePages, siblingOf],
-  );
+    });
+    // En översättningsgrupp är EN menypost. show_in_menu frågar inte på språk,
+    // så en operatör som bockar i både /home och /home-en får båda i listan —
+    // och lokaliseringen ovan pekar då om båda till SAMMA syskon. Dubbletten
+    // syns som två identiska poster i besökarens meny. Dedupe på slutadressen
+    // löser båda formerna av felet på en gång.
+    const seen = new Set<string>();
+    return localized.filter((page) => {
+      if (seen.has(page.slug)) return false;
+      seen.add(page.slug);
+      return true;
+    });
+  }, [sourcePages, siblingOf]);
 
   // Custom nav items from header settings
   const customNavItems = useMemo(() => {

--- a/src/pages/admin/PagesListPage.tsx
+++ b/src/pages/admin/PagesListPage.tsx
@@ -43,13 +43,14 @@ import {
 import { StatusBadge } from '@/components/StatusBadge';
 
 import { usePages, useDeletePage, useCreatePage } from '@/hooks/usePages';
+import { supabase } from '@/integrations/supabase/client';
 import { useWorkingLanguage } from '@/hooks/useWorkingLanguage';
 import { pagesInWorkingLanguage } from '@/lib/page-language-grouping';
 import { useAuth } from '@/hooks/useAuth';
 import { useGeneralSettings, useUpdateGeneralSettings } from '@/hooks/useSiteSettings';
 import { Skeleton } from '@/components/ui/skeleton';
 import { toast } from 'sonner';
-import type { PageStatus, Page } from '@/types/cms';
+import type { PageStatus, Page, ContentBlock, PageMeta } from '@/types/cms';
 
 type SortField = 'title' | 'updated_at' | 'status' | 'menu_order';
 type SortDirection = 'asc' | 'desc';
@@ -65,7 +66,7 @@ function PageRow({ page, homepageSlug, isAdmin, onDuplicate, onDelete, onSetHome
   page: Page;
   homepageSlug: string;
   isAdmin: boolean;
-  onDuplicate: (page: { title: string; slug: string }) => void;
+  onDuplicate: (page: { id: string; title: string; slug: string }) => void;
   onDelete: (id: string) => void;
   onSetHomepage: (slug: string) => void;
   onOpenTranslations: (slug: string) => void;
@@ -213,11 +214,31 @@ export default function PagesListPage() {
     });
   }, [pages, search, statusFilter, sortField, sortDirection, workingLang, languages]);
 
-  const handleDuplicate = async (page: { title: string; slug: string }) => {
+  const handleDuplicate = async (page: { id: string; title: string; slug: string }) => {
+    // En kopia är en kopia. Den här skickade bara titel och slug, så
+    // "Duplicate" skapade en TOM sida med "(copy)" i namnet — blocken och
+    // SEO-inställningarna följde aldrig med (Magnus, 2026-08-31, Optic).
+    // Källan hämtas färskt i stället för ur listan: listraden bär inte
+    // content_json, och en färsk läsning kopierar alltid senaste versionen.
+    const { data: source, error } = await supabase
+      .from('pages')
+      .select('content_json, meta_json')
+      .eq('id', page.id)
+      .single();
+    if (error || !source) {
+      toast.error('Could not read the page to copy it.');
+      return;
+    }
     const newSlug = `${page.slug}-copy-${Date.now()}`;
     const result = await createPage.mutateAsync({
       title: `${page.title} (copy)`,
       slug: newSlug,
+      content: (source.content_json ?? []) as unknown as ContentBlock[],
+      meta: (source.meta_json ?? {}) as unknown as Partial<PageMeta>,
+      // En kopia är ett utkast utanför menyn: att duplicera startsidan ska inte
+      // publicera en dubblett av den, och inte heller lägga den i navigationen.
+      status: 'draft',
+      show_in_menu: false,
     });
     navigate(`/admin/pages/${result.id}`);
   };


### PR DESCRIPTION
Två fynd från Magnus arbete på Optic, båda i sidytan.

## 1. Kopian kopierade inte
`handleDuplicate` skickade **bara titel och slug** till `createPage`, så *Duplicate* skapade en tom sida med "(copy)" i namnet — blocken och SEO-inställningarna följde aldrig med. Det bittra: `useCreatePage` kunde ta emot innehållet hela tiden. Dupliceringen skickade det bara aldrig.

- Källan hämtas **färskt** i stället för ur listan — listraden bär inte `content_json`, och en färsk läsning kopierar alltid senaste versionen
- Kopian föds som **utkast utanför menyn**: att duplicera startsidan ska inte publicera en dubblett av den, och inte lägga den i navigationen

## 2. Menyn frågar inte på språk
En operatör som bockar i `show_in_menu` på både `/home` och `/home-en` får båda i listan — och språkväxlingen pekar då om båda till **samma** syskon, så besökaren ser två identiska poster. En översättningsgrupp är **en** menypost; dedupe på slutadressen löser båda formerna av felet på en gång.

## Svar på headerfrågan
Undermenyer **finns redan**: header-inställningarnas `customNavItems` bär `children`, och mega-menyvarianten renderar dem. Och menyposternas etiketter är redan språkberoende — poster som pekar på sidor får syskonets titel automatiskt.

tsc / 3633 tester gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)