### PR TITLE
fix(i18n): widgetens rubrikrad genom operatorText — headern hade en egen titel-väg

### DIFF
--- a/src/components/public/ChatWidget.tsx
+++ b/src/components/public/ChatWidget.tsx
@@ -136,7 +136,7 @@ export function ChatWidget() {
           ref={panelRef}
           id={panelId}
           role="dialog"
-          aria-label={settings.title || 'AI Assistant'}
+          aria-label={operatorText(settings.title, t('chat.assistantTitle', 'AI Assistant'), lang, siteLang)}
           className={cn(
             'absolute bottom-16 mb-2',
             size.width, size.height,
@@ -151,7 +151,7 @@ export function ChatWidget() {
           <div className="flex items-center justify-between px-4 py-3 border-b bg-primary/5 shrink-0">
             <div className="flex items-center gap-2 min-w-0">
               <MessageCircle className="h-4 w-4 text-primary shrink-0" aria-hidden="true" />
-              <p className="font-medium font-serif truncate">{settings.title || 'AI Assistant'}</p>
+              <p className="font-medium font-serif truncate">{operatorText(settings.title, t('chat.assistantTitle', 'AI Assistant'), lang, siteLang)}</p>
             </div>
             <Button
               variant="ghost"

--- a/src/lib/__tests__/operator-text-adoption.guardrails.test.ts
+++ b/src/lib/__tests__/operator-text-adoption.guardrails.test.ts
@@ -24,7 +24,7 @@ const CONSUMERS: Array<{ file: string; fields: string[] }> = [
   { file: 'components/public/PublicFooter.tsx', fields: ['link.label'] },
   { file: 'pages/PublicPage.tsx', fields: ['maintenanceSettings.title', 'maintenanceSettings.message'] },
   { file: 'components/chat/ChatConversation.tsx', fields: ['settings?.title', 'settings?.welcomeMessage', 'settings?.placeholder'] },
-  { file: 'components/public/ChatWidget.tsx', fields: ['settings.widgetButtonText'] },
+  { file: 'components/public/ChatWidget.tsx', fields: ['settings.widgetButtonText', 'settings.title'] },
 ];
 
 describe('operatorText används där en operatörssträng möter en besökare', () => {


### PR DESCRIPTION
Magnus test på EN-sidan: allt bytte språk utom rubriken **"AI assistenten"**. ChatWidget renderar en egen header ovanför ChatConversation, och dess rad skrev `settings.title || 'AI Assistant'` — bypass-mönstret, på en rad adoptionsgrinden inte täckte. Genom `operatorText`, fältet ratchetat in i grinden (30 tester).

🤖 Generated with [Claude Code](https://claude.com/claude-code)