### PR TITLE
fix(i18n): anteckningsrutan bor i mallen — sista engelska etiketten ut ur bokningsbekräftelsen

### DIFF
--- a/docs/architecture/language.md
+++ b/docs/architecture/language.md
@@ -173,6 +173,15 @@ insert trigger would otherwise stamp the site's language onto templates that
 are written in English. All language lives in the template text (labels
 included); the sender prerenders only data: item rows, amounts, links.
 
+Conditional text is expressed in the template too, never in code:
+`{{#notes}}…{{/notes}}` keeps its content when the variable is filled and
+disappears when it is empty (one engine for senders and the admin preview:
+`_shared/template-render.ts`; sections do not nest). This is what moved the
+booking note box — label and all — out of `booking_confirmation.ts` and into
+the template (migration `20260903190000`); the code-rendered `{{notes_block}}`
+variable, English label baked in, is still sent for templates that predate the
+move, but new templates use the section.
+
 Still hardcoded: invoice_email, order_confirmation and the rest of comms-send —
 same recipe when they matter.
 

--- a/src/lib/__tests__/template-render.test.ts
+++ b/src/lib/__tests__/template-render.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The one substitution engine for email templates — sections included.
+ *
+ * The rule under test is the language rule (docs/architecture/language.md
+ * §Email templates): ALL language lives in the template text, the sender sends
+ * only data. `{{#notes}}…{{/notes}}` is what makes a labelled, conditional box
+ * expressible IN the template — before it, booking_confirmation prerendered
+ * the whole box in code with a hardcoded English "Your note:" label.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderTemplate } from '../../../supabase/functions/_shared/template-render';
+import { renderTokens, detectTokens, buildSampleValues } from '../email-preview';
+
+describe('renderTemplate', () => {
+  it('substitutes plain tokens, unknown keys render empty', () => {
+    expect(renderTemplate('Hi {{name}}, re {{missing}}!', { name: 'Anna' })).toBe('Hi Anna, re !');
+  });
+
+  it('tolerates whitespace and dots/hyphens in tokens (email-send legacy charset)', () => {
+    expect(renderTemplate('{{ a.b-c }}', { 'a.b-c': 'x' })).toBe('x');
+  });
+
+  it('keeps a section when the variable is non-empty', () => {
+    const tpl = 'before {{#notes}}<strong>Din anteckning:</strong> {{notes}}{{/notes}} after';
+    expect(renderTemplate(tpl, { notes: 'ring mig' })).toBe(
+      'before <strong>Din anteckning:</strong> ring mig after',
+    );
+  });
+
+  it('drops the whole section — label included — when the variable is empty or missing', () => {
+    const tpl = 'before {{#notes}}<strong>Your note:</strong> {{notes}}{{/notes}}after';
+    expect(renderTemplate(tpl, { notes: '' })).toBe('before after');
+    expect(renderTemplate(tpl, {})).toBe('before after');
+  });
+
+  it('handles several independent sections in one template', () => {
+    const tpl = '{{#a}}A={{a}}{{/a}}|{{#b}}B={{b}}{{/b}}';
+    expect(renderTemplate(tpl, { a: '1' })).toBe('A=1|');
+    expect(renderTemplate(tpl, { a: '1', b: '2' })).toBe('A=1|B=2');
+  });
+
+  it('spans newlines — templates are multi-line HTML', () => {
+    expect(renderTemplate('{{#x}}\nline\n{{/x}}', { x: 'y' })).toBe('\nline\n');
+    expect(renderTemplate('{{#x}}\nline\n{{/x}}', {})).toBe('');
+  });
+
+  it('legacy {{notes_block}} keeps working as a plain token (backward compat)', () => {
+    expect(renderTemplate('{{notes_block}}', { notes_block: '<div>x</div>' })).toBe('<div>x</div>');
+    expect(renderTemplate('{{notes_block}}', { notes_block: '' })).toBe('');
+  });
+});
+
+describe('admin preview uses the same engine', () => {
+  it('renderTokens strips section markers exactly like the sender', () => {
+    const tpl = '{{#notes}}<strong>Your note:</strong> {{notes}}{{/notes}}';
+    expect(renderTokens(tpl, { notes: 'hej' })).not.toContain('{{#notes}}');
+    expect(renderTokens(tpl, { notes: 'hej' })).toContain('hej');
+    expect(renderTokens(tpl, {})).toBe('');
+  });
+
+  it('detectTokens sees the inner variable, not the markers, so the sample fills the section', () => {
+    const tpl = 'a {{#notes}}{{notes}}{{/notes}} {{site_name}}';
+    const tokens = detectTokens(tpl);
+    expect(tokens).toContain('notes');
+    expect(tokens).toContain('site_name');
+    expect(tokens).not.toContain('#notes');
+    const rendered = renderTokens(tpl, buildSampleValues(tokens));
+    expect(rendered).not.toContain('{{');
+  });
+});

--- a/src/lib/email-preview.ts
+++ b/src/lib/email-preview.ts
@@ -12,6 +12,7 @@ import {
   wrapInShell,
   type EmailShell,
 } from '../../supabase/functions/_shared/email-shell';
+import { renderTemplate } from '../../supabase/functions/_shared/template-render';
 import type { BrandingSettings, GeneralSettings } from '@/hooks/useSiteSettings';
 
 export { wrapInShell, type EmailShell };
@@ -85,7 +86,11 @@ export function buildSampleValues(tokens: string[]): Record<string, string> {
   return Object.fromEntries(tokens.map((t) => [t, sampleValueFor(t)]));
 }
 
-/** Same substitution rule as `renderTemplate` in email-send. */
+/**
+ * THE substitution engine the senders use (_shared/template-render), sections
+ * included — a preview with its own copy of the rule would show literal
+ * {{#notes}} markers the sent mail never contains.
+ */
 export function renderTokens(input: string, vars: Record<string, string>): string {
-  return (input ?? '').replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (_, k) => vars[k] ?? '');
+  return renderTemplate(input ?? '', vars);
 }

--- a/supabase/functions/_shared/template-render.ts
+++ b/supabase/functions/_shared/template-render.ts
@@ -1,0 +1,30 @@
+/**
+ * Template rendering for email_templates — the one substitution engine.
+ *
+ * Two passes:
+ *
+ *   1. Sections — `{{#key}}…{{/key}}` keeps its inner content when `vars.key`
+ *      is non-empty and disappears entirely when it is empty or missing. This
+ *      is what lets ALL language live in the template text (the rule from
+ *      docs/architecture/language.md §Email templates): a labelled box like
+ *      `{{#notes}}<strong>Your note:</strong> {{notes}}{{/notes}}` is template
+ *      text an operator can translate, where a code-built `notes_block`
+ *      variable froze its label in English. Sections do not nest — none of the
+ *      templates need it, and a non-nesting rule is one a template editor can
+ *      hold in their head.
+ *
+ *   2. Tokens — `{{key}}` → value; unknown keys render as ''. The permissive
+ *      charset (`[\w.-]`, optional inner whitespace) is inherited from
+ *      email-send's original renderer, which this replaces.
+ *
+ * Consumers: the comms-send senders, email-send's `template_name` path, and
+ * the admin preview (src/lib/email-preview.ts) — one engine, so the preview
+ * cannot drift from the sent mail.
+ */
+export function renderTemplate(input: string, vars: Record<string, string> = {}): string {
+  const withSections = (input ?? '').replace(
+    /\{\{\s*#([\w.-]+)\s*\}\}([\s\S]*?)\{\{\s*\/\1\s*\}\}/g,
+    (_m, key: string, inner: string) => (vars[key] ? inner : ''),
+  );
+  return withSections.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (_m, k: string) => vars[k] ?? '');
+}

--- a/supabase/functions/comms-send/booking_confirmation.ts
+++ b/supabase/functions/comms-send/booking_confirmation.ts
@@ -1,6 +1,7 @@
 // Moved VERBATIM from supabase/functions/send-booking-confirmation/index.ts (edge-surface B2).
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.87.1";
 import { getServiceClient } from '../_shared/supabase-clients.ts';
+import { renderTemplate } from '../_shared/template-render.ts';
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -14,6 +15,10 @@ interface BookingConfirmationRequest {
 interface EmailConfig {
   fromEmail: string;
   fromName: string;
+}
+
+function escapeHtml(s: string) {
+  return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
 }
 
 export const handler = async (req: Request): Promise<Response> => {
@@ -294,14 +299,22 @@ export const handler = async (req: Request): Promise<Response> => {
           date: formattedDate,
           start_time: formattedStartTime,
           end_time: formattedEndTime,
+          // Anteckningen är DATA. Rutan och dess etikett bor i mallen som en
+          // {{#notes}}-sektion (seedbytet i 20260903190000) — annars kan
+          // etiketten aldrig översättas, och en svensk mottagare fick
+          // "Your note:" ur koden.
+          notes: escapeHtml(booking.notes ?? ''),
+          // Legacy: mallar från före sektionssyntaxen bär hela rutan som
+          // variabel, engelsk etikett inklusive. Behålls så en operatörs
+          // gamla omskrivning fortsätter rendera — nya mallar använder
+          // {{#notes}}…{{/notes}}.
           notes_block: booking.notes
             ? `<div style="background:#f3f4f6;border-radius:8px;padding:12px 16px;margin:16px 0;"><p style="margin:0;"><strong>Your note:</strong> ${booking.notes}</p></div>`
             : '',
           site_name: siteName,
         };
-        const render = (t: string) => t.replace(/\{\{(\w+)\}\}/g, (_, k) => vars[k] ?? '');
-        templateHtml = render(tpl.html);
-        templateSubject = tpl.subject ? render(tpl.subject) : null;
+        templateHtml = renderTemplate(tpl.html, vars);
+        templateSubject = tpl.subject ? renderTemplate(tpl.subject, vars) : null;
         if (recipientLang && tpl.locale && tpl.locale !== recipientLang.toLowerCase()) {
           console.warn(`[send-booking-confirmation] no ${recipientLang} template — sent the ${tpl.locale} one`);
         }

--- a/supabase/functions/comms-send/contract_email.ts
+++ b/supabase/functions/comms-send/contract_email.ts
@@ -8,6 +8,7 @@
 // expects_reply, since a signing request is a conversation the customer may
 // reply to.
 import { getServiceClient } from '../_shared/supabase-clients.ts';
+import { renderTemplate } from '../_shared/template-render.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -117,9 +118,8 @@ export async function handler(req: Request): Promise<Response> {
         cta_url: link,
         custom_block: custom,
       };
-      const render = (t: string) => t.replace(/\{\{(\w+)\}\}/g, (_, k) => vars[k] ?? '');
-      html = render(tpl.html);
-      subject = tpl.subject ? render(tpl.subject)
+      html = renderTemplate(tpl.html, vars);
+      subject = tpl.subject ? renderTemplate(tpl.subject, vars)
         : `Agreement ${contract.contract_number} from ${siteName} — ready to sign`;
       if (recipientLang && tpl.locale && tpl.locale !== recipientLang.toLowerCase()) {
         console.warn(`[contract-email] no ${recipientLang} template for ${templateKind} — sent the ${tpl.locale} one`);

--- a/supabase/functions/comms-send/quote_email.ts
+++ b/supabase/functions/comms-send/quote_email.ts
@@ -3,6 +3,7 @@
 // driven by `site_settings.integrations.email.config.provider`.
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0';
 import { getServiceClient } from '../_shared/supabase-clients.ts';
+import { renderTemplate } from '../_shared/template-render.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -205,9 +206,8 @@ export async function handler(req: Request): Promise<Response> {
         custom_block: body.custom_message
           ? `<p style="margin:0 0 16px;white-space:pre-wrap">${escapeHtml(body.custom_message)}</p>` : '',
       };
-      const render = (t: string) => t.replace(/\{\{(\w+)\}\}/g, (_, k) => vars[k] ?? '');
-      html = render(tpl.html);
-      subject = tpl.subject ? render(tpl.subject) : `Quote ${quote.quote_number} from ${siteName}`;
+      html = renderTemplate(tpl.html, vars);
+      subject = tpl.subject ? renderTemplate(tpl.subject, vars) : `Quote ${quote.quote_number} from ${siteName}`;
       if (recipientLang && tpl.locale && tpl.locale !== recipientLang.toLowerCase()) {
         console.warn(`[quote-email] no ${recipientLang} template for ${templateKind} — sent the ${tpl.locale} one`);
       }

--- a/supabase/functions/email-send/index.ts
+++ b/supabase/functions/email-send/index.ts
@@ -10,6 +10,7 @@
 // Body: { to, subject, html, text?, fromOverride?, tags? }
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { filterRecipients, blockedResponse } from '../_shared/email-allowlist.ts';
+import { renderTemplate } from '../_shared/template-render.ts';
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { getServiceClient } from '../_shared/supabase-clients.ts';
 import { SMTPClient } from "https://deno.land/x/denomailer@1.6.0/mod.ts";
@@ -48,9 +49,6 @@ interface SendBody {
   extra_metadata?: Record<string, unknown>;
 }
 
-function renderTemplate(input: string, vars: Record<string, string> = {}): string {
-  return input.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (_, k) => vars[k] ?? "");
-}
 
 
 interface EmailSettings {

--- a/supabase/migrations/20260903190000_anteckningen-bor-i-mallen.sql
+++ b/supabase/migrations/20260903190000_anteckningen-bor-i-mallen.sql
@@ -1,0 +1,72 @@
+-- Anteckningen bor i mallen.
+--
+-- Bokningsbekräftelsens mall gick genom mallrälsen (20260828170000) — men EN
+-- rad språktext blev kvar i koden: {{notes_block}} prerendrade hela
+-- anteckningsrutan i booking_confirmation.ts, engelsk etikett ("Your note:")
+-- inklusive. En svensk mottagare med svensk mall fick en engelsk etikettrad
+-- mitt i mejlet, och ingenting en operatör kunde redigera. Brott mot regeln i
+-- docs/architecture/language.md §Email templates: ALL språktext bor i mallen,
+-- koden prerendrar bara DATA.
+--
+-- Fixen är i render(): comms-send förstår nu {{#notes}}…{{/notes}} — sektionen
+-- behålls när variabeln är ifylld och stryks när den är tom. Rutan OCH dess
+-- etikett flyttar in i mallens HTML; koden skickar bara {{notes}} (data).
+--
+-- Bytet nedan är OUTPUT-IDENTISKT: sektionen renderar exakt den div koden
+-- byggde, tecken för tecken. Därför får den röra även en operatörs omskrivna
+-- mall — mottagaren ser ingen skillnad, men etiketten blir redigerbar. Svenska
+-- rader (locale sv*) får svensk etikett direkt; det är ju hela ärendet.
+--
+-- Bakåtkompatibilitet: koden fortsätter skicka {{notes_block}} (legacy), så en
+-- mall som återinför variabeln — eller en instans där den här migrationen
+-- aldrig körs — renderar som förr. Framåtvägen är sektionen.
+
+UPDATE public.email_templates
+   SET html = replace(
+         html,
+         '{{notes_block}}',
+         '{{#notes}}<div style="background:#f3f4f6;border-radius:8px;padding:12px 16px;margin:16px 0;"><p style="margin:0;"><strong>'
+           || CASE WHEN locale LIKE 'sv%' THEN 'Din anteckning:' ELSE 'Your note:' END
+           || '</strong> {{notes}}</p></div>{{/notes}}'
+       ),
+       variables = (coalesce(variables, '[]'::jsonb) - 'notes_block')
+                   || CASE WHEN coalesce(variables, '[]'::jsonb) ? 'notes'
+                           THEN '[]'::jsonb ELSE '["notes"]'::jsonb END,
+       updated_at = now()
+ WHERE name = 'booking_confirmation'
+   AND html LIKE '%{{notes_block}}%';
+
+-- ── Bevisas där den körs ───────────────────────────────────────────────────
+DO $$
+DECLARE v jsonb; v_html text;
+BEGIN
+  PERFORM set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+  -- Ingen rad får längre bära den kodrendrade rutan.
+  IF EXISTS (
+    SELECT 1 FROM public.email_templates
+     WHERE name = 'booking_confirmation' AND html LIKE '%{{notes_block}}%'
+  ) THEN
+    RAISE EXCEPTION 'booking_confirmation: {{notes_block}} survived the move into the template';
+  END IF;
+
+  -- Mallen måste fortfarande gå att lösa ut och sektionen vara balanserad —
+  -- men bara om en aktiv mall alls finns: en operatör som raderat eller
+  -- inaktiverat sin (koden har ju en inbyggd fallback) ska inte fälla
+  -- migrationskörningen.
+  IF EXISTS (
+    SELECT 1 FROM public.email_templates
+     WHERE name = 'booking_confirmation' AND active
+  ) THEN
+    v := public.resolve_email_template('booking_confirmation', NULL);
+    IF NOT coalesce((v ->> 'ok')::boolean, false) THEN
+      RAISE EXCEPTION 'booking_confirmation: an active template exists but does not resolve';
+    END IF;
+    v_html := v ->> 'html';
+    IF v_html LIKE '%{{#notes}}%' AND v_html NOT LIKE '%{{/notes}}%' THEN
+      RAISE EXCEPTION 'booking_confirmation: unbalanced {{#notes}} section';
+    END IF;
+  END IF;
+
+  RAISE NOTICE 'booking_confirmation: the note box (label included) lives in the template';
+END $$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260903170000",
-      "migrations_count": 561,
+      "migration_head": "20260903190000",
+      "migrations_count": 562,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2249,6 +2249,10 @@
         {
           "version": "20260903170000",
           "name": "oversattningsdriften-sags-hogt"
+        },
+        {
+          "version": "20260903190000",
+          "name": "anteckningen-bor-i-mallen"
         }
       ]
     },
@@ -2259,7 +2263,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:aecb72c73f8d2a108e26494fed68d8a2110937312e39a3bd05578dccd4538a6d",
+      "shared_hash": "sha256:beeab2bcc5a71646a2d657d4345718e2563abaf775c5ebdf1a948ffcc7715016",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
@@ -2272,7 +2276,7 @@
         "chat-completion": "sha256:d840d8aa54a221a3a59a3b114285c60a018ef13670f76d8bcb0a71b41ff5437c",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
-        "comms-send": "sha256:106bc132612208bdeafbaaa96157ecdfc016042bf5764af4c09100580ed2a1b4",
+        "comms-send": "sha256:3074f89675ae1eb93c7f486298d19b671b6f33a23edd7ef35d11b3991ba63d0c",
         "composio-proxy": "sha256:08477e4658cee04b6a09458a5e8dc45fbf9737c2188f7b972ae954782a4bdc95",
         "composio-webhook": "sha256:27f17b7198bfbab422931ef1c872da083299e095792e43b98b4154ec79c858ca",
         "consultant-match": "sha256:1419717affb3711a2d7f13d44c9a228e1557a3d927e3aa05ee5e179584131e1b",
@@ -2290,7 +2294,7 @@
         "document-sign-request": "sha256:1df2d2989368c711d2ad0dbac629c754804bde795f0e081ae9c7892f0a193be3",
         "dunning-processor": "sha256:e05e55a6624859ed9f36f296aa5eccbb313f5d70f861a84067af4a4738b12679",
         "elks46-ingest": "sha256:7c9211df6847396b20cc5d1bf537a61767119e48c0c2bfb5e40bc10e2b9f075f",
-        "email-send": "sha256:dd16d71530bd31384d8f4d188f600640c57632c38b3248a3d156000199c5cf11",
+        "email-send": "sha256:3d52b70a3ebe9d7dfce8f00525089f48e60354a024fa340221ff1a2a7a74eb68",
         "email-webhook": "sha256:2593b55c6730a00efc698b948de37f7aace1f916e8d2ee1dafd9f3014d5cf1a4",
         "event-dispatcher": "sha256:1226b1ce317cb70cfdae46441f59499f8559b159fd08ee5063105ebfd98e5aa0",
         "extract-pdf-text": "sha256:80474c20ca8c39ba6bbf8bcb7e2be777632b312915a4c48a13a92fb2dcc0cdfe",


### PR DESCRIPTION
## Problemet

`comms-send/booking_confirmation.ts` byggde `notes_block` i koden med hårdkodad engelsk etikett **"Your note:"** — ett brott mot regeln att ALL språktext bor i mallen (`docs/architecture/language.md` §Email templates, jfr migration `20260903150000`). En svensk mottagare med svensk mall fick en engelsk etikettrad mitt i mejlet när kunden skrivit en anteckning, och ingenting en operatör kunde redigera.

## Lösningen

**En delad rendermotor med sektionssyntax** — `supabase/functions/_shared/template-render.ts`:

- `{{#notes}}…{{/notes}}` behålls när variabeln är ifylld, stryks helt (etikett inklusive) när den är tom. Sektioner nästlar inte.
- Tokenpasset ärver email-sends permissiva regex (`[\w.-]`, valfri whitespace) — superset av comms-sends gamla `(\w+)`.
- **En motor, fyra konsumenter:** booking/quote/contract i comms-send (tre identiska inline-kopior borta), email-sends `template_name`-väg, och adminpreviewen (`src/lib/email-preview.ts` → `renderTokens`). Previewen kan därmed inte visa literala `{{#notes}}`-markörer som det skickade mejlet saknar.

**booking_confirmation** skickar nu `notes` som ren data (HTML-escapad — anteckningen är besökartext). `{{notes_block}}` behålls som legacyvariabel så mallar från före flytten fortsätter rendera exakt som förr.

**Migration `20260903190000_anteckningen-bor-i-mallen.sql`** (forward-daterad, idempotent): byter `{{notes_block}}` mot sektionen i alla `booking_confirmation`-rader som ännu bär den. Bytet är **output-identiskt** (samma div, tecken för tecken), därför får det röra även operatörsomskrivna mallar — mottagaren ser ingen skillnad, men etiketten blir redigerbar. Rader med `locale sv*` får **"Din anteckning:"** direkt, övriga "Your note:". `variables` uppdateras (`notes_block` → `notes`). Verifieringsblock i migrationen; fäller inte körningen om en operatör raderat/inaktiverat sin mall.

Fräsch-installvägen: seeden i `20260828170000` (orörd) sår `{{notes_block}}`-versionen, den nya migrationen konverterar direkt efteråt.

## Verifierat

- `npx vitest run` — **3655 tester gröna** (2 skipped), inkl. nytt `template-render.test.ts` (sektioner, legacy-token, preview-paritet)
- `tsc --noEmit` rent; ESLint rent på nya filer (kvarvarande `any`-fel i comms-send är förbefintliga)
- Migrationen provkörd mot lokal PG16-harness (riktiga migrationer 20260828170000 → 20260903110000 som bas): svensk sajt → sv-etikett, en-rad → en-etikett, andra körningen no-op
- `bun run scripts/check-doc-drift.ts` rent; `instance-manifest.json` omgenererad (schema head `20260903190000`)

## Kvar efter merge (manuellt)

1. **Deploy till fleeten:** `supabase functions deploy comms-send --no-verify-jwt` och `email-send` per instans (+ `supabase db push`)
2. **Optic (`dhitpytulqrvterkatiq`):** migrationen fixar raderna vid nästa `db push`; alternativt via gatewayn med `manage_email_template` (list → update per `template_id`) — svensk rad ska bära `{{#notes}}…<strong>Din anteckning:</strong> {{notes}}…{{/notes}}`. Kräver `OPTIC_MCP_KEY` (lokal `.env.local`, finns inte i denna miljö)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBEMhsyMi57GpV6Fa9cLTU

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBEMhsyMi57GpV6Fa9cLTU)_