### PR TITLE
fix(chat): useUiTextLanguage upp till komponenttoppen — låg efter en early return

### DIFF
--- a/src/components/public/ChatWidget.tsx
+++ b/src/components/public/ChatWidget.tsx
@@ -46,6 +46,7 @@ const sizeMap = {
 
 export function ChatWidget() {
   const t = useUiText();
+  const { lang, siteLang } = useUiTextLanguage();
   const [isOpen, setIsOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [initialMessage, setInitialMessage] = useState<string | undefined>();
@@ -117,7 +118,6 @@ export function ChatWidget() {
   const style = settings.widgetStyle || 'floating';
 
   const isPill = style === 'pill';
-  const { lang, siteLang } = useUiTextLanguage();
   const buttonLabel = operatorText(settings.widgetButtonText, t('chat.buttonLabel', 'Chat'), lang, siteLang);
 
   return (


### PR DESCRIPTION
Correctness-grinden fällde #413 med `react-hooks/rules-of-hooks`: hooken sattes in vid `buttonLabel`-raden — **efter** `if (...) return null`. Samma klass som PublicPage-incidenten (React #310). Flyttad upp bland de övriga hookarna; grinden körd lokalt: grön.

Beklagar röd main — mitt merge-skript bröt loopen på fail men körde ändå merge. Forkarna hann synka, därför fix framåt i stället för revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)