### PR TITLE
feat(i18n): /en/ — språket blir en del av adressens form, additivt

### DIFF
--- a/api/og.ts
+++ b/api/og.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- prerender reads dynamic, loosely-typed PostgREST JSON */
 export const config = { runtime: 'edge' };
 
+import { pagePath, splitLanguagePrefix } from '../src/lib/language-path';
+
 declare const process: { env: Record<string, string | undefined> };
 
 function esc(s: unknown): string {
@@ -43,6 +45,12 @@ export default async function handler(req: Request): Promise<Response> {
   // Sidans eget språk, och dess syskon — båda tomma tills en sida slås upp.
   let pageLocale = '';
   let siblings: any[] = [];
+  // /en/product: prefixet är språket, resten är GRUPPENS basslugg. Vilka
+  // prefix som finns avgörs av sajtens deklaration — fylls i när
+  // inställningarna lästs.
+  let requestedLang: string | null = null;
+  let byKeyOuter: Record<string, any> = {};
+  let canonicalUrl = '';
   const host = req.headers.get('host') || url.host;
   const proto = req.headers.get('x-forwarded-proto') || 'https';
   const origin = `${proto}://${host}`;
@@ -61,9 +69,10 @@ export default async function handler(req: Request): Promise<Response> {
   let isArticle = false;
 
   if (base && key) {
-    const settings = await pg(base, key, 'site_settings?key=in.(seo,general,branding)&select=key,value');
+    const settings = await pg(base, key, 'site_settings?key=in.(seo,general,branding,site_languages)&select=key,value');
     const byKey: Record<string, any> = {};
     for (const row of settings) byKey[row.key] = row.value || {};
+    byKeyOuter = byKey;
     const seo = byKey.seo || {};
     const branding = byKey.branding || {};
     title = seo.siteTitle || branding.organizationName || 'Website';
@@ -73,6 +82,10 @@ export default async function handler(req: Request): Promise<Response> {
     logoFallback = branding.logo || '';
     twitter = seo.twitterHandle || '';
     titleTemplate = seo.titleTemplate || '%s';
+
+    const langs = (byKey.site_languages || {}) as { default?: string; enabled?: string[] };
+    const split = splitLanguagePrefix(path, langs.enabled ?? [], String(langs.default ?? 'en'));
+    requestedLang = split.lang;
 
 
     const blog = path.match(/^\/blog\/(.+)$/);
@@ -94,29 +107,61 @@ export default async function handler(req: Request): Promise<Response> {
       // path '/' hoppade över hela uppslaget, så crawlers fick lang="en" på en
       // svensk startsida medan varenda undersida var rätt. Roten pekar på en
       // riktig sidrad via general.homepageSlug, och den raden bär språket.
-      const rawSlug = path === '/'
-        ? String((byKey.general || {}).homepageSlug || 'home')
-        : decodeURIComponent(path.replace(/^\//, ''));
+      const homepageSlug = String((byKey.general || {}).homepageSlug || 'home');
+      const langs = (byKey.site_languages || {}) as { default?: string; enabled?: string[] };
+      const defaultLang = String(langs.default ?? 'en');
+      // /en → engelska startsidan; /en/product → basen 'product', språket 'en'.
+      const requestedRest = requestedLang !== null
+        ? splitLanguagePrefix(path, langs.enabled ?? [], defaultLang).rest
+        : path;
+      const rawSlug = requestedRest === '/'
+        ? homepageSlug
+        : decodeURIComponent(requestedRest.replace(/^\//, ''));
       const slug = encodeURIComponent(rawSlug);
-      const [page] = await pg(
+      let [page] = await pg(
         base,
         key,
-        `pages?slug=eq.${slug}&status=eq.published&select=title,meta_json,locale,translation_group_id&limit=1`,
+        `pages?slug=eq.${slug}&status=eq.published&select=slug,title,meta_json,locale,translation_group_id&limit=1`,
       );
+      // Prefix begärt: sidan vi vill visa är SYSKONET i det språket, inte
+      // basraden. Basen är bara adressens ryggrad.
+      if (page && requestedLang && page.translation_group_id
+          && String(page.locale ?? '').toLowerCase() !== requestedLang) {
+        const [sibling] = await pg(
+          base,
+          key,
+          `pages?translation_group_id=eq.${encodeURIComponent(String(page.translation_group_id))}`
+            + `&locale=eq.${encodeURIComponent(requestedLang)}&status=eq.published&select=slug,title,meta_json,locale,translation_group_id&limit=1`,
+        );
+        if (sibling) page = sibling;
+      }
       if (page) {
         if (page.title) title = page.title;
-        // Språket följer sidan. Skalet hade `lang="en"` hårdkodat, så en
-        // crawler fick veta att en svensk sida var engelsk — samma fel som
-        // index.html bar innan sidorna fick sitt eget språk.
-        if (page.locale) pageLocale = String(page.locale);
+        // Kanonisk adress på prefixformen — även när den GAMLA adressen
+        // (/product-en) begärdes. Det är omdirigeringens crawler-halva:
+        // klienten navigerar, boten läser rel=canonical.
         if (page.translation_group_id) {
-          siblings = await pg(
+          const canonSiblings = await pg(
             base,
             key,
             `pages?translation_group_id=eq.${encodeURIComponent(String(page.translation_group_id))}`
               + `&status=eq.published&select=slug,locale`,
           );
+          const baseSlug = canonSiblings.find(
+            (x: any) => String(x.locale ?? '').toLowerCase().split('-')[0] === defaultLang.toLowerCase().split('-')[0],
+          )?.slug ?? null;
+          const p2 = pagePath({
+            slug: String(page.slug), locale: page.locale ? String(page.locale) : null,
+            defaultLanguage: defaultLang, baseSlug, homepageSlug,
+          });
+          canonicalUrl = p2 === '/' ? `${origin}/` : `${origin}${p2}`;
+          siblings = canonSiblings;
         }
+        // Språket följer sidan. Skalet hade `lang="en"` hårdkodat, så en
+        // crawler fick veta att en svensk sida var engelsk — samma fel som
+        // index.html bar innan sidorna fick sitt eget språk.
+        if (page.locale) pageLocale = String(page.locale);
+
         const m = (page.meta_json || {}) as Record<string, unknown>;
         description = (m.description as string) || (m.seoDescription as string) || (m.metaDescription as string) || description;
         image = (m.ogImage as string) || (m.og_image as string) || (m.image as string) || image;
@@ -158,14 +203,28 @@ export default async function handler(req: Request): Promise<Response> {
     description && `<meta name="twitter:description" content="${esc(description)}">`,
     image && `<meta name="twitter:image" content="${esc(image)}">`,
     twitter && `<meta name="twitter:site" content="${esc(twitter)}">`,
-    `<link rel="canonical" href="${esc(pageUrl)}">`,
-    // Samma uppsättning som sitemapen och sidhuvudet: varje version listar
-    // varje version, sig själv inkluderad, med absoluta adresser.
+    `<link rel="canonical" href="${esc(canonicalUrl || pageUrl)}">`,
+    // Samma adressform som sidhuvudet och sitemapen: standardspråket på
+    // roten, andra språk som /lang/<basslugg> — via samma pagePath.
     ...(siblings.length > 1
-      ? siblings
-        .filter((s: any) => s?.slug && s?.locale)
-        .map((s: any) => `<link rel="alternate" hreflang="${esc(String(s.locale).toLowerCase())}" `
-          + `href="${esc(`${origin}/${s.slug}`)}">`)
+      ? (() => {
+          const langs = (byKeyOuter.site_languages || {}) as { default?: string };
+          const defaultLang = String(langs.default ?? 'en');
+          const homepageSlug = String((byKeyOuter.general || {}).homepageSlug || 'home');
+          const baseSlug = siblings.find(
+            (s: any) => String(s.locale ?? '').toLowerCase().split('-')[0] === defaultLang.toLowerCase().split('-')[0],
+          )?.slug ?? null;
+          return siblings
+            .filter((s: any) => s?.slug && s?.locale)
+            .map((s: any) => {
+              const p = pagePath({
+                slug: String(s.slug), locale: String(s.locale),
+                defaultLanguage: defaultLang, baseSlug, homepageSlug,
+              });
+              return `<link rel="alternate" hreflang="${esc(String(s.locale).toLowerCase())}" `
+                + `href="${esc(p === '/' ? `${origin}/` : `${origin}${p}`)}">`;
+            });
+        })()
       : []),
   ]
     .filter(Boolean)

--- a/docs/architecture/language.md
+++ b/docs/architecture/language.md
@@ -58,6 +58,17 @@ Any table holding translatable *documents* gets two columns:
   itself lives in `src/lib/hreflang.ts` — every version lists every version
   including itself, the hrefs are absolute, and `x-default` points at the site's
   default language rather than at whichever version came first.
+- **The address form is `/{lang}/{baseSlug}`** — the default language owns the
+  root (`/product`), other languages get a prefix on the GROUP's base slug
+  (`/en/product`), and the homepage in another language is the bare prefix
+  (`/en`). `pagePath()` in `src/lib/language-path.ts` is the single owner;
+  seven consumers (canonical, switcher, nav, hreflang, sitemap, prerender,
+  redirect) all call it, and the sitemap's edge twin mirrors it because the
+  edge bundle cannot reach `src/`. This is ADDITIVE: storage keeps the `-en`
+  suffixed slugs, the old address still resolves and then redirects home —
+  the prefix is presentation, which is what made it safe to introduce days
+  before a launch. A prefix only counts when it is a DECLARED non-default
+  language, so `/blog/...` and a site without English keep their meanings.
 - **A new row is born in the site's default language** (`pages_default_locale`
   trigger). Do not put a literal default on the column — `pages.locale` once
   defaulted to `'en'`, which asserted English about every page on every

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -468,6 +468,11 @@ const router = createBrowserRouter([
       { path: "/admin/platform-tests", element: <PlatformTestsPage /> },
       { path: "/preview/:id", element: <PreviewPage /> },
       { path: "/:slug", element: <PublicPage /> },
+      // /en/product — språkprefix på gruppens basslugg. Ligger SIST så varje
+      // specifik tvåsegmentsrutt (/blog/:slug, /kb/:slug …) vinner på statiskt
+      // segment; PublicPage verifierar att prefixet är ett DEKLARERAT språk
+      // och svarar 404 annars, precis som tvåsegmentsokända gjorde förut.
+      { path: "/:lang/:slug", element: <PublicPage /> },
     ],
   },
 ]);

--- a/src/components/public/LanguageSwitcher.tsx
+++ b/src/components/public/LanguageSwitcher.tsx
@@ -6,6 +6,8 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
+import { pagePath } from '@/lib/language-path';
+import { useSiteLanguages, useGeneralSettings } from '@/hooks/useSiteSettings';
 import { useUiText } from '@/lib/ui-text';
 
 export interface PageTranslation {
@@ -47,10 +49,22 @@ interface LanguageSwitcherProps {
 export function LanguageSwitcher({ translations, currentLocale, className }: LanguageSwitcherProps) {
   const t = useUiText();
 
+  const { defaultLanguage } = useSiteLanguages();
+  const { data: generalSettings } = useGeneralSettings();
+
   const options = (translations ?? []).filter((x) => x.slug && x.locale);
   if (options.length < 2) return null;
 
   const current = options.find((x) => x.locale === currentLocale) ?? null;
+  // Adressformen: standardspråket på roten, andra som /lang/<basslugg>.
+  const homepageSlug = generalSettings?.homepageSlug || 'home';
+  const groupBase = options.find(
+    (x) => x.locale.toLowerCase().split('-')[0] === defaultLanguage.split('-')[0],
+  )?.slug ?? null;
+  const optionHref = (option: PageTranslation) => pagePath({
+    slug: option.slug, locale: option.locale,
+    defaultLanguage, baseSlug: groupBase, homepageSlug,
+  });
 
   return (
     <DropdownMenu>
@@ -71,7 +85,7 @@ export function LanguageSwitcher({ translations, currentLocale, className }: Lan
           return (
             <DropdownMenuItem key={option.locale} asChild>
               <a
-                href={`/${option.slug}`}
+                href={optionHref(option)}
                 hrefLang={option.locale}
                 lang={option.locale}
                 aria-current={isCurrent ? 'true' : undefined}

--- a/src/components/public/PublicNavigation.tsx
+++ b/src/components/public/PublicNavigation.tsx
@@ -12,6 +12,7 @@ import { CartIndicator } from './CartIndicator';
 import { AccountIndicator } from './AccountIndicator';
 import { LanguageSwitcher, type PageTranslation } from './LanguageSwitcher';
 import { pickLocale } from '@/lib/pick-locale';
+import { pagePath } from '@/lib/language-path';
 import { operatorText } from '@/lib/operator-text';
 import { SandboxBanner } from '@/components/SandboxBanner';
 import { useHeaderBlock, defaultHeaderData } from '@/hooks/useGlobalBlocks';
@@ -152,7 +153,7 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
 
   /** The sibling of `slug` in the visitor's language, or null when there is none. */
   const siblingOf = useMemo(() => {
-    if (!currentLocale || siblings.length === 0) return () => null as null | { slug: string; title: string };
+    if (!currentLocale || siblings.length === 0) return () => null as null | { slug: string; title: string; path: string };
     const bySlug = new Map(siblings.map((p) => [p.slug, p]));
     return (slug: string) => {
       const source = bySlug.get(slug);
@@ -164,7 +165,19 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
       });
       if (!chosen) return null;
       const target = group.find((p) => String(p.locale ?? '') === chosen);
-      return target && target.slug !== slug ? { slug: target.slug, title: target.title } : null;
+      if (!target || target.slug === slug) return null;
+      const groupBase = group.find(
+        (p) => String(p.locale ?? '').toLowerCase().split('-')[0] === siteDefaultLanguage.split('-')[0],
+      )?.slug ?? null;
+      return {
+        slug: target.slug,
+        title: target.title,
+        // Adressformen: /en/<basslugg>, aldrig den egna -en-sluggen.
+        path: pagePath({
+          slug: target.slug, locale: String(target.locale ?? ''),
+          defaultLanguage: siteDefaultLanguage, baseSlug: groupBase,
+        }),
+      };
     };
   }, [siblings, currentLocale]);
 
@@ -175,7 +188,7 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
     const slug = path.replace(/^\//, '').replace(/\/$/, '');
     const sibling = slug ? siblingOf(slug) : null;
     if (!sibling) return url;
-    return `/${sibling.slug}${path.endsWith('/') ? '/' : ''}${hash ? `#${hash}` : ''}`;
+    return `${sibling.path}${hash ? `#${hash}` : ''}`;
   };
 
   // The menu is built from ALREADY localised data, so every renderer below —
@@ -183,7 +196,9 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
   const pages = useMemo(() => {
     const localized = sourcePages.map((page) => {
       const sibling = siblingOf(page.slug);
-      return sibling ? { ...page, slug: sibling.slug, title: sibling.title } : page;
+      return sibling
+        ? { ...page, slug: sibling.slug, title: sibling.title, path: sibling.path }
+        : { ...page, path: page.slug === 'hem' ? '/' : `/${page.slug}` };
     });
     // En översättningsgrupp är EN menypost. show_in_menu frågar inte på språk,
     // så en operatör som bockar i både /home och /home-en får båda i listan —
@@ -556,7 +571,7 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
             {pages.map((page) => (
               <Link
                 key={page.id}
-                to={page.slug === 'hem' ? '/' : `/${page.slug}`}
+                to={page.path}
                 className={getLinkClasses(currentSlug === page.slug)}
               >
                 {page.title}
@@ -611,7 +626,7 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
               {pages.map((page) => (
                 <Link
                   key={page.id}
-                  to={page.slug === 'hem' ? '/' : `/${page.slug}`}
+                  to={page.path}
                   onClick={() => setMobileMenuOpen(false)}
                   className={cn(
                     'px-4 py-3 rounded-md text-base font-medium transition-colors',
@@ -679,7 +694,7 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
               {pages.map((page) => (
                 <Link
                   key={page.id}
-                  to={page.slug === 'hem' ? '/' : `/${page.slug}`}
+                  to={page.path}
                   onClick={() => setMobileMenuOpen(false)}
                   className={cn(
                     'text-2xl font-medium transition-colors',
@@ -740,7 +755,7 @@ export function PublicNavigation({ translations, currentLocale }: PublicNavigati
               {pages.map((page) => (
                 <Link
                   key={page.id}
-                  to={page.slug === 'hem' ? '/' : `/${page.slug}`}
+                  to={page.path}
                   onClick={() => setMobileMenuOpen(false)}
                   className={cn(
                     'px-4 py-3 rounded-md text-base font-medium transition-colors',

--- a/src/components/public/__tests__/language-switcher.guardrails.test.tsx
+++ b/src/components/public/__tests__/language-switcher.guardrails.test.tsx
@@ -1,6 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render as rtlRender, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
 import { LanguageSwitcher } from '../LanguageSwitcher';
+
+// Växlaren läser sajtens språk och startsida via TanStack Query för att bygga
+// /en/-adresser — testerna monterar därför en provider. Frågorna får svara
+// tomt: fallbacken (default 'en') räcker för form-kontrakten här.
+const render = (ui: ReactElement) => rtlRender(
+  <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    {ui}
+  </QueryClientProvider>,
+);
 
 /**
  * Språkväljaren får INTE synas på en enspråkig sajt.

--- a/src/lib/__tests__/hreflang.guardrails.test.ts
+++ b/src/lib/__tests__/hreflang.guardrails.test.ts
@@ -28,9 +28,11 @@ describe('hreflang', () => {
     const alts = buildHreflangAlternates({
       translations: PAIR, baseUrl: BASE, homepageSlug: 'ingen', defaultLanguage: 'sv',
     });
+    // Sedan /en/-prefixet: andra språk adresseras på GRUPPENS basslugg med
+    // språkprefix — aldrig på sin egen -en-slug.
     expect(alts.filter((a) => a.hreflang !== 'x-default')).toEqual([
       { hreflang: 'sv', href: `${BASE}/home` },
-      { hreflang: 'en', href: `${BASE}/home-en` },
+      { hreflang: 'en', href: `${BASE}/en/home` },
     ]);
   });
 
@@ -46,13 +48,16 @@ describe('hreflang', () => {
       translations: PAIR, baseUrl: BASE, homepageSlug: 'home', defaultLanguage: 'sv',
     });
     expect(alts.find((a) => a.hreflang === 'sv')?.href).toBe(`${BASE}/`);
-    expect(alts.find((a) => a.hreflang === 'en')?.href).toBe(`${BASE}/home-en`);
+    // Startsidan i annat språk är bara prefixet.
+    expect(alts.find((a) => a.hreflang === 'en')?.href).toBe(`${BASE}/en`);
   });
 
   it('x-default pekar på SAJTENS språk, inte på den första i listan', () => {
     const alts = buildHreflangAlternates({
       translations: PAIR, baseUrl: BASE, homepageSlug: 'ingen', defaultLanguage: 'en',
     });
+    // Här ÄR engelska standardspråket, så dess adress är rotformen med egen
+    // slug — prefix får bara icke-standardspråk.
     expect(alts.find((a) => a.hreflang === 'x-default')?.href).toBe(`${BASE}/home-en`);
   });
 

--- a/src/lib/__tests__/language-path.guardrails.test.ts
+++ b/src/lib/__tests__/language-path.guardrails.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { pagePath, splitLanguagePrefix } from '../language-path';
+
+/**
+ * Adressformen för språkversioner: standardspråket äger roten, andra språk får
+ * prefix på GRUPPENS basslugg. Sju konsumenter (canonical, växlare, nav,
+ * hreflang, sitemap, prerender, redirect) anropar samma funktion — de här
+ * fallen är kontraktet de delar.
+ */
+describe('pagePath', () => {
+  const SV = { defaultLanguage: 'sv', homepageSlug: 'home' };
+
+  it('standardspråket äger roten — ingenting flyttar', () => {
+    expect(pagePath({ slug: 'product', locale: 'sv', ...SV })).toBe('/product');
+    expect(pagePath({ slug: 'home', locale: 'sv', ...SV })).toBe('/');
+    expect(pagePath({ slug: 'villkor', locale: null, ...SV })).toBe('/villkor');
+  });
+
+  it('andra språk får prefix på GRUPPENS basslugg, inte sin egen', () => {
+    expect(pagePath({ slug: 'product-en', locale: 'en', baseSlug: 'product', ...SV }))
+      .toBe('/en/product');
+  });
+
+  it('startsidan i annat språk är bara prefixet', () => {
+    expect(pagePath({ slug: 'home-en', locale: 'en', baseSlug: 'home', ...SV })).toBe('/en');
+  });
+
+  it('utan känt syskon faller den till egen slug — fult men aldrig brutet', () => {
+    expect(pagePath({ slug: 'product-en', locale: 'en', ...SV })).toBe('/en/product-en');
+  });
+
+  it('regionstagg räknas som samma språk som standarden', () => {
+    expect(pagePath({ slug: 'product', locale: 'sv-SE', ...SV })).toBe('/product');
+  });
+});
+
+describe('splitLanguagePrefix', () => {
+  const ENABLED = ['sv', 'en'];
+
+  it('läser prefixet bara för DEKLARERADE icke-standardspråk', () => {
+    expect(splitLanguagePrefix('/en/product', ENABLED, 'sv')).toEqual({ lang: 'en', rest: '/product' });
+    expect(splitLanguagePrefix('/de/product', ENABLED, 'sv')).toEqual({ lang: null, rest: '/de/product' });
+  });
+
+  it('/en ensamt är den engelska startsidan', () => {
+    expect(splitLanguagePrefix('/en', ENABLED, 'sv')).toEqual({ lang: 'en', rest: '/' });
+    expect(splitLanguagePrefix('/en/', ENABLED, 'sv')).toEqual({ lang: 'en', rest: '/' });
+  });
+
+  it('standardspråket är aldrig ett prefix — /sv/x vore en dubblettadress', () => {
+    expect(splitLanguagePrefix('/sv/product', ENABLED, 'sv')).toEqual({ lang: null, rest: '/sv/product' });
+  });
+
+  it('vanliga sökvägar passerar orörda', () => {
+    expect(splitLanguagePrefix('/product', ENABLED, 'sv')).toEqual({ lang: null, rest: '/product' });
+    expect(splitLanguagePrefix('/', ENABLED, 'sv')).toEqual({ lang: null, rest: '/' });
+    expect(splitLanguagePrefix('/blog/post', ENABLED, 'sv')).toEqual({ lang: null, rest: '/blog/post' });
+  });
+
+  it('en sida som råkar heta som ett språk skyddas av deklarationen', () => {
+    // "en" är prefix ENDAST för att sajten deklarerat engelska. En sajt utan
+    // engelska behåller /en som vanlig slug.
+    expect(splitLanguagePrefix('/en/product', ['sv'], 'sv')).toEqual({ lang: null, rest: '/en/product' });
+  });
+});

--- a/src/lib/__tests__/sitemap-alternates.guardrails.test.ts
+++ b/src/lib/__tests__/sitemap-alternates.guardrails.test.ts
@@ -1,76 +1,71 @@
 import { describe, it, expect } from 'vitest';
 import { sitemapAlternates } from '../../../supabase/functions/_shared/sitemap-alternates.ts';
 
-const href = (slug: string) => (slug === 'home' ? 'https://x.se' : `https://x.se/${slug}`);
+const BASE = 'https://x.se';
+const ARGS = { defaultLanguage: 'sv', baseUrl: BASE, homepageSlug: 'home' };
 const PAIR = [
   { slug: 'product', locale: 'sv', translation_group_id: 'g1' },
   { slug: 'product-en', locale: 'en', translation_group_id: 'g1' },
 ];
 
 /**
- * Sitemapen är den ENDA kanal en sökmotor läser utan att köra JavaScript:
- * hreflang i huvudet kommer från react-helmet, och den här instansens
- * prerender körs bara för SOCIALA crawlers. Utan detta ser Google fjorton
- * orelaterade adresser, varav hälften liknar dubblettinnehåll på fel marknad.
+ * Sitemapen är den ENDA kanal en sökmotor läser utan att köra JavaScript.
+ * Adressformen speglar src/lib/language-path.ts (edge-bundlingen når inte
+ * src/) — de här fallen är kontraktet mellan tvillingarna: ändra den ena,
+ * ändra båda.
  */
-describe('sitemapens språkalternativ', () => {
-  it('en sida utan syskon får inga alternativ', () => {
-    const m = sitemapAlternates({
-      pages: [{ slug: 'villkor', locale: 'sv', translation_group_id: null }],
-      defaultLanguage: 'sv', href,
+describe('sitemapens adressering', () => {
+  it('en sida utan syskon får ingen alternativuppsättning men en kanonisk sökväg', () => {
+    const { alternates, canonicalPath } = sitemapAlternates({
+      pages: [{ slug: 'villkor', locale: 'sv', translation_group_id: null }], ...ARGS,
     });
-    expect(m.size).toBe(0);
+    expect(alternates.size).toBe(0);
+    expect(canonicalPath.get('villkor')).toBe('/villkor');
   });
 
-  it('en ensam sida i en grupp räknas inte som en uppsättning', () => {
-    const m = sitemapAlternates({
-      pages: [{ slug: 'a', locale: 'sv', translation_group_id: 'g' }],
-      defaultLanguage: 'sv', href,
-    });
-    expect(m.size).toBe(0);
-  });
-
-  it('båda versionerna får SAMMA uppsättning, sig själva inkluderade', () => {
-    const m = sitemapAlternates({ pages: PAIR, defaultLanguage: 'sv', href });
-    const sv = m.get('product')!;
-    const en = m.get('product-en')!;
-    expect(sv).toEqual(en);
-    expect(sv.filter((a) => a.hreflang !== 'x-default')).toEqual([
-      { hreflang: 'sv', href: 'https://x.se/product' },
-      { hreflang: 'en', href: 'https://x.se/product-en' },
+  it('icke-standardspråk adresseras som /lang/<basslugg>, aldrig egen -en-slug', () => {
+    const { canonicalPath, alternates } = sitemapAlternates({ pages: PAIR, ...ARGS });
+    expect(canonicalPath.get('product')).toBe('/product');
+    expect(canonicalPath.get('product-en')).toBe('/en/product');
+    const set = alternates.get('product')!;
+    expect(set).toEqual(alternates.get('product-en'));
+    expect(set.filter((a) => a.hreflang !== 'x-default')).toEqual([
+      { hreflang: 'sv', href: `${BASE}/product` },
+      { hreflang: 'en', href: `${BASE}/en/product` },
     ]);
   });
 
   it('x-default pekar på sajtens språk', () => {
-    const m = sitemapAlternates({ pages: PAIR, defaultLanguage: 'sv-SE', href });
-    expect(m.get('product')!.find((a) => a.hreflang === 'x-default')?.href)
-      .toBe('https://x.se/product');
+    const { alternates } = sitemapAlternates({ pages: PAIR, ...ARGS, defaultLanguage: 'sv-SE' });
+    expect(alternates.get('product')!.find((a) => a.hreflang === 'x-default')?.href)
+      .toBe(`${BASE}/product`);
   });
 
   it('utan deklarerat språk utelämnas x-default hellre än gissas', () => {
-    const m = sitemapAlternates({ pages: PAIR, defaultLanguage: '', href });
-    expect(m.get('product')!.some((a) => a.hreflang === 'x-default')).toBe(false);
+    const { alternates } = sitemapAlternates({ pages: PAIR, ...ARGS, defaultLanguage: '' });
+    expect(alternates.get('product')!.some((a) => a.hreflang === 'x-default')).toBe(false);
   });
 
-  it('startsidan får bara origin — samma href-funktion som <loc>', () => {
-    const m = sitemapAlternates({
+  it('startsidan: roten för standardspråket, bara prefixet för det andra', () => {
+    const { canonicalPath, alternates } = sitemapAlternates({
       pages: [
         { slug: 'home', locale: 'sv', translation_group_id: 'g' },
         { slug: 'home-en', locale: 'en', translation_group_id: 'g' },
-      ],
-      defaultLanguage: 'sv', href,
+      ], ...ARGS,
     });
-    expect(m.get('home')!.find((a) => a.hreflang === 'sv')?.href).toBe('https://x.se');
+    expect(canonicalPath.get('home')).toBe('/');
+    expect(canonicalPath.get('home-en')).toBe('/en');
+    expect(alternates.get('home')!.find((a) => a.hreflang === 'sv')?.href).toBe(`${BASE}/`);
+    expect(alternates.get('home')!.find((a) => a.hreflang === 'en')?.href).toBe(`${BASE}/en`);
   });
 
-  it('en sida utan locale hoppas över i stället för att bli hreflang=""', () => {
-    const m = sitemapAlternates({
+  it('en sida utan locale i en grupp hoppas över i stället för att bli hreflang=""', () => {
+    const { alternates } = sitemapAlternates({
       pages: [
         { slug: 'a', locale: 'sv', translation_group_id: 'g' },
         { slug: 'b', locale: null, translation_group_id: 'g' },
-      ],
-      defaultLanguage: 'sv', href,
+      ], ...ARGS,
     });
-    expect(m.size).toBe(0);
+    expect(alternates.size).toBe(0);
   });
 });

--- a/src/lib/hreflang.ts
+++ b/src/lib/hreflang.ts
@@ -1,4 +1,5 @@
 import { baseSubtag } from './pick-locale';
+import { pagePath } from './language-path';
 
 export interface TranslatedPage {
   slug: string;
@@ -53,11 +54,24 @@ export function buildHreflangAlternates({
   // One version is not a set of alternates — it is just the page.
   if (!origin || usable.length < 2) return [];
 
-  const href = (slug: string) => (slug === homepageSlug ? `${origin}/` : `${origin}/${slug}`);
+  // Standardspråket äger roten; andra språk får /lang/-prefix på gruppens
+  // basslugg. Samma pagePath som canonical, växlaren, navet och sitemapen —
+  // en hreflang-länk får aldrig peka på en form ingen annan använder.
+  const baseSlug = (
+    usable.find((t) => t.locale.toLowerCase() === String(defaultLanguage ?? '').toLowerCase())
+    ?? usable.find((t) => baseSubtag(t.locale) === baseSubtag(defaultLanguage))
+  )?.slug ?? null;
+
+  const href = (t: TranslatedPage) => {
+    const path = pagePath({
+      slug: t.slug, locale: t.locale, defaultLanguage, baseSlug, homepageSlug,
+    });
+    return path === '/' ? `${origin}/` : `${origin}${path}`;
+  };
 
   const alternates: HreflangAlternate[] = usable.map((t) => ({
     hreflang: t.locale.toLowerCase(),
-    href: href(t.slug),
+    href: href(t),
   }));
 
   const wanted = baseSubtag(defaultLanguage);
@@ -69,7 +83,7 @@ export function buildHreflangAlternates({
   // stranger should get, and guessing would send the wrong market to the wrong
   // page. Better to declare the pairs and let the engine choose.
   if (fallbackVersion) {
-    alternates.push({ hreflang: 'x-default', href: href(fallbackVersion.slug) });
+    alternates.push({ hreflang: 'x-default', href: href(fallbackVersion) });
   }
 
   return alternates;

--- a/src/lib/language-path.ts
+++ b/src/lib/language-path.ts
@@ -1,0 +1,80 @@
+import { baseSubtag } from './pick-locale';
+
+/**
+ * The address form for a translated page, in ONE place.
+ *
+ * The default language owns the root: `/product` is Swedish on a Swedish site,
+ * exactly as before — nothing the operator built moves. Every other language
+ * gets a prefix on the GROUP's base slug: `/en/product`, not `/product-en`.
+ *
+ * The `-en` suffix was the tooling's choice, not a design: the language lived
+ * in a naming convention. With the prefix it lives in the address's shape —
+ * scales to a third language (`/de/product`), and the base slug stays clean.
+ *
+ * This is ADDITIVE. Storage is untouched: the English row still has slug
+ * `product-en` in the database, and the old address still resolves (then
+ * redirects). The prefix is presentation on top, which is what makes the
+ * change safe days before a launch — the old path is the fallback.
+ *
+ * Seven consumers must agree on this shape — the page's canonical, the
+ * switcher, the nav, hreflang, the sitemap, the prerender and the redirect.
+ * Seven hand-rolled spellings is how one of them drifts, so they all call
+ * this.
+ */
+export interface PagePathInput {
+  /** The row's own slug, e.g. 'product-en'. */
+  slug: string;
+  /** The row's language. Missing means the site's own. */
+  locale?: string | null;
+  /** The site's declared default language. */
+  defaultLanguage: string;
+  /**
+   * The slug of the DEFAULT-language sibling in the same group, when known.
+   * That is what appears after the prefix: /en/product. Unknown (no sibling,
+   * or not yet loaded) falls back to the row's own slug — an uglier address
+   * that still resolves, never a broken one.
+   */
+  baseSlug?: string | null;
+  /** The slug served at '/'. Its path is the bare root, per language. */
+  homepageSlug?: string;
+}
+
+export function pagePath({ slug, locale, defaultLanguage, baseSlug, homepageSlug }: PagePathInput): string {
+  const lang = String(locale ?? '').trim().toLowerCase();
+  const isDefault = !lang || baseSubtag(lang) === baseSubtag(defaultLanguage);
+
+  if (isDefault) {
+    return slug === homepageSlug ? '/' : `/${slug}`;
+  }
+
+  const base = String(baseSlug ?? '').trim() || slug;
+  // The homepage in another language is the bare prefix: /en — not /en/home.
+  if (homepageSlug && base === homepageSlug) return `/${lang}`;
+  return `/${lang}/${base}`;
+}
+
+/**
+ * Reads a language prefix off a URL path, against the declared language set.
+ *
+ * `/en/product` → { lang: 'en', slug: 'product' }; `/en` → the English
+ * homepage; `/product` → no prefix. Only DECLARED non-default languages count
+ * as prefixes — `/blog/...` and every other route must never be mistaken for
+ * one, which is why this takes the enabled set instead of pattern-matching
+ * two-letter segments.
+ */
+export function splitLanguagePrefix(
+  path: string,
+  enabledLanguages: Iterable<string>,
+  defaultLanguage: string,
+): { lang: string | null; rest: string } {
+  const clean = String(path ?? '').replace(/\/+$/, '') || '/';
+  const segments = clean.split('/').filter(Boolean);
+  if (segments.length === 0) return { lang: null, rest: '/' };
+
+  const first = segments[0].toLowerCase();
+  const enabled = new Set([...enabledLanguages].map((l) => String(l).toLowerCase()));
+  const isPrefix = enabled.has(first) && baseSubtag(first) !== baseSubtag(defaultLanguage);
+  if (!isPrefix) return { lang: null, rest: clean };
+
+  return { lang: first, rest: '/' + segments.slice(1).join('/') };
+}

--- a/src/pages/PublicPage.tsx
+++ b/src/pages/PublicPage.tsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { useUiText, useSetUiTextLang } from '@/lib/ui-text';
+import { pagePath } from '@/lib/language-path';
 import { buildHreflangAlternates } from '@/lib/hreflang';
 import { operatorText } from '@/lib/operator-text';
 import { useSiteLanguages } from '@/hooks/useSiteSettings';
@@ -43,7 +44,7 @@ function parseContent(data: {
 
 export default function PublicPage() {
   const t = useUiText();
-  const { slug } = useParams<{ slug: string }>();
+  const { slug: slugParam, lang: langParam } = useParams<{ slug?: string; lang?: string }>();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { data: generalSettings } = useGeneralSettings();
@@ -59,7 +60,61 @@ export default function PublicPage() {
 
   // Use configured homepage slug, default to 'home'
   const homepageSlug = generalSettings?.homepageSlug || 'home';
-  const pageSlug = slug || homepageSlug;
+
+  // ── /en/-prefixet ────────────────────────────────────────────────────────
+  // Adressformen: standardspråket äger roten (/product), andra språk får
+  // prefix på GRUPPENS basslugg (/en/product), startsidan i annat språk är
+  // bara prefixet (/en). Ett prefix är ett prefix ENDAST när det är ett
+  // deklarerat icke-standardspråk — en sajt utan engelska behåller /en som
+  // vanlig slug, och /foo/bar förblir 404 precis som förut.
+  const { languages: enabledLanguages, defaultLanguage: siteDefault } = useSiteLanguages();
+  const enabledSet = new Set(enabledLanguages);
+  const isLangPrefix = (seg: string | undefined): seg is string =>
+    !!seg && enabledSet.has(seg.toLowerCase()) && seg.toLowerCase() !== siteDefault;
+
+  let urlLang: string | null = null;
+  let baseParam: string | undefined = slugParam;
+  if (langParam !== undefined) {
+    // Tvåsegmentsrutten: /:lang/:slug. Ett okänt förstasegment var 404 innan
+    // rutten fanns och ska förbli det.
+    if (isLangPrefix(langParam)) {
+      urlLang = langParam.toLowerCase();
+      baseParam = slugParam;
+    } else {
+      baseParam = '__no_such_page__';
+    }
+  } else if (isLangPrefix(slugParam)) {
+    // /en ensamt: den engelska startsidan.
+    urlLang = slugParam.toLowerCase();
+    baseParam = undefined;
+  }
+  const baseSlug = baseParam || homepageSlug;
+
+  // Prefixet pekar på basen; innehållet är SYSKONET i det språket. Uppslag via
+  // samma RPC som växlaren — endast publicerade syskon.
+  const { data: prefixTarget } = useQuery({
+    queryKey: ['lang-prefix-target', baseSlug, urlLang],
+    enabled: !!urlLang,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+    queryFn: async (): Promise<string | null> => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await supabase.rpc('get_page_translations' as any, { p_slug: baseSlug });
+      if (error) return null;
+      const list = ((data as { translations?: Array<{ slug: string; locale: string }> })?.translations) ?? [];
+      return list.find((x) => x.locale?.toLowerCase() === urlLang)?.slug ?? null;
+    },
+  });
+
+  // Ingen version i det språket → till basadressen, utan att låtsas. En sida
+  // får inte tyst bli ett annat språk; adressen ska säga vad den visar.
+  useEffect(() => {
+    if (urlLang && prefixTarget === null) {
+      navigate(baseParam ? `/${baseSlug}` : '/', { replace: true });
+    }
+  }, [urlLang, prefixTarget, baseSlug, baseParam, navigate]);
+
+  const pageSlug = urlLang ? (prefixTarget ?? baseSlug) : baseSlug;
 
   // Check auth state for dev mode protection
   useEffect(() => {
@@ -205,8 +260,11 @@ export default function PublicPage() {
     },
     staleTime: 5 * 60 * 1000, // 5 min client-side cache
     retry: false, // Don't retry on errors
-    // Wait for generalSettings to load before fetching homepage (when no explicit slug)
-    enabled: slug !== undefined || generalSettings !== undefined,
+    // Wait for generalSettings to load before fetching homepage (when no
+    // explicit slug), and for the sibling lookup when a language prefix must
+    // resolve first — otherwise the base page flashes before the right one.
+    enabled: (baseParam !== undefined || generalSettings !== undefined)
+      && (!urlLang || prefixTarget !== undefined),
   });
 
   // Smooth-scroll till #ankare — EFTER att sidan laddats: en tvärsideslänk
@@ -270,12 +328,15 @@ export default function PublicPage() {
   const { defaultLanguage: siteDefaultLanguage, isDeclared: siteLanguageIsDeclared } = useSiteLanguages();
   const setUiTextLang = useSetUiTextLang();
   useEffect(() => { setUiTextLang(declaredLang); }, [declaredLang, setUiTextLang]);
+
   const { data: translations } = useQuery({
     queryKey: ['page-translations', pageSlug],
     queryFn: async (): Promise<Array<{ slug: string; locale: string; title: string }>> => {
       try {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const { data, error } = await supabase.rpc('get_page_translations' as any, { p_slug: pageSlug });
+
+
         if (error) return [];
         return ((data as { translations?: Array<{ slug: string; locale: string; title: string }> })?.translations) ?? [];
       } catch {
@@ -286,6 +347,39 @@ export default function PublicPage() {
     staleTime: 5 * 60 * 1000,
     retry: false,
   });
+
+  // Adressformen: /product, /en/product eller /en. Beräknas HÄR — ovanför
+  // varje tidig return — eftersom effekten nedan är en hook: hamnar den efter
+  // en villkorlig return kastar React (#310) och felsidan tar över, vilket är
+  // exakt vad som hände första gången.
+  const groupBaseSlug = (translations ?? []).find(
+    (t2) => t2.locale?.toLowerCase() === siteDefault,
+  )?.slug ?? null;
+  const ownPath = pagePath({
+    slug: pageSlug,
+    locale: declaredLang,
+    defaultLanguage: siteDefault,
+    baseSlug: groupBaseSlug,
+    homepageSlug,
+  });
+
+  // Den gamla adressen (/product-en) lever men flyttar hem: en besökare via en
+  // gammal länk navigeras till prefixformen. Boten behöver inte flytten —
+  // rel=canonical pekar redan rätt.
+  //
+  // VÄNTA på syskonen: skjuter omdirigeringen innan translations laddats är
+  // basen okänd och adressen blir /en/<egen-slug> i stället för
+  // /en/<basslugg> — den fula formen fastnar, för väl där matchar språket och
+  // ingenting rättar den. Fångades i lokala provet.
+  useEffect(() => {
+    if (translations === undefined) return;
+    if (declaredLang && ownPath !== window.location.pathname
+        && ownPath.startsWith(`/${declaredLang.toLowerCase().split('-')[0]}`)) {
+      navigate(ownPath + window.location.search, { replace: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [translations, declaredLang, ownPath]);
+
 
   useEffect(() => {
     if (!requestedLang || !rawPageData || !translations) return;
@@ -448,9 +542,10 @@ export default function PublicPage() {
     );
   }
 
-  // Build canonical URL
+  // Build canonical URL — på adressformen (ownPath beräknas ovanför de tidiga
+  // return-satserna, tillsammans med legacy-omdirigeringen).
   const baseUrl = window.location.origin;
-  const canonicalUrl = `${baseUrl}/${pageSlug === homepageSlug ? '' : pageSlug}`;
+  const canonicalUrl = ownPath === '/' ? `${baseUrl}/` : `${baseUrl}${ownPath}`;
 
   // Språkversionerna deklareras för sökmotorerna. `translations` innehåller
   // sidan själv, vilket krävs — en uppsättning som utelämnar den nuvarande

--- a/supabase/functions/_shared/sitemap-alternates.ts
+++ b/supabase/functions/_shared/sitemap-alternates.ts
@@ -35,8 +35,38 @@ export interface AlternatesInput {
   pages: SitemapPage[];
   /** The site's declared default language, or '' when it has not declared one. */
   defaultLanguage: string;
-  /** Builds the absolute URL for a slug — shared with the <loc> so they agree. */
-  href: (slug: string) => string;
+  /** Origin without a trailing slash. */
+  baseUrl: string;
+  /** The slug served at '/'. */
+  homepageSlug: string;
+}
+
+export interface SitemapAddressing {
+  /** slug → the canonical PATH for that row ('/en/product', '/product', '/'). */
+  canonicalPath: Map<string, string>;
+  /** slug → the alternates to nest inside that page's <url> entry. */
+  alternates: Map<string, Array<{ hreflang: string; href: string }>>;
+}
+
+/**
+ * The address form, mirrored from src/lib/language-path.ts — the edge bundle
+ * cannot reach src/, so this is a twin like pick_locale's SQL side. The shared
+ * cases are pinned in sitemap-alternates.guardrails.test.ts; change one,
+ * change both.
+ */
+function pagePath(
+  slug: string,
+  locale: string | null | undefined,
+  defaultLanguage: string,
+  baseSlug: string | null,
+  homepageSlug: string,
+): string {
+  const lang = String(locale ?? '').trim().toLowerCase();
+  const isDefault = !lang || baseSubtag(lang) === baseSubtag(defaultLanguage);
+  if (isDefault) return slug === homepageSlug ? '/' : `/${slug}`;
+  const base = String(baseSlug ?? '').trim() || slug;
+  if (homepageSlug && base === homepageSlug) return `/${lang}`;
+  return `/${lang}/${base}`;
 }
 
 /**
@@ -44,35 +74,56 @@ export interface AlternatesInput {
  *   A slug missing from the map has none.
  */
 export function sitemapAlternates(
-  { pages, defaultLanguage, href }: AlternatesInput,
-): Map<string, Array<{ hreflang: string; href: string }>> {
+  { pages, defaultLanguage, baseUrl, homepageSlug }: AlternatesInput,
+): SitemapAddressing {
+  const origin = String(baseUrl ?? '').replace(/\/+$/, '');
+  const wanted = baseSubtag(defaultLanguage);
+  const abs = (path: string) => (path === '/' ? `${origin}/` : `${origin}${path}`);
+
   const groups = new Map<string, SitemapPage[]>();
+  const canonicalPath = new Map<string, string>();
   for (const page of pages ?? []) {
-    const group = page?.translation_group_id;
-    if (!group || !page.slug || !page.locale) continue;
+    if (!page?.slug) continue;
+    // Varje rad får en kanonisk sökväg — även de ogrupperade, som alltid bor
+    // på roten i sajtens eget språk.
+    const group = page.translation_group_id;
+    if (!group || !page.locale) {
+      canonicalPath.set(page.slug, pagePath(page.slug, null, defaultLanguage, null, homepageSlug));
+      continue;
+    }
     if (!groups.has(group)) groups.set(group, []);
     groups.get(group)!.push(page);
   }
 
-  const out = new Map<string, Array<{ hreflang: string; href: string }>>();
-  const wanted = baseSubtag(defaultLanguage);
+  const alternates = new Map<string, Array<{ hreflang: string; href: string }>>();
 
   for (const siblings of groups.values()) {
+    const baseSlug = (
+      siblings.find((s) => String(s.locale).toLowerCase() === String(defaultLanguage ?? '').toLowerCase())
+      ?? (wanted ? siblings.find((s) => baseSubtag(String(s.locale)) === wanted) : undefined)
+    )?.slug ?? null;
+
+    for (const sibling of siblings) {
+      canonicalPath.set(
+        sibling.slug,
+        pagePath(sibling.slug, sibling.locale, defaultLanguage, baseSlug, homepageSlug),
+      );
+    }
+
     if (siblings.length < 2) continue;
 
-    const alternates = siblings.map((s) => ({
+    const set = siblings.map((s) => ({
       hreflang: String(s.locale).toLowerCase(),
-      href: href(s.slug),
+      href: abs(canonicalPath.get(s.slug)!),
     }));
-
     const fallback = wanted
       ? (siblings.find((s) => String(s.locale).toLowerCase() === String(defaultLanguage).toLowerCase())
         ?? siblings.find((s) => baseSubtag(String(s.locale)) === wanted))
       : undefined;
-    if (fallback) alternates.push({ hreflang: 'x-default', href: href(fallback.slug) });
+    if (fallback) set.push({ hreflang: 'x-default', href: abs(canonicalPath.get(fallback.slug)!) });
 
-    for (const sibling of siblings) out.set(sibling.slug, alternates);
+    for (const sibling of siblings) alternates.set(sibling.slug, set);
   }
 
-  return out;
+  return { canonicalPath, alternates };
 }

--- a/supabase/functions/sitemap/index.ts
+++ b/supabase/functions/sitemap/index.ts
@@ -58,14 +58,19 @@ Deno.serve(async (req) => {
       (langRow?.value as { default?: string } | null)?.default ?? '',
     ).toLowerCase();
 
-    // The SAME function that builds <loc>, so an alternate can never point
-    // somewhere the sitemap does not also list.
-    const pageHref = (slug: string) => (slug === 'home' ? baseUrl : `${baseUrl}/${slug}`);
-    const alternates = sitemapAlternates({
+    // Adressformen ägs av sitemapAlternates: standardspråket på roten, andra
+    // språk som /lang/<basslugg>. <loc> och alternativen kommer ur SAMMA karta,
+    // så en alternativlänk aldrig kan peka på en form sitemapen inte listar.
+    const { canonicalPath, alternates } = sitemapAlternates({
       pages: (pages || []) as SitemapPage[],
       defaultLanguage: siteDefaultLanguage,
-      href: pageHref,
+      baseUrl,
+      homepageSlug: 'home',
     });
+    const pageHref = (slug: string) => {
+      const path = canonicalPath.get(slug) ?? (slug === 'home' ? '/' : `/${slug}`);
+      return path === '/' ? baseUrl : `${baseUrl}${path}`;
+    };
 
     // Build XML
     const entries: string[] = [];

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2255,7 +2255,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:3be3a1a95cd7511901011a011e70d5d6b188ece40c0e7e19a14276bd5d577433",
+      "shared_hash": "sha256:c533b34d9b45aa1c5ccce03578ee2a254bb974e423e8f42eb151dfd7d6269bb4",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
@@ -2320,7 +2320,7 @@
         "setup-database": "sha256:49f03dc85ea4d48cd53b7760b0a68f4e2a628a217207b0fe4590d931f594e56e",
         "signal-dispatcher": "sha256:a76e992430f13d05003a0e00ba622c239006fc853531400d88a1f238310c90dc",
         "signal-ingest": "sha256:b7bf9c636845229394e12d2cec9b78da6657b3a321775f65063e53794eb0ea3d",
-        "sitemap": "sha256:cd836c71f091df075e0ddc1dd49d2334e7ad876a654f0e95e6ee563c0313e69a",
+        "sitemap": "sha256:8173e345621b97184ce181684590e9389a952d473368c5c83c834bbc813e9180",
         "stripe-webhook": "sha256:7be2d24d1a70818815e6aa829d6f7b1ed83877172a2f8ed50c98af98ae180072",
         "subscription-billing-cron": "sha256:d3a4089951cbc82379b1f667b1d5b98503961e4364ab811617b4c5d5a6036663",
         "subscriptions": "sha256:d3ac2a631b793a4507315d92f144c69a3697ffc6a0186b6bbc3d7cda05a46a33",


### PR DESCRIPTION
Språket bodde i ett slug-suffix (`product-en`): fungerande, men verktygsvalt. Nu bor det i adressens **form**: standardspråket äger roten (`/product`), andra språk får prefix på **gruppens basslugg** (`/en/product`), startsidan i annat språk är bara prefixet (`/en`).

## Additivt — det är vad som gör det säkert före en lansering
- **Lagringen orörd** — raderna behåller sina `-en`-sluggar; prefixet är presentation ovanpå
- **Gamla adressen lever**: `/product-en` renderar och navigeras hem till `/en/product`; boten behöver inte flytten, `rel=canonical` pekar redan rätt
- **Ett prefix räknas endast när det är ett deklarerat icke-standardspråk** — `/blog/...` och en sajt utan engelska behåller sina betydelser, och en sida som råkar heta `en` skyddas av deklarationen
- **Saknad version i språket** → ärligt till basen, aldrig tyst ett annat språk

## En ägare av formen
`pagePath()` i `language-path.ts`; **sju konsumenter** anropar den: canonical, växlaren, navet, hreflang, sitemapen, prerendern och omdirigeringen. Sitemapens edge-tvilling speglar den (bundlingen når inte `src/`) — pinnad med samma falltabell. Prerendern importerar `src/lib` direkt och hoppar till syskonet i prefixets språk.

## Tre fel hittade i det lokala webbläsarprovet
1. Min omdirigerings-hook hamnade **efter tidiga returns** → React #310 → felsidan tog över varje sida
2. En blockflytt landade **mitt i en queryFn** — ankarsökning på `});` är farlig
3. Legacy-omdirigeringen sköt **innan syskonen laddats** → `/en/<egen-slug>` fastnade som adress; den väntar nu på basen

## Och en gåta löst
*"Helmet är inert lokalt"* — mysteriet som ätit timmar — var **bakgrundsflikens rAF-frys**: react-helmet-async spolar via `requestAnimationFrame`, och en dold browserpanel fryser den. Därför fungerade allt live och ingenting i dold flik.

## Verifierat (produktionsbygge mot lokal Supabase)
| | |
|---|---|
| `/en/sprakprov` | engelska innehållet, adressen står kvar |
| `/language-test` | hem till `/en/sprakprov` |
| `/en/ensam` (ingen engelsk version) | ärligt till `/ensam` |
| 10 nya kontraktstest på `pagePath`/`splitLanguagePrefix` | gröna |
| hreflang/sitemap-kontrakten uppdaterade till prefixformen | gröna |
| tsc / 3642 tester / doc-drift | gröna |

Verifieras live på optictunnels.se efter deploy (sitemapen kräver edge-deploy via forkens workflow — den kör på push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)