### PR TITLE
feat(i18n): chattens strängar följer språket — 15 nycklar ur chattfamiljen

### DIFF
--- a/src/components/chat/ChatEmptyState.tsx
+++ b/src/components/chat/ChatEmptyState.tsx
@@ -1,6 +1,7 @@
 import { MessageSquare, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { useUiText } from '@/lib/ui-text';
 
 interface ChatEmptyStateProps {
   title?: string;
@@ -11,24 +12,26 @@ interface ChatEmptyStateProps {
   compact?: boolean;
 }
 
-const defaultPrompts = [
-  'What can you help me with?',
-  'Tell me about your services',
-  'How do I book an appointment?',
-];
-
-export function ChatEmptyState({ 
-  title = 'AI Assistant',
-  welcomeMessage = 'Hi! How can I help you today?',
-  suggestedPrompts = defaultPrompts,
+export function ChatEmptyState({
+  title,
+  welcomeMessage,
+  suggestedPrompts,
   onPromptClick,
   maxPrompts,
   compact = false,
 }: ChatEmptyStateProps) {
+  const t = useUiText();
+  const shownTitle = title ?? t('chat.assistantTitle', 'AI Assistant');
+  const shownWelcome = welcomeMessage ?? t('chat.welcome', 'Hi! How can I help you today?');
+  const prompts = suggestedPrompts ?? [
+    t('chat.suggestion1', 'What can you help me with?'),
+    t('chat.suggestion2', 'Tell me about your services'),
+    t('chat.suggestion3', 'How do I book an appointment?'),
+  ];
   // Limit prompts if maxPrompts is specified
-  const visiblePrompts = maxPrompts 
-    ? suggestedPrompts.slice(0, maxPrompts) 
-    : suggestedPrompts;
+  const visiblePrompts = maxPrompts
+    ? prompts.slice(0, maxPrompts)
+    : prompts;
 
   return (
     <div className={cn(
@@ -46,13 +49,13 @@ export function ChatEmptyState({
         'text-2xl font-serif font-semibold mb-2',
         compact && 'text-lg mb-1'
       )}>
-        {title}
+        {shownTitle}
       </h2>
       <p className={cn(
         'text-muted-foreground mb-4 max-w-md',
         compact && 'text-sm mb-3'
       )}>
-        {welcomeMessage}
+        {shownWelcome}
       </p>
 
       {visiblePrompts.length > 0 && (

--- a/src/components/chat/ChatFeedback.tsx
+++ b/src/components/chat/ChatFeedback.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { useUiText } from '@/lib/ui-text';
 
 interface ChatFeedbackProps {
   messageId: string;
@@ -25,6 +26,7 @@ export function ChatFeedback({
   contextKbArticles = [],
   sessionId,
 }: ChatFeedbackProps) {
+  const t = useUiText();
   const [submitted, setSubmitted] = useState<'positive' | 'negative' | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -58,13 +60,13 @@ export function ChatFeedback({
       setSubmitted(rating);
       
       if (rating === 'positive') {
-        toast.success('Thanks for your feedback!');
+        toast.success(t('chat.feedback.saved', 'Thanks for your feedback!'));
       } else {
-        toast.success('Thanks! We\'ll use this to improve.');
+        toast.success(t('chat.feedback.improve', "Thanks! We'll use this to improve."));
       }
     } catch (error) {
       logger.error('Failed to submit feedback:', error);
-      toast.error('Could not save feedback');
+      toast.error(t('chat.feedback.error', 'Could not save feedback'));
     } finally {
       setIsSubmitting(false);
     }
@@ -78,7 +80,7 @@ export function ChatFeedback({
         ) : (
           <ThumbsDown className="h-3 w-3 text-destructive fill-destructive" />
         )}
-        <span>Thanks!</span>
+        <span>{t('chat.feedback.thanks', 'Thanks!')}</span>
       </div>
     );
   }

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -3,6 +3,7 @@ import { Send, StopCircle, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
+import { useUiText } from '@/lib/ui-text';
 
 interface ChatInputProps {
   onSend: (message: string) => void;
@@ -16,9 +17,11 @@ export function ChatInput({
   onSend, 
   onCancel, 
   isLoading, 
-  placeholder = 'Type your message...',
+  placeholder,
   disabled 
 }: ChatInputProps) {
+  const t = useUiText();
+  const shownPlaceholder = placeholder ?? t('chat.placeholder', 'Type your message...');
   const [value, setValue] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -52,7 +55,7 @@ export function ChatInput({
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={handleKeyDown}
-        placeholder={placeholder}
+        placeholder={shownPlaceholder}
         disabled={disabled || isLoading}
         className={cn(
           'min-h-[44px] max-h-[150px] resize-none pr-12',

--- a/src/components/chat/ConversationCSAT.tsx
+++ b/src/components/chat/ConversationCSAT.tsx
@@ -2,6 +2,7 @@ import { logger } from '@/lib/logger';
 import { useState } from 'react';
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { useUiText } from '@/lib/ui-text';
 import { supabase } from '@/integrations/supabase/client';
 
 interface ConversationCSATProps {
@@ -14,6 +15,7 @@ interface ConversationCSATProps {
  * Anonymous insert is allowed by chat_feedback INSERT policy.
  */
 export function ConversationCSAT({ conversationId }: ConversationCSATProps) {
+  const t = useUiText();
   const [submitted, setSubmitted] = useState<'positive' | 'negative' | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -37,21 +39,21 @@ export function ConversationCSAT({ conversationId }: ConversationCSATProps) {
   if (submitted) {
     return (
       <div className="text-xs text-muted-foreground">
-        Thanks for the feedback!
+        {t('chat.csat.thanks', 'Thanks for the feedback!')}
       </div>
     );
   }
 
   return (
     <div className="flex items-center gap-2">
-      <span className="text-xs text-muted-foreground">How was this chat?</span>
+      <span className="text-xs text-muted-foreground">{t('chat.csat.question', 'How was this chat?')}</span>
       <Button
         variant="ghost"
         size="icon"
         className="h-7 w-7 rounded-full"
         disabled={submitting}
         onClick={() => submit('positive')}
-        aria-label="Good"
+        aria-label={t('chat.csat.good', 'Good')}
       >
         <ThumbsUp className="h-3.5 w-3.5 text-muted-foreground hover:text-green-500 transition-colors" />
       </Button>
@@ -61,7 +63,7 @@ export function ConversationCSAT({ conversationId }: ConversationCSATProps) {
         className="h-7 w-7 rounded-full"
         disabled={submitting}
         onClick={() => submit('negative')}
-        aria-label="Bad"
+        aria-label={t('chat.csat.bad', 'Bad')}
       >
         <ThumbsDown className="h-3.5 w-3.5 text-muted-foreground hover:text-destructive transition-colors" />
       </Button>

--- a/src/components/public/ChatWidget.tsx
+++ b/src/components/public/ChatWidget.tsx
@@ -197,7 +197,7 @@ export function ChatWidget() {
           onClick={() => setIsOpen(!isOpen)}
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
-          aria-label={isOpen ? 'Close chat' : buttonLabel}
+          aria-label={isOpen ? t('chat.close', 'Close chat') : buttonLabel}
           aria-expanded={isOpen}
           aria-controls={panelId}
         >
@@ -232,7 +232,7 @@ export function ChatWidget() {
             isOpen && 'bg-muted text-muted-foreground hover:bg-muted/90'
           )}
           onClick={() => setIsOpen(!isOpen)}
-          aria-label={isOpen ? 'Close chat' : buttonLabel}
+          aria-label={isOpen ? t('chat.close', 'Close chat') : buttonLabel}
           aria-expanded={isOpen}
           aria-controls={panelId}
         >

--- a/src/data/ui-text-catalog.json
+++ b/src/data/ui-text-catalog.json
@@ -106,9 +106,54 @@
       "fallback": "Your Details"
     },
     {
+      "key": "chat.assistantTitle",
+      "group": "chat",
+      "fallback": "AI Assistant"
+    },
+    {
       "key": "chat.close",
       "group": "chat",
       "fallback": "Close chat"
+    },
+    {
+      "key": "chat.conversations",
+      "group": "chat",
+      "fallback": "Conversations"
+    },
+    {
+      "key": "chat.csat.bad",
+      "group": "chat",
+      "fallback": "Bad"
+    },
+    {
+      "key": "chat.csat.good",
+      "group": "chat",
+      "fallback": "Good"
+    },
+    {
+      "key": "chat.csat.question",
+      "group": "chat",
+      "fallback": "How was this chat?"
+    },
+    {
+      "key": "chat.csat.thanks",
+      "group": "chat",
+      "fallback": "Thanks for the feedback!"
+    },
+    {
+      "key": "chat.feedback.error",
+      "group": "chat",
+      "fallback": "Could not save feedback"
+    },
+    {
+      "key": "chat.feedback.saved",
+      "group": "chat",
+      "fallback": "Thanks for your feedback!"
+    },
+    {
+      "key": "chat.feedback.thanks",
+      "group": "chat",
+      "fallback": "Thanks!"
     },
     {
       "key": "chat.leadCapture.error",
@@ -161,6 +206,16 @@
       "fallback": "Your message"
     },
     {
+      "key": "chat.newConversation",
+      "group": "chat",
+      "fallback": "New conversation"
+    },
+    {
+      "key": "chat.placeholder",
+      "group": "chat",
+      "fallback": "Type your message..."
+    },
+    {
       "key": "chat.send",
       "group": "chat",
       "fallback": "Send message"
@@ -169,6 +224,26 @@
       "key": "chat.start",
       "group": "chat",
       "fallback": "Start a chat"
+    },
+    {
+      "key": "chat.suggestion1",
+      "group": "chat",
+      "fallback": "What can you help me with?"
+    },
+    {
+      "key": "chat.suggestion2",
+      "group": "chat",
+      "fallback": "Tell me about your services"
+    },
+    {
+      "key": "chat.suggestion3",
+      "group": "chat",
+      "fallback": "How do I book an appointment?"
+    },
+    {
+      "key": "chat.welcome",
+      "group": "chat",
+      "fallback": "Hi! How can I help you today?"
     },
     {
       "key": "comments.empty",

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -7,6 +7,7 @@ import { PublicFooter } from '@/components/public/PublicFooter';
 import { Button } from '@/components/ui/button';
 import { Plus, MessageSquare, Trash2 } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
+import { useUiText } from '@/lib/ui-text';
 import { useAuth } from '@/hooks/useAuth';
 import { cn } from '@/lib/utils';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -18,6 +19,7 @@ interface Conversation {
 }
 
 export default function ChatPage() {
+  const t = useUiText();
   const navigate = useNavigate();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
@@ -136,14 +138,14 @@ export default function ChatPage() {
           <div className="flex items-center justify-between gap-1 px-3 py-2 border-b">
             <div className="flex items-center gap-1.5 min-w-0">
               <MessageSquare className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-              <span className="text-xs font-medium text-muted-foreground truncate">Conversations</span>
+              <span className="text-xs font-medium text-muted-foreground truncate">{t('chat.conversations', 'Conversations')}</span>
             </div>
             <Button
               onClick={handleNewConversation}
               size="icon"
               variant="ghost"
               className="h-7 w-7"
-              title="New conversation"
+              title={t('chat.newConversation', 'New conversation')}
             >
               <Plus className="h-4 w-4" />
             </Button>


### PR DESCRIPTION
Chatten talade engelska på den svenska sajten: `/chat`-sidans **Conversations** / **New conversation**, tomlägets välkomst + tre förslagsknappar, skrivfältets platshållare, feedback-toasten och CSAT-frågan. Adressen `/chat` delas medvetet av båda språken (samma beslut som `/blog`) — det är **strängarna** som ska följa besökarens språk via packet.

## Vakter före konvertering
- `components/chat/`-familjen verifierad **publik-endast** innan `t()` infördes — admin-träffarna var namnkollisionen `ChatFeedbackDashboardWidget`. Annars hade svenska läckt in i admin-UI:t.
- Medarbetarytan (Profile Check-in-strängarna i `ChatConversation`) lämnad på engelska med flit.

## Mönstret för komponentdefaults
Default-parametrar kan inte anropa hooks: `welcomeMessage = 'Hi!…'` blev prop utan default + `welcomeMessage ?? t('chat.welcome', …)` i kroppen. `??` bevarar semantiken — tom sträng från operatörens settings respekteras, bara `undefined` faller till packet.

Katalogen 106 → **121** nycklar. Svenskan läggs i Optics pack efter merge (datasteg, samma merge-mönster som förra omgången).

🤖 Generated with [Claude Code](https://claude.com/claude-code)