### PR TITLE
fix(i18n): snabbknapparna genom regeln — ChatLauncherBlock läste settings direkt

### DIFF
--- a/src/components/chat/ChatConversation.tsx
+++ b/src/components/chat/ChatConversation.tsx
@@ -6,9 +6,9 @@ import { LiveAgentIndicator } from './LiveAgentIndicator';
 import { ChatLeadCapture } from './ChatLeadCapture';
 import { supabase } from '@/integrations/supabase/client';
 import { cn } from '@/lib/utils';
-import { operatorText } from '@/lib/operator-text';
+import { operatorText, operatorPrompts } from '@/lib/operator-text';
 import { useUiText, useUiTextLanguage } from '@/lib/ui-text';
-import { baseSubtag } from '@/lib/pick-locale';
+
 import type { AgentSkill } from '@/types/agent';
 
 interface ChatConversationProps {
@@ -94,20 +94,13 @@ export function ChatConversation({
   const { lang, siteLang } = useUiTextLanguage();
 
   // Operatörens förslag är skrivna på sajtens eget språk — på andra språk
-  // vinner packet, samma regel som operatorText fast för en lista.
-  // Fyra slots — operatörer har ofta fler egna frågor än tre. Tomma rader
-  // (även operatörens) blir inga knappar.
-  const packPrompts = [
+  // vinner packet. Delad regel (operatorPrompts) med ChatLauncherBlock.
+  const localizedPrompts = operatorPrompts(settings?.suggestedPrompts, [
     t('chat.suggestion1', 'What can you help me with?'),
     t('chat.suggestion2', 'Tell me about your services'),
     t('chat.suggestion3', 'How do I book an appointment?'),
     t('chat.suggestion4', 'How do I get in touch?'),
-  ].filter((p) => p.trim() !== '');
-  const ownPrompts = (settings?.suggestedPrompts ?? []).filter((p) => p?.trim());
-  const localizedPrompts =
-    lang && baseSubtag(lang) !== baseSubtag(siteLang)
-      ? packPrompts
-      : (ownPrompts.length ? ownPrompts : packPrompts);
+  ], lang, siteLang);
   // Limit prompts if needed
   const suggestedPrompts = maxPrompts
     ? localizedPrompts.slice(0, maxPrompts)

--- a/src/components/public/blocks/ChatLauncherBlock.tsx
+++ b/src/components/public/blocks/ChatLauncherBlock.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
-import { useUiText } from '@/lib/ui-text';
+import { useUiText, useUiTextLanguage } from '@/lib/ui-text';
+import { operatorPrompts } from '@/lib/operator-text';
 import { useNavigate } from 'react-router-dom';
 import { ArrowRight, Sparkles } from 'lucide-react';
 import { Input } from '@/components/ui/input';
@@ -38,7 +39,14 @@ export function ChatLauncherBlock({ data }: ChatLauncherBlockProps) {
     variant = 'card',
   } = data;
 
-  const quickActions = chatSettings?.suggestedPrompts?.slice(0, quickActionCount) || [];
+  const { lang, siteLang } = useUiTextLanguage();
+  // Samma regel som chatten: operatörens frågor på sajtens språk, packets på andra.
+  const quickActions = operatorPrompts(chatSettings?.suggestedPrompts, [
+    t('chat.suggestion1', 'What can you help me with?'),
+    t('chat.suggestion2', 'Tell me about your services'),
+    t('chat.suggestion3', 'How do I book an appointment?'),
+    t('chat.suggestion4', 'How do I get in touch?'),
+  ], lang, siteLang).slice(0, quickActionCount);
 
   const chatModuleEnabled = useIsModuleEnabled('chat');
   const isEnabled = chatModuleEnabled && chatSettings?.landingPageEnabled;

--- a/src/lib/__tests__/operator-text.guardrails.test.ts
+++ b/src/lib/__tests__/operator-text.guardrails.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { operatorText } from '../operator-text';
+import { operatorText, operatorPrompts } from '../operator-text';
 
 /**
  * Bloggänkens etikett — precedensen som varit fel två gånger.
@@ -28,5 +28,25 @@ describe('bloggänkens etikett', () => {
   it('utan operatörsord faller det tillbaka på packet', () => {
     expect(operatorText(null, 'Blog', 'sv', 'sv')).toBe('Blog');
     expect(operatorText('   ', 'Blog', 'sv', 'sv')).toBe('Blog');
+  });
+});
+
+describe('operatorPrompts — listvarianten', () => {
+  const pack = ['P1', 'P2'];
+  it('sajtens eget språk: operatörens lista vinner, tomma rader bort', () => {
+    expect(operatorPrompts(['Egen', '', null], pack, 'sv', 'sv')).toEqual(['Egen']);
+  });
+  it('annat språk: packet vinner även när operatören har egna', () => {
+    expect(operatorPrompts(['Egen'], pack, 'en', 'sv')).toEqual(pack);
+  });
+  it('ingen sidkontext räknas som sajtens språk', () => {
+    expect(operatorPrompts(['Egen'], pack, null, 'sv')).toEqual(['Egen']);
+  });
+  it('tom operatörslista faller till packet', () => {
+    expect(operatorPrompts([], pack, 'sv', 'sv')).toEqual(pack);
+    expect(operatorPrompts(undefined, pack, 'sv', 'sv')).toEqual(pack);
+  });
+  it('tomma packrader blir inga knappar', () => {
+    expect(operatorPrompts([], ['P1', ''], 'en', 'sv')).toEqual(['P1']);
   });
 });

--- a/src/lib/operator-text.ts
+++ b/src/lib/operator-text.ts
@@ -32,3 +32,23 @@ export function operatorText(
   const chosen = String(own ?? '').trim();
   return chosen || packText;
 }
+
+/**
+ * `operatorText` for a LIST: the operator's own suggested prompts win on the
+ * site's own language, the pack's prompts on every other. One rule, three
+ * chat surfaces (widget, block, launcher) — the launcher reading settings
+ * directly is how Swedish quick actions reached an English page.
+ */
+export function operatorPrompts(
+  own: ReadonlyArray<string | null | undefined> | null | undefined,
+  packPrompts: string[],
+  currentLocale: string | null | undefined,
+  siteLanguage: string,
+): string[] {
+  const cleanPack = packPrompts.filter((p) => p.trim() !== '');
+  const inSiteLanguage = !currentLocale
+    || baseSubtag(currentLocale) === baseSubtag(siteLanguage);
+  if (!inSiteLanguage) return cleanPack;
+  const cleanOwn = (own ?? []).filter((p): p is string => !!p?.trim());
+  return cleanOwn.length ? cleanOwn : cleanPack;
+}


### PR DESCRIPTION
Magnus slog på quick actions i chat-launcherblocket och de svenska frågorna dök upp på EN-sidan: blocket läste `chatSettings.suggestedPrompts` **direkt** och gick förbi lokaliseringen som satt inline i ChatConversation.

Regeln är nu en delad funktion — **`operatorPrompts`**, listvarianten av `operatorText`: operatörens frågor på sajtens eget språk, packets på andra, tomma rader blir aldrig knappar. Egna guardrail-tester (5 st), och båda ytorna anropar den. `t()`-literalerna stannar vid call-siten så katalogen ser dem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)