### PR TITLE
feat(i18n): fjärde förslags-slotten + tomradsfiltret — overlayn är widgetens översättningsmetod

### DIFF
--- a/src/components/chat/ChatConversation.tsx
+++ b/src/components/chat/ChatConversation.tsx
@@ -95,15 +95,19 @@ export function ChatConversation({
 
   // Operatörens förslag är skrivna på sajtens eget språk — på andra språk
   // vinner packet, samma regel som operatorText fast för en lista.
+  // Fyra slots — operatörer har ofta fler egna frågor än tre. Tomma rader
+  // (även operatörens) blir inga knappar.
   const packPrompts = [
     t('chat.suggestion1', 'What can you help me with?'),
     t('chat.suggestion2', 'Tell me about your services'),
     t('chat.suggestion3', 'How do I book an appointment?'),
-  ];
+    t('chat.suggestion4', 'How do I get in touch?'),
+  ].filter((p) => p.trim() !== '');
+  const ownPrompts = (settings?.suggestedPrompts ?? []).filter((p) => p?.trim());
   const localizedPrompts =
     lang && baseSubtag(lang) !== baseSubtag(siteLang)
       ? packPrompts
-      : (settings?.suggestedPrompts?.length ? settings.suggestedPrompts : packPrompts);
+      : (ownPrompts.length ? ownPrompts : packPrompts);
   // Limit prompts if needed
   const suggestedPrompts = maxPrompts
     ? localizedPrompts.slice(0, maxPrompts)

--- a/src/data/ui-text-catalog.json
+++ b/src/data/ui-text-catalog.json
@@ -246,6 +246,11 @@
       "fallback": "How do I book an appointment?"
     },
     {
+      "key": "chat.suggestion4",
+      "group": "chat",
+      "fallback": "How do I get in touch?"
+    },
+    {
       "key": "chat.welcome",
       "group": "chat",
       "fallback": "Hi! How can I help you today?"


### PR DESCRIPTION
Magnus utmaning: chat-blockets snabbfrågor gick att lösa per sida (dolda på EN-sidan), men widgeten följer med på **alla** sidor — ingen metod för operatörens egna frågor på andra språk.

Metoden finns sedan #413: på andra språk hämtas förslagen ur **packet**, så `@en`-overlayens `chat.suggestion1..4` bär de engelska versionerna av operatörens frågor — redigerbara i översättningstabellen i settings. Ingen ny mekanism.

Två kompletteringar:
- **Fjärde slotten** (`chat.suggestion4`) — Optic har fyra egna frågor, packet hade tre slots. Katalog-grinden krävde en riktig engelsk fallback (tomma nycklar blir osynliga i editorn) → generisk default *"How do I get in touch?"*.
- **Tomradsfiltret** — en tom rad i operatörens lista renderades som tom knapp; filtreras nu på båda vägarna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)