### PR TITLE
fix(seo): AI-hämtarna får läsa sajten — de stod inte i prerender-listan

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,7 @@
         {
           "type": "header",
           "key": "user-agent",
-          "value": ".*(facebookexternalhit|Facebot|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|TelegramBot|Pinterest|redditbot|vkShare|Embedly|Iframely|SkypeUriPreview).*"
+          "value": ".*(facebookexternalhit|Facebot|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|TelegramBot|Pinterest|redditbot|vkShare|Embedly|Iframely|SkypeUriPreview|GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|Claude-User|Claude-SearchBot|anthropic-ai|PerplexityBot|Perplexity-User|Meta-ExternalAgent|Amazonbot|DuckAssistBot|YouBot|cohere-ai|MistralAI).*"
         }
       ],
       "dest": "/api/og?path=/$1"


### PR DESCRIPTION
Peter länkade optictunnels.eu i ChatGPT och den extraherade **0 rader** — hämtade i stället allt från LinkedIn. Hans diagnos var korrekt: sajten är en JS-app, och prerendern körde bara för **sociala** botar. LinkedIn stod i listan; GPTBot gjorde det inte.

Verifierat med curl innan fixen:

```
UA=ChatGPT-User → TOMT SKAL
UA=GPTBot      → TOMT SKAL
UA=facebookexternalhit → fullt serverrenderat huvud + innehåll
```

## Fixen
14 AI-hämtare in i user-agent-listan: GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, Claude-User, Claude-SearchBot, PerplexityBot, Perplexity-User, Meta-ExternalAgent, Amazonbot, DuckAssistBot, YouBot, cohere-ai, MistralAI. De får samma serverrenderade vy som de sociala botarna: titel, beskrivning, språk, hreflang och sidans kärntext.

`llms.txt` fanns redan och är den rikare AI-ytan — men en agent som får ett tomt skal letar inte vidare. Nu får den något att läsa på första försöket.

En rads diff i `vercel.json`; gäller alla instanser vid nästa deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)