### PR TITLE
fix(i18n): widgetens operatörstexter följer besökarens språk

### DIFF
--- a/src/components/chat/ChatConversation.tsx
+++ b/src/components/chat/ChatConversation.tsx
@@ -6,6 +6,9 @@ import { LiveAgentIndicator } from './LiveAgentIndicator';
 import { ChatLeadCapture } from './ChatLeadCapture';
 import { supabase } from '@/integrations/supabase/client';
 import { cn } from '@/lib/utils';
+import { operatorText } from '@/lib/operator-text';
+import { useUiText, useUiTextLanguage } from '@/lib/ui-text';
+import { baseSubtag } from '@/lib/pick-locale';
 import type { AgentSkill } from '@/types/agent';
 
 interface ChatConversationProps {
@@ -87,10 +90,24 @@ export function ChatConversation({
     !checkinId &&
     messages.some((m) => m.role === 'user');
 
+  const t = useUiText();
+  const { lang, siteLang } = useUiTextLanguage();
+
+  // Operatörens förslag är skrivna på sajtens eget språk — på andra språk
+  // vinner packet, samma regel som operatorText fast för en lista.
+  const packPrompts = [
+    t('chat.suggestion1', 'What can you help me with?'),
+    t('chat.suggestion2', 'Tell me about your services'),
+    t('chat.suggestion3', 'How do I book an appointment?'),
+  ];
+  const localizedPrompts =
+    lang && baseSubtag(lang) !== baseSubtag(siteLang)
+      ? packPrompts
+      : (settings?.suggestedPrompts?.length ? settings.suggestedPrompts : packPrompts);
   // Limit prompts if needed
-  const suggestedPrompts = maxPrompts 
-    ? settings?.suggestedPrompts?.slice(0, maxPrompts) 
-    : settings?.suggestedPrompts;
+  const suggestedPrompts = maxPrompts
+    ? localizedPrompts.slice(0, maxPrompts)
+    : localizedPrompts;
 
   return (
     <div className={cn(
@@ -125,14 +142,14 @@ export function ChatConversation({
           onStartNew: clearMessages,
         }}
         visitorSettings={{
-          title: hideInternalTitle ? '' : (checkinId ? 'Profile Check-in' : settings?.title),
+          title: hideInternalTitle ? '' : (checkinId ? 'Profile Check-in' : operatorText(settings?.title, t('chat.assistantTitle', 'AI Assistant'), lang, siteLang)),
           welcomeMessage: checkinId
             ? 'Hi! Tell me about your latest project and I\'ll update your profile. You can also use voice input 🎙️'
-            : settings?.welcomeMessage,
+            : operatorText(settings?.welcomeMessage, t('chat.welcome', 'Hi! How can I help you today?'), lang, siteLang),
           suggestedPrompts: checkinId
             ? ['Tell me about my latest project', 'I want to update my availability', 'What information do you need?']
             : suggestedPrompts,
-          placeholder: checkinId ? 'Tell me about your latest project...' : settings?.placeholder,
+          placeholder: checkinId ? 'Tell me about your latest project...' : operatorText(settings?.placeholder, t('chat.placeholder', 'Type your message...'), lang, siteLang),
           enabled: true,
           feedbackEnabled: checkinId ? false : (settings?.feedbackEnabled ?? true),
           showIcons: settings?.showChatIcons ?? true,

--- a/src/components/public/ChatWidget.tsx
+++ b/src/components/public/ChatWidget.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useId, useRef } from 'react';
-import { useUiText } from '@/lib/ui-text';
+import { useUiText, useUiTextLanguage } from '@/lib/ui-text';
+import { operatorText } from '@/lib/operator-text';
 import { MessageCircle, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ChatConversation } from '@/components/chat/ChatConversation';
@@ -116,7 +117,8 @@ export function ChatWidget() {
   const style = settings.widgetStyle || 'floating';
 
   const isPill = style === 'pill';
-  const buttonLabel = settings.widgetButtonText || 'Chat';
+  const { lang, siteLang } = useUiTextLanguage();
+  const buttonLabel = operatorText(settings.widgetButtonText, t('chat.buttonLabel', 'Chat'), lang, siteLang);
 
   return (
     <div className={cn(

--- a/src/data/ui-text-catalog.json
+++ b/src/data/ui-text-catalog.json
@@ -111,6 +111,11 @@
       "fallback": "AI Assistant"
     },
     {
+      "key": "chat.buttonLabel",
+      "group": "chat",
+      "fallback": "Chat"
+    },
+    {
       "key": "chat.close",
       "group": "chat",
       "fallback": "Close chat"

--- a/src/lib/__tests__/operator-text-adoption.guardrails.test.ts
+++ b/src/lib/__tests__/operator-text-adoption.guardrails.test.ts
@@ -23,6 +23,8 @@ const CONSUMERS: Array<{ file: string; fields: string[] }> = [
   { file: 'components/public/PublicNavigation.tsx', fields: ['blogSettings?.archiveTitle'] },
   { file: 'components/public/PublicFooter.tsx', fields: ['link.label'] },
   { file: 'pages/PublicPage.tsx', fields: ['maintenanceSettings.title', 'maintenanceSettings.message'] },
+  { file: 'components/chat/ChatConversation.tsx', fields: ['settings?.title', 'settings?.welcomeMessage', 'settings?.placeholder'] },
+  { file: 'components/public/ChatWidget.tsx', fields: ['settings.widgetButtonText'] },
 ];
 
 describe('operatorText används där en operatörssträng möter en besökare', () => {


### PR DESCRIPTION
Magnus fråga — *"widgeten förblir svensk när EN är valt?"* — avslöjade halva jobbet. Chromen bytte språk (#412), men operatörens **chat-inställningar** (titel, välkomstmeddelande, förslagsfrågor, platshållare, knappetikett) är envärdiga, skrivna på sajtens eget språk, och visades rakt av på engelska sidor: svensk hälsning, svenska förslagsknappar.

Det är exakt klassen `operatorText` finns för — operatörens ord vinner på sajtens EGET språk, packet på de andra. Och `widgetButtonText || 'Chat'` var dessutom själva bypass-mönstret som adoptionsgrinden jagar, på en yta grinden inte täckte.

- Fem fält genom regeln; förslagslistan med samma logik fast för en array
- Adoptionsgrinden **ratchetad** med `ChatConversation.tsx` + `ChatWidget.tsx` (28 tester)
- Medarbetarspåret (Profile Check-in) orört — engelsk yta
- Ny nyckel `chat.buttonLabel` (packet bär redan engelskan via call-siten)

🤖 Generated with [Claude Code](https://claude.com/claude-code)