### PR TITLE
fix(seo): dev-lägets noindex når prerendern — löftet gällde bara JS-botar

### DIFF
--- a/api/og.ts
+++ b/api/og.ts
@@ -187,6 +187,9 @@ export default async function handler(req: Request): Promise<Response> {
   const tags = [
     `<title>${esc(fullTitle)}</title>`,
     description && `<meta name="description" content="${esc(description)}">`,
+    // Dev mode promises "hidden from search engines", but the client-side tag
+    // only reaches JS-running crawlers — the prerendered head must carry it too.
+    (byKeyOuter.seo || {}).developmentMode === true && '<meta name="robots" content="noindex, nofollow">',
     `<meta property="og:type" content="${isArticle ? 'article' : 'website'}">`,
     `<meta property="og:title" content="${esc(fullTitle)}">`,
     description && `<meta property="og:description" content="${esc(description)}">`,


### PR DESCRIPTION
Uppföljning på Peter-spåret. Magnus har dev-läget på: *"All pages are hidden from search engines (noindex, nofollow)"*. Men taggen sattes **client-side** via Helmet — botarna på prerender-vägen (sociala, och sedan #405 även AI-hämtarna) fick ett huvud **utan** noindex. Verifierat med curl som GPTBot mot optictunnels.se med dev-läget på: noll `noindex`-träffar. Google kör JS och ser taggen till slut; alla andra såg den aldrig.

Prerendern läser redan `seo`-nyckeln, så fixen är en rad: `developmentMode === true` ⇒ `<meta name="robots" content="noindex, nofollow">` i det serverrenderade huvudet. Client-sidan orörd.

Notera samspelet med #405: AI-botarna får nu **läsa** sajten (Peters ärende — länkdelning i ChatGPT ska funka), och dev-läget säger samtidigt ärligt åt dem att inte **indexera** förrän lanseringen. Läsning och indexering är olika saker; nu uttrycker huvudet båda korrekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)