### PR TITLE
fix(seo): startsidan är den enda sida crawlers fick fel språk på

### DIFF
--- a/api/og.ts
+++ b/api/og.ts
@@ -89,8 +89,15 @@ export default async function handler(req: Request): Promise<Response> {
         if (post.excerpt) description = post.excerpt;
         if (post.featured_image) image = post.featured_image;
       }
-    } else if (path !== '/') {
-      const slug = encodeURIComponent(decodeURIComponent(path.replace(/^\//, '')));
+    } else {
+      // Startsidan är den mest besökta sidan och den enda som INTE slogs upp —
+      // path '/' hoppade över hela uppslaget, så crawlers fick lang="en" på en
+      // svensk startsida medan varenda undersida var rätt. Roten pekar på en
+      // riktig sidrad via general.homepageSlug, och den raden bär språket.
+      const rawSlug = path === '/'
+        ? String((byKey.general || {}).homepageSlug || 'home')
+        : decodeURIComponent(path.replace(/^\//, ''));
+      const slug = encodeURIComponent(rawSlug);
       const [page] = await pg(
         base,
         key,


### PR DESCRIPTION
Prerendern slog bara upp sidraden när sökvägen inte var `/`. Roten — den mest besökta adressen — hoppade över hela uppslaget, så crawlers fick `lang="en"` på Optics svenska startsida medan **varenda undersida var rätt**.

Verifierat live innan fixen:

```
/            <html lang="en"   ← fel
/product     <html lang="sv"   ← rätt
/product-en  <html lang="en"   ← rätt
```

Roten pekar nu på en riktig sidrad via `general.homepageSlug` (fallback `home`), och den raden bär språket, syskonen och hreflang precis som alla andra.

tsc / 3633 tester gröna. Verifieras live efter deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)