### PR TITLE
feat(email): offerten och avtalet på mallrälsen — affärsmejlen följer mottagaren

### DIFF
--- a/docs/architecture/language.md
+++ b/docs/architecture/language.md
@@ -146,20 +146,24 @@ SQL side **every time it is applied**, because no CI has a database.
 
 ---
 
-## Next: email templates
+## Email templates
 
-`email_templates` is selected by `name` (the kind: `booking_confirmation`,
-`invoice_email`, …). It should adopt §2, not invent anything:
+`email_templates` adopted §2: `locale` on the row, key `(name, locale)` where
+`name` is the KIND (`booking_confirmation`, `quote_email`, `quote_reminder`,
+`contract_email`, `contract_reminder`). `resolve_email_template(name, locale)`
+walks the ladder with the recipient's language from `partner_language()`, with
+one deliberate deviation at step 4: ANY active version rather than nothing — an
+email that does not go out is worse than one in the wrong language, and the
+deviation is logged.
 
-- add `locale`, make the key `(name, locale)`
-- the recipient's language is already known — `partner_language(partner_id)`,
-  since a party carries its own language
-- choose with `pick_locale(available_locales, recipient_language, site_default)`
-- and keep Law 4: a missing translation must fall back to a template that
-  exists, never to no email at all
+Senders wired so far: booking confirmation, quote (+reminder), contract
+(+reminder). The product seeds are English with `locale='en'` EXPLICITLY — the
+insert trigger would otherwise stamp the site's language onto templates that
+are written in English. All language lives in the template text (labels
+included); the sender prerenders only data: item rows, amounts, links.
 
-The reason this is a small step and not a project is that the ladder, the
-declaration and the fallback discipline are already built and already shared.
+Still hardcoded: invoice_email, order_confirmation and the rest of comms-send —
+same recipe when they matter.
 
 ## What is deliberately not here
 

--- a/supabase/functions/comms-send/contract_email.ts
+++ b/supabase/functions/comms-send/contract_email.ts
@@ -56,7 +56,7 @@ export async function handler(req: Request): Promise<Response> {
 
     const { data: contract, error: cErr } = await supabase
       .from('contracts')
-      .select('id, title, contract_number, counterparty_name, counterparty_email, accept_token')
+      .select('id, title, contract_number, counterparty_name, counterparty_email, accept_token, partner_id')
       .eq('id', body.contract_id)
       .single();
     if (cErr || !contract) throw new Error(cErr?.message || 'Contract not found');
@@ -87,14 +87,50 @@ export async function handler(req: Request): Promise<Response> {
       : body.public_url;
     if (!link) throw new Error('No signing link — contract has no token and no public_url given');
 
-    const intro = body.reminder
-      ? 'A reminder to review and sign the agreement below.'
-      : 'Please review and sign the agreement below.';
+    // ── Mallen är sajtinnehåll, på mottagarens språk ─────────────────────
+    // Signeringsbegäran var hårdkodad engelska. Nu: mottagarens språk från
+    // parten, mallen via stegen, gamla HTML:en som Law 4-fallback.
+    let recipientLang: string | null = null;
+    if (contract.partner_id) {
+      const { data: langRow, error: langErr } = await supabase.rpc('partner_language', { p_partner_id: contract.partner_id });
+      if (langErr) console.warn('[contract-email] could not read the recipient language:', langErr.message);
+      recipientLang = (langRow as { lang?: string } | null)?.lang ?? null;
+    }
+    const templateKind = body.reminder ? 'contract_reminder' : 'contract_email';
+    const { data: resolvedTpl, error: tplErr } = await supabase.rpc('resolve_email_template', {
+      p_name: templateKind,
+      p_locale: recipientLang,
+    });
+    if (tplErr) console.warn('[contract-email] template lookup failed — using built-in fallback:', tplErr.message);
+    const tpl = resolvedTpl as { ok?: boolean; html?: string; subject?: string; locale?: string } | null;
+
     const custom = body.custom_message
       ? `<p style="white-space:pre-wrap">${escapeHtml(body.custom_message)}</p>` : '';
 
-    // Fragment — email-send applies the branded shell.
-    const html = `
+    let html: string;
+    let subject: string;
+    if (tpl?.ok && tpl.html) {
+      const vars: Record<string, string> = {
+        contract_title: escapeHtml(contract.title || 'Agreement'),
+        contract_number: escapeHtml(contract.contract_number || ''),
+        site_name: escapeHtml(siteName),
+        cta_url: link,
+        custom_block: custom,
+      };
+      const render = (t: string) => t.replace(/\{\{(\w+)\}\}/g, (_, k) => vars[k] ?? '');
+      html = render(tpl.html);
+      subject = tpl.subject ? render(tpl.subject)
+        : `Agreement ${contract.contract_number} from ${siteName} — ready to sign`;
+      if (recipientLang && tpl.locale && tpl.locale !== recipientLang.toLowerCase()) {
+        console.warn(`[contract-email] no ${recipientLang} template for ${templateKind} — sent the ${tpl.locale} one`);
+      }
+    } else {
+      const intro = body.reminder
+        ? 'A reminder to review and sign the agreement below.'
+        : 'Please review and sign the agreement below.';
+
+      // Fragment — email-send applies the branded shell.
+      html = `
       <h2 style="margin:0 0 12px;font-size:20px;">${escapeHtml(contract.title || 'Agreement')}</h2>
       <p>${intro}</p>
       ${custom}
@@ -107,9 +143,10 @@ export async function handler(req: Request): Promise<Response> {
       <p style="font-size:12px;color:#6b7280;word-break:break-all">Or open this link:<br/>${escapeHtml(link)}</p>
     `;
 
-    const subject = body.reminder
-      ? `Reminder: sign ${contract.contract_number} from ${siteName}`
-      : `Agreement ${contract.contract_number} from ${siteName} — ready to sign`;
+      subject = body.reminder
+        ? `Reminder: sign ${contract.contract_number} from ${siteName}`
+        : `Agreement ${contract.contract_number} from ${siteName} — ready to sign`;
+    }
 
     // expects_reply: a signing request is a conversation, not a receipt — same
     // reasoning as quote_email (Composio → SMTP → Resend).

--- a/supabase/functions/comms-send/quote_email.ts
+++ b/supabase/functions/comms-send/quote_email.ts
@@ -159,19 +159,72 @@ export async function handler(req: Request): Promise<Response> {
       .eq('quote_id', quote.id)
       .order('position', { ascending: true });
 
-    const html = buildHtml({
-      quote,
-      items: items || [],
-      url: body.public_url,
-      reminder: !!body.reminder,
-      custom: body.custom_message || '',
-      siteName,
-      contractMode,
+    // ── Mallen är sajtinnehåll, på mottagarens språk ─────────────────────
+    // Mejlet i själva AFFÄREN var hårdkodad engelska: en svensk kund fick sin
+    // offert på engelska och ingen operatör kunde ändra det. Nu: mottagarens
+    // språk från parten, mallen via samma stege som allt annat (exakt tagg →
+    // samma språk → sajtens standard → NÅGON aktiv version), och den gamla
+    // HTML:en som Law 4-fallback — mejlet uteblir aldrig för att en mall
+    // saknas. ALL språktext bor i mallen; koden prerendrar bara data.
+    let recipientLang: string | null = null;
+    if (quote.partner_id) {
+      const { data: langRow, error: langErr } = await supabase.rpc('partner_language', { p_partner_id: quote.partner_id });
+      if (langErr) console.warn('[quote-email] could not read the recipient language:', langErr.message);
+      recipientLang = (langRow as { lang?: string } | null)?.lang ?? null;
+    }
+    const templateKind = body.reminder ? 'quote_reminder' : 'quote_email';
+    const { data: resolvedTpl, error: tplErr } = await supabase.rpc('resolve_email_template', {
+      p_name: templateKind,
+      p_locale: recipientLang,
     });
+    if (tplErr) console.warn('[quote-email] template lookup failed — using built-in fallback:', tplErr.message);
+    const tpl = resolvedTpl as { ok?: boolean; html?: string; subject?: string; locale?: string } | null;
 
-    const subject = body.reminder
-      ? `Reminder: Quote ${quote.quote_number} from ${siteName}`
-      : `Quote ${quote.quote_number} from ${siteName}`;
+    let html: string;
+    let subject: string;
+    if (tpl?.ok && tpl.html) {
+      // Prerendrade DATA-block — inga ord, bara rader, belopp och länkar.
+      const itemsRows = (items || []).map((it: any) => `
+    <tr>
+      <td style="padding:8px 0;border-bottom:1px solid #eef0f3;font-size:13px;vertical-align:top">
+        <div>${escapeHtml(it.description || '')}</div>
+        <div style="color:#6b7280;font-size:11px;margin-top:2px">${it.quantity} ${escapeHtml(it.unit || '')} × ${fmtMoney(it.unit_price_cents, quote.currency || 'SEK')}</div>
+      </td>
+      <td style="padding:8px 0;border-bottom:1px solid #eef0f3;text-align:right;font-family:ui-monospace,monospace;font-size:13px;white-space:nowrap;vertical-align:top">${fmtMoney(it.line_total_cents ?? (it.quantity * it.unit_price_cents), quote.currency || 'SEK')}</td>
+    </tr>`).join('');
+      const vars: Record<string, string> = {
+        quote_number: String(quote.quote_number ?? ''),
+        quote_title: escapeHtml(quote.title || ''),
+        site_name: escapeHtml(siteName),
+        items_rows: itemsRows,
+        subtotal: fmtMoney(quote.subtotal_cents, quote.currency || 'SEK'),
+        tax: fmtMoney(quote.tax_cents, quote.currency || 'SEK'),
+        total: fmtMoney(quote.total_cents, quote.currency || 'SEK'),
+        valid_until: quote.valid_until ? new Date(quote.valid_until).toLocaleDateString('sv-SE') : '—',
+        cta_url: body.public_url,
+        custom_block: body.custom_message
+          ? `<p style="margin:0 0 16px;white-space:pre-wrap">${escapeHtml(body.custom_message)}</p>` : '',
+      };
+      const render = (t: string) => t.replace(/\{\{(\w+)\}\}/g, (_, k) => vars[k] ?? '');
+      html = render(tpl.html);
+      subject = tpl.subject ? render(tpl.subject) : `Quote ${quote.quote_number} from ${siteName}`;
+      if (recipientLang && tpl.locale && tpl.locale !== recipientLang.toLowerCase()) {
+        console.warn(`[quote-email] no ${recipientLang} template for ${templateKind} — sent the ${tpl.locale} one`);
+      }
+    } else {
+      html = buildHtml({
+        quote,
+        items: items || [],
+        url: body.public_url,
+        reminder: !!body.reminder,
+        custom: body.custom_message || '',
+        siteName,
+        contractMode,
+      });
+      subject = body.reminder
+        ? `Reminder: Quote ${quote.quote_number} from ${siteName}`
+        : `Quote ${quote.quote_number} from ${siteName}`;
+    }
 
     // Route via the provider-agnostic email-send function.
     //

--- a/supabase/migrations/20260903150000_affarsmejlen-ar-sajtinnehall.sql
+++ b/supabase/migrations/20260903150000_affarsmejlen-ar-sajtinnehall.sql
@@ -1,0 +1,136 @@
+-- Affärsmejlen är sajtinnehåll — offerten och avtalet på mallrälsen.
+--
+-- Mallsystemet fick ett språk (20260903110000) och bokningsbekräftelsen går
+-- genom det. Men mejlen i själva AFFÄREN — offerten och signeringsbegäran —
+-- var hårdkodad engelsk HTML rakt i avsändarna. En svensk kund som får en
+-- offert från en svensk sajt fick den på engelska, och ingenting en operatör
+-- eller agent kunde göra åt saken utan en kodändring.
+--
+-- Samma mönster som bokningens seed (20260828170000):
+--   * Seedas återhävdbart, WHERE NOT EXISTS på (name, locale) — en operatörs
+--     omskrivning skrivs ALDRIG över.
+--   * locale='en' UTTRYCKLIGEN. Triggern sätter annars sajtens språk på nya
+--     rader, och de här är skrivna på engelska — produktens golv. Att låta en
+--     svensk instans stämpla dem 'sv' vore samma lögn som pages.locale-defaulten.
+--   * ALL språktext bor i mallen. Koden prerendrar bara DATA: radlistor,
+--     belopp, adresser. Etiketterna (Item, Amount, Subtotal, Valid until) står
+--     i mallens text, annars kan de aldrig översättas.
+--   * Sortnamnen är KINDS: quote_email, quote_reminder, contract_email,
+--     contract_reminder. En påminnelse är en annan sorts meddelande med egen
+--     ton — inte en flagga i samma mall, för replace-rendering kan inte grena.
+--
+-- En medveten förenkling: offertknappen säger "Open quote" oavsett om offerten
+-- är i avtalsläge (approve) eller signeringsläge (sign). Distinktionen bar
+-- juridisk nyans i koden, men den bor redan på offertSIDAN som renderar rätt —
+-- mejlknappen behöver bara öppna den. Hellre en neutral etikett som går att
+-- översätta än en precis som inte gör det.
+
+DO $$
+DECLARE
+  v_quote_html text;
+  v_quote_box text;
+  v_contract_html text;
+BEGIN
+  -- Delade byggstenar. Beloppen och raderna är data ({{items_rows}} är färdiga
+  -- <tr> utan språk); rubrikraden och etiketterna är mallens text.
+  v_quote_box :=
+    '<div style="background:#f9fafb;border:1px solid #e6e8ec;border-radius:8px;padding:16px;margin:16px 0">'
+ || '<div style="display:flex;justify-content:space-between;margin-bottom:6px"><span style="color:#6b7280">Quote</span><strong>{{quote_number}}</strong></div>'
+ || '<div style="margin-bottom:6px">{{quote_title}}</div>'
+ || '<table style="width:100%;border-collapse:collapse;margin:12px 0 4px">'
+ || '<thead><tr>'
+ || '<th style="text-align:left;font-size:11px;text-transform:uppercase;color:#6b7280;padding-bottom:6px;border-bottom:1px solid #e6e8ec">Item</th>'
+ || '<th style="text-align:right;font-size:11px;text-transform:uppercase;color:#6b7280;padding-bottom:6px;border-bottom:1px solid #e6e8ec">Amount</th>'
+ || '</tr></thead><tbody>{{items_rows}}</tbody></table>'
+ || '<div style="display:flex;justify-content:space-between;margin-top:8px;font-size:13px"><span style="color:#6b7280">Subtotal</span><span style="font-family:ui-monospace,monospace">{{subtotal}}</span></div>'
+ || '<div style="display:flex;justify-content:space-between;font-size:13px"><span style="color:#6b7280">Tax</span><span style="font-family:ui-monospace,monospace">{{tax}}</span></div>'
+ || '<div style="display:flex;justify-content:space-between;margin-top:6px;border-top:1px solid #e6e8ec;padding-top:6px"><strong>Total</strong><strong style="font-family:ui-monospace,monospace">{{total}}</strong></div>'
+ || '<div style="display:flex;justify-content:space-between;margin-top:8px;font-size:12px;color:#6b7280"><span>Valid until</span><span>{{valid_until}}</span></div>'
+ || '</div>';
+
+  v_quote_html :=
+    '<h1 style="margin:0 0 8px;font-size:20px">{{heading}}</h1>'
+ || '<p style="margin:0 0 16px;color:#4b5563">{{intro}}</p>'
+ || '{{custom_block}}'
+ || v_quote_box
+ || '<div style="text-align:center;margin:24px 0">'
+ || '<a href="{{cta_url}}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600">Open quote</a>'
+ || '</div>'
+ || '<p style="margin:16px 0 0;font-size:12px;color:#6b7280;word-break:break-all">Or copy this link:<br/>{{cta_url}}</p>';
+
+  v_contract_html :=
+    '<h2 style="margin:0 0 12px;font-size:20px">{{contract_title}}</h2>'
+ || '<p>{{intro}}</p>'
+ || '{{custom_block}}'
+ || '<div style="background:#f9fafb;border:1px solid #e6e8ec;border-radius:8px;padding:12px 16px;margin:16px 0;font-size:14px">'
+ || '<div><span style="color:#6b7280">Agreement</span> &nbsp; <strong>{{contract_number}}</strong></div>'
+ || '</div>'
+ || '<p style="margin:24px 0"><a href="{{cta_url}}" style="display:inline-block;padding:12px 24px;background-color:#111;color:#ffffff;text-decoration:none;border-radius:6px;font-weight:600">Review &amp; sign</a></p>'
+ || '<p style="font-size:12px;color:#6b7280;word-break:break-all">Or open this link:<br/>{{cta_url}}</p>';
+
+  -- {{heading}}/{{intro}} är EGNA mallfält i sorterna nedan, så tonen skiljer
+  -- sig mellan förstautskick och påminnelse utan att koden grenar.
+  INSERT INTO email_templates (name, locale, subject, html, category, variables, active)
+  SELECT 'quote_email', 'en',
+         'Quote {{quote_number}} from {{site_name}}',
+         replace(replace(v_quote_html,
+           '{{heading}}', 'Your quote {{quote_number}}'),
+           '{{intro}}', 'Thank you for your interest. Please find your quote below.'),
+         'sales',
+         '["quote_number","quote_title","site_name","items_rows","subtotal","tax","total","valid_until","cta_url","custom_block"]'::jsonb,
+         true
+  WHERE NOT EXISTS (SELECT 1 FROM email_templates WHERE name = 'quote_email' AND locale = 'en');
+
+  INSERT INTO email_templates (name, locale, subject, html, category, variables, active)
+  SELECT 'quote_reminder', 'en',
+         'Reminder: Quote {{quote_number}} from {{site_name}}',
+         replace(replace(v_quote_html,
+           '{{heading}}', 'Reminder: Quote {{quote_number}}'),
+           '{{intro}}', 'This is a friendly reminder regarding the quote we sent you.'),
+         'sales',
+         '["quote_number","quote_title","site_name","items_rows","subtotal","tax","total","valid_until","cta_url","custom_block"]'::jsonb,
+         true
+  WHERE NOT EXISTS (SELECT 1 FROM email_templates WHERE name = 'quote_reminder' AND locale = 'en');
+
+  INSERT INTO email_templates (name, locale, subject, html, category, variables, active)
+  SELECT 'contract_email', 'en',
+         'Agreement {{contract_number}} from {{site_name}} — ready to sign',
+         replace(v_contract_html,
+           '{{intro}}', 'Please review and sign the agreement below.'),
+         'sales',
+         '["contract_title","contract_number","site_name","cta_url","custom_block"]'::jsonb,
+         true
+  WHERE NOT EXISTS (SELECT 1 FROM email_templates WHERE name = 'contract_email' AND locale = 'en');
+
+  INSERT INTO email_templates (name, locale, subject, html, category, variables, active)
+  SELECT 'contract_reminder', 'en',
+         'Reminder: sign {{contract_number}} from {{site_name}}',
+         replace(v_contract_html,
+           '{{intro}}', 'A reminder to review and sign the agreement below.'),
+         'sales',
+         '["contract_title","contract_number","site_name","cta_url","custom_block"]'::jsonb,
+         true
+  WHERE NOT EXISTS (SELECT 1 FROM email_templates WHERE name = 'contract_reminder' AND locale = 'en');
+END $$;
+
+-- ── Bevisas där den körs ───────────────────────────────────────────────────
+DO $$
+DECLARE v jsonb; kind text;
+BEGIN
+  PERFORM set_config('request.jwt.claims', '{"role":"service_role"}', true);
+  FOREACH kind IN ARRAY ARRAY['quote_email','quote_reminder','contract_email','contract_reminder'] LOOP
+    -- En svensk mottagare på en sajt utan svensk version ska ändå få ETT mejl.
+    v := public.resolve_email_template(kind, 'sv');
+    IF NOT (v ->> 'ok')::boolean THEN
+      RAISE EXCEPTION 'resolve(%): no template resolved at all — an email would not go out', kind;
+    END IF;
+    IF (v ->> 'html') IS NULL OR length(v ->> 'html') < 100 THEN
+      RAISE EXCEPTION 'resolve(%): the template came back without a body', kind;
+    END IF;
+    -- Etiketterna måste bo i MALLEN — det är hela flytten.
+    IF kind LIKE 'quote%' AND (v ->> 'html') NOT LIKE '%Subtotal%' THEN
+      RAISE EXCEPTION 'resolve(%): the labels are not in the template text', kind;
+    END IF;
+  END LOOP;
+  RAISE NOTICE 'business emails: 4 kinds seeded and resolvable';
+END $$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260903130000",
-      "migrations_count": 559,
+      "migration_head": "20260903150000",
+      "migrations_count": 560,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2241,6 +2241,10 @@
         {
           "version": "20260903130000",
           "name": "sprakdeklarationen-hor-till-skyltfonstret"
+        },
+        {
+          "version": "20260903150000",
+          "name": "affarsmejlen-ar-sajtinnehall"
         }
       ]
     },
@@ -2264,7 +2268,7 @@
         "chat-completion": "sha256:d840d8aa54a221a3a59a3b114285c60a018ef13670f76d8bcb0a71b41ff5437c",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
-        "comms-send": "sha256:c0a50f6580f51c98dffd652e7cb3203d90555c60275344c951f645044c5acfb2",
+        "comms-send": "sha256:106bc132612208bdeafbaaa96157ecdfc016042bf5764af4c09100580ed2a1b4",
         "composio-proxy": "sha256:08477e4658cee04b6a09458a5e8dc45fbf9737c2188f7b972ae954782a4bdc95",
         "composio-webhook": "sha256:27f17b7198bfbab422931ef1c872da083299e095792e43b98b4154ec79c858ca",
         "consultant-match": "sha256:1419717affb3711a2d7f13d44c9a228e1557a3d927e3aa05ee5e179584131e1b",


### PR DESCRIPTION
Mallsystemet fick ett språk och bokningsbekräftelsen gick genom det. Men mejlen i själva **affären** — offerten och signeringsbegäran, hjärtat i Optics resa lead → offert → avtal — var hårdkodad engelsk HTML rakt i avsändarna. En svensk kund fick sin offert på engelska, och ingen operatör kunde ändra det utan kodändring.

## Fyra sorter, samma seedmönster som bokningen
`quote_email`, `quote_reminder`, `contract_email`, `contract_reminder`. En påminnelse är en **annan sorts meddelande** med egen ton — inte en flagga i samma mall, för replace-rendering kan inte grena.

- Seedas `WHERE NOT EXISTS` på `(name, locale)` — en operatörs omskrivning skrivs aldrig över
- **`locale='en'` uttryckligen.** Insert-triggern hade annars stämplat *sajtens* språk på mallar som är skrivna på engelska — samma lögn som `pages.locale`-defaulten
- **All språktext bor i mallen**, etiketterna inklusive (Item, Amount, Subtotal, Valid until). Koden prerendrar bara **data**: radlistor, belopp, länkar. Migreringen bevisar det — en mall utan "Subtotal" i sin text vägras vid applicering.

## Avsändarna
Mottagarens språk via `partner_language`, mallen via stegen (exakt tagg → samma språk → sajtens standard → **någon** aktiv version), och den gamla HTML:en som Law 4-fallback — mejlet uteblir aldrig för att en mall saknas. Avvikelsen loggas när mottagarens språk inte fanns.

`contracts`-hämtningen fick `partner_id` i sin kolumnlista; `quotes` hade redan `select('*')`.

## En medveten förenkling
Offertknappen säger *"Open quote"* oavsett approve/sign-läge. Distinktionen bor på offert**sidan**, som renderar rätt — hellre en neutral etikett som går att översätta än en precis som inte gör det.

## Verifierat
| | |
|---|---|
| Migreringen: 4 sorter seedade och upplösbara för en svensk mottagare | ✓ |
| Etiketterna i mallens text, inte i koden | bevisas vid applicering |
| Idempotent | ✓ |
| tsc / 3633 tester / forward-dating / doc-drift | gröna |

Kvar på hårdkodad engelska: `invoice_email`, `order_confirmation` m.fl. — samma recept när de behövs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)