### PR TITLE
feat(admin): företagsbrevlådan in i vänsterpanelen — Inbox djuplänkar till Threads

### DIFF
--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -129,8 +129,11 @@ export function AdminSidebar() {
   const adminName = branding?.adminName || 'FlowWink';
   const GITHUB_RELEASES_URL = 'https://github.com/magnusfroste/flowwink/releases';
 
-  const isItemActive = (href: string) =>
-    location.pathname === href || (href !== "/admin" && location.pathname.startsWith(href));
+  const isItemActive = (href: string) => {
+    // Menyposter får djuplänka med ?tab= — aktiv-markeringen gäller sidan.
+    const path = href.split("?")[0];
+    return location.pathname === path || (path !== "/admin" && location.pathname.startsWith(path));
+  };
 
   // Role → module access map (from DB). Admin bypasses all role checks.
   const { data: accessMap } = useRoleModuleAccess();

--- a/src/components/admin/adminNavigation.ts
+++ b/src/components/admin/adminNavigation.ts
@@ -161,6 +161,7 @@ export const navigationGroups: NavGroup[] = [
       { name: "Forms", href: "/admin/forms", icon: Inbox, moduleId: "forms" },
       { name: "Communications", href: "/admin/communications", icon: Mail, moduleId: "email" },
       { name: "Email", href: "/admin/email", icon: MailOpen, moduleId: "email" },
+      { name: "Inbox", href: "/admin/email?tab=threads", icon: Inbox, moduleId: "email" },
     ],
   },
   {


### PR DESCRIPTION
Trådvyn (delade inkorgen) låg bakom `/admin/email?tab=threads` och krävde att man visste om fliken. Beslut: brevlådan bevakas av **admin** tills vidare — ingen matrisändring — men den ska synas i menyn.

- **"Inbox"** efter "Email", samma `moduleId: "email"`
- `isItemActive` strippar query-delen så menyposter får djuplänka med `?tab=` utan att aktiv-markeringen tappas (`prefetchRoute` klarade redan query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)