### PR TITLE
fix(admin): mejlsidan in i vänsterpanelen — mallytan krävde djuplänk

### DIFF
--- a/src/components/admin/adminNavigation.ts
+++ b/src/components/admin/adminNavigation.ts
@@ -7,6 +7,7 @@ import {
   BookOpen,
   Image,
   Mail,
+  MailOpen,
   Puzzle,
   UserCheck,
   Briefcase,
@@ -159,6 +160,7 @@ export const navigationGroups: NavGroup[] = [
       { name: "WebMeet", href: "/admin/webmeet", icon: Video, moduleId: "webmeet" },
       { name: "Forms", href: "/admin/forms", icon: Inbox, moduleId: "forms" },
       { name: "Communications", href: "/admin/communications", icon: Mail, moduleId: "email" },
+      { name: "Email", href: "/admin/email", icon: MailOpen, moduleId: "email" },
     ],
   },
   {


### PR DESCRIPTION
`/admin/email` — Templates, Threads, Signatures, Suppressions — fanns inte i vänsterpanelen; enda vägen in var djuplänken från modulkortet. Magnus hittade den inte när han skulle redigera de svenska mallversionerna, och det är operatörens redigeringsyta för allt utgående mejl.

**"Email"** läggs bredvid **"Communications"** (loggen + routern) i Marketing-gruppen, samma `moduleId: "email"` — rollmatrisen gäller alltså oförändrad, ingen ny gating.

tsc + admin-testerna gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)