### PR TITLE
feat(i18n): fakturan och ordern på mallrälsen — de två sista hårdkodade affärsmejlen

### DIFF
--- a/supabase/functions/comms-send/invoice_email.ts
+++ b/supabase/functions/comms-send/invoice_email.ts
@@ -2,6 +2,7 @@
 // Includes PDF attachment + link to public payment page.
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0';
 import { getServiceClient } from '../_shared/supabase-clients.ts';
+import { renderTemplate } from '../_shared/template-render.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -157,17 +158,75 @@ export async function handler(req: Request): Promise<Response> {
       console.warn('[send-invoice-email] PDF fetch error:', pdfErr);
     }
 
-    const html = buildHtml({
-      invoice,
-      url: body.public_url,
-      reminder: !!body.reminder,
-      custom: body.custom_message || '',
-      siteName,
+    // ── Mallen är sajtinnehåll, på mottagarens språk ─────────────────────
+    // Samma räls som offerten/avtalet: mottagarens språk från parten, mallen
+    // via stegen (exakt tagg → samma språk → sajtens standard → NÅGON aktiv),
+    // gamla HTML:en som Law 4-fallback. ALL språktext bor i mallen; koden
+    // prerendrar bara data. Villkorsdelar ({{#due_date}}, {{#items_rows}})
+    // stryks av motorn när variabeln är tom.
+    let recipientLang: string | null = null;
+    if (invoice.partner_id) {
+      const { data: langRow, error: langErr } = await supabase.rpc('partner_language', { p_partner_id: invoice.partner_id });
+      if (langErr) console.warn('[send-invoice-email] could not read the recipient language:', langErr.message);
+      recipientLang = (langRow as { lang?: string } | null)?.lang ?? null;
+    }
+    const templateKind = body.reminder ? 'invoice_reminder' : 'invoice_email';
+    const { data: resolvedTpl, error: tplErr } = await supabase.rpc('resolve_email_template', {
+      p_name: templateKind,
+      p_locale: recipientLang,
     });
+    if (tplErr) console.warn('[send-invoice-email] template lookup failed — using built-in fallback:', tplErr.message);
+    const tpl = resolvedTpl as { ok?: boolean; html?: string; subject?: string; locale?: string } | null;
 
-    const subject = body.reminder
-      ? `Reminder: Invoice ${invoice.invoice_number} from ${siteName}`
-      : `Invoice ${invoice.invoice_number} from ${siteName}`;
+    let html: string;
+    let subject: string;
+    if (tpl?.ok && tpl.html) {
+      const currency = invoice.currency || 'SEK';
+      const items = Array.isArray(invoice.line_items) ? invoice.line_items : [];
+      const itemsRows = items.map((it: any) => {
+        const qty = Number(it.qty ?? it.quantity ?? 1);
+        const unit = Number(it.unit_price_cents ?? 0);
+        return `
+    <tr>
+      <td style="padding:8px 0;border-bottom:1px solid #eef0f3;font-size:13px;vertical-align:top">
+        <div>${escapeHtml(it.description || '')}</div>
+        <div style="color:#6b7280;font-size:11px;margin-top:2px">${qty} × ${fmtMoney(unit, currency)}</div>
+      </td>
+      <td style="padding:8px 0;border-bottom:1px solid #eef0f3;text-align:right;font-family:ui-monospace,monospace;font-size:13px;white-space:nowrap;vertical-align:top">${fmtMoney(qty * unit, currency)}</td>
+    </tr>`;
+      }).join('');
+      const vars: Record<string, string> = {
+        invoice_number: String(invoice.invoice_number ?? ''),
+        site_name: escapeHtml(siteName),
+        items_rows: itemsRows,
+        subtotal: fmtMoney(invoice.subtotal_cents, currency),
+        tax: fmtMoney(invoice.tax_cents, currency),
+        total: fmtMoney(invoice.total_cents, currency),
+        due_date: invoice.due_date ? new Date(invoice.due_date).toLocaleDateString('sv-SE') : '',
+        cta_url: body.public_url,
+        custom_block: body.custom_message
+          ? `<p style="margin:0 0 16px;white-space:pre-wrap">${escapeHtml(body.custom_message)}</p>` : '',
+      };
+      html = renderTemplate(tpl.html, vars);
+      subject = tpl.subject ? renderTemplate(tpl.subject, vars)
+        : (body.reminder
+            ? `Reminder: Invoice ${invoice.invoice_number} from ${siteName}`
+            : `Invoice ${invoice.invoice_number} from ${siteName}`);
+      if (recipientLang && tpl.locale && tpl.locale !== recipientLang.toLowerCase()) {
+        console.warn(`[send-invoice-email] no ${recipientLang} template for ${templateKind} — sent the ${tpl.locale} one`);
+      }
+    } else {
+      html = buildHtml({
+        invoice,
+        url: body.public_url,
+        reminder: !!body.reminder,
+        custom: body.custom_message || '',
+        siteName,
+      });
+      subject = body.reminder
+        ? `Reminder: Invoice ${invoice.invoice_number} from ${siteName}`
+        : `Invoice ${invoice.invoice_number} from ${siteName}`;
+    }
 
     const attachments = pdfBase64
       ? [{ filename: `${invoice.invoice_number}.pdf`, content: pdfBase64, contentType: 'application/pdf' }]

--- a/supabase/functions/comms-send/order_confirmation.ts
+++ b/supabase/functions/comms-send/order_confirmation.ts
@@ -1,5 +1,6 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
 import { getServiceClient } from '../_shared/supabase-clients.ts';
+import { renderTemplate } from '../_shared/template-render.ts';
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -13,6 +14,10 @@ interface OrderConfirmationRequest {
 interface EmailConfig {
   fromEmail: string;
   fromName: string;
+}
+
+function escapeHtml(s: string) {
+  return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
 }
 
 const formatPrice = (cents: number, currency: string) => {
@@ -94,13 +99,24 @@ export async function handler(req: Request): Promise<Response> {
       .map(
         (item) => `
         <tr>
-          <td style="padding: 12px; border-bottom: 1px solid #e5e7eb;">${item.product_name}</td>
+          <td style="padding: 12px; border-bottom: 1px solid #e5e7eb;">${escapeHtml(item.product_name)}</td>
           <td style="padding: 12px; border-bottom: 1px solid #e5e7eb; text-align: center;">${item.quantity}</td>
           <td style="padding: 12px; border-bottom: 1px solid #e5e7eb; text-align: right;">${formatPrice(item.price_cents * item.quantity, order.currency)}</td>
         </tr>
       `
       )
       .join("");
+
+    // ── Mallen är sajtinnehåll ───────────────────────────────────────────
+    // Ordern har ingen part i registret (e-handelskund), så mallen löses med
+    // sajtens standardspråk — ärligt, i stället för en gissning. Gamla HTML:en
+    // är Law 4-fallback; ALL språktext bor i mallen, koden prerendrar data.
+    const { data: resolvedTpl, error: tplErr } = await supabase.rpc('resolve_email_template', {
+      p_name: 'order_confirmation',
+      p_locale: null,
+    });
+    if (tplErr) console.warn('[send-order-confirmation] template lookup failed — using built-in fallback:', tplErr.message);
+    const tpl = resolvedTpl as { ok?: boolean; html?: string; subject?: string; locale?: string } | null;
 
     const emailHtml = `
       <!DOCTYPE html>
@@ -170,11 +186,27 @@ export async function handler(req: Request): Promise<Response> {
       </html>
     `;
 
+    let finalHtml = emailHtml;
+    let finalSubject = `Order Confirmation - ${order.id.slice(0, 8)}`;
+    if (tpl?.ok && tpl.html) {
+      const vars: Record<string, string> = {
+        customer_name: escapeHtml(order.customer_name || ''),
+        items_rows: itemsHtml,
+        total: formatPrice(order.total_cents, order.currency),
+        order_ref: order.id.slice(0, 8),
+        customer_email: escapeHtml(order.customer_email || ''),
+        order_date: new Date(order.created_at).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", hour: "2-digit", minute: "2-digit" }),
+        site_name: escapeHtml(siteName),
+      };
+      finalHtml = renderTemplate(tpl.html, vars);
+      finalSubject = tpl.subject ? renderTemplate(tpl.subject, vars) : finalSubject;
+    }
+
     const { data: emailResponse, error: emailError } = await supabase.functions.invoke('email-send', {
       body: {
         to: order.customer_email,
-        subject: `Order Confirmation - ${order.id.slice(0, 8)}`,
-        html: emailHtml,
+        subject: finalSubject,
+        html: finalHtml,
         fromOverride: `${emailConfig.fromName} <${emailConfig.fromEmail}>`,
         tags: { source: 'send-order-confirmation', order_id: order.id },
       },

--- a/supabase/migrations/20260903210000_fakturan-och-ordern-pa-mallralsen.sql
+++ b/supabase/migrations/20260903210000_fakturan-och-ordern-pa-mallralsen.sql
@@ -1,0 +1,148 @@
+-- Fakturan och ordern på mallrälsen — de två sista hårdkodade affärsmejlen.
+--
+-- Samma recept som offerten/avtalet (20260903150000) och bokningen:
+--   * Seedas återhävdbart, WHERE NOT EXISTS på (name, locale).
+--   * locale='en' UTTRYCKLIGEN — triggern hade annars stämplat sajtens språk
+--     på mallar som är skrivna på engelska.
+--   * ALL språktext bor i mallen (Item, Amount, Subtotal, Due, Product,
+--     Quantity, Total, knapptexter, footern). Koden prerendrar bara DATA:
+--     radlistor, belopp, datum, länkar.
+--   * Villkorstext uttrycks med sektioner ({{#due_date}}…{{/due_date}},
+--     {{#items_rows}}…{{/items_rows}}, {{#customer_name}}…) — motorn i
+--     _shared/template-render.ts stryker sektionen när variabeln är tom.
+--
+-- Sorter: invoice_email, invoice_reminder (påminnelsen är en egen sort med
+-- egen ton — replace-rendering kan inte grena), order_confirmation.
+--
+-- Mottagarspråket: fakturan har partner_id → partner_language som offerten.
+-- Ordern har ingen part (e-handelskund utan register) — den löses med sajtens
+-- standardspråk, vilket är ärligt snarare än en gissning på Accept-Language.
+
+DO $$
+DECLARE
+  v_invoice_html text;
+  v_order_html text;
+BEGIN
+  v_invoice_html :=
+    '<!doctype html><html><body style="font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:#f6f7f9;margin:0;padding:24px;color:#111">'
+ || '<div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;padding:32px;border:1px solid #e6e8ec">'
+ || '<h1 style="margin:0 0 8px;font-size:20px">{{heading}}</h1>'
+ || '<p style="margin:0 0 16px;color:#4b5563">{{intro}}</p>'
+ || '{{custom_block}}'
+ || '<div style="background:#f9fafb;border:1px solid #e6e8ec;border-radius:8px;padding:16px;margin:16px 0">'
+ || '<div style="display:flex;justify-content:space-between;margin-bottom:6px"><span style="color:#6b7280">Invoice</span><strong>{{invoice_number}}</strong></div>'
+ || '{{#items_rows}}<table style="width:100%;border-collapse:collapse;margin:12px 0 4px">'
+ || '<thead><tr>'
+ || '<th style="text-align:left;font-size:11px;text-transform:uppercase;color:#6b7280;padding-bottom:6px;border-bottom:1px solid #e6e8ec">Item</th>'
+ || '<th style="text-align:right;font-size:11px;text-transform:uppercase;color:#6b7280;padding-bottom:6px;border-bottom:1px solid #e6e8ec">Amount</th>'
+ || '</tr></thead><tbody>{{items_rows}}</tbody></table>{{/items_rows}}'
+ || '<div style="display:flex;justify-content:space-between;margin-top:8px;font-size:13px"><span style="color:#6b7280">Subtotal</span><span style="font-family:ui-monospace,monospace">{{subtotal}}</span></div>'
+ || '<div style="display:flex;justify-content:space-between;font-size:13px"><span style="color:#6b7280">Tax</span><span style="font-family:ui-monospace,monospace">{{tax}}</span></div>'
+ || '<div style="display:flex;justify-content:space-between;margin-top:6px;border-top:1px solid #e6e8ec;padding-top:6px"><strong>Total</strong><strong style="font-family:ui-monospace,monospace">{{total}}</strong></div>'
+ || '{{#due_date}}<div style="display:flex;justify-content:space-between;margin-top:8px;font-size:12px;color:#6b7280"><span>Due</span><span>{{due_date}}</span></div>{{/due_date}}'
+ || '</div>'
+ || '<div style="text-align:center;margin:24px 0">'
+ || '<a href="{{cta_url}}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600">View &amp; pay invoice</a>'
+ || '</div>'
+ || '<p style="margin:16px 0 0;font-size:12px;color:#6b7280;word-break:break-all">Or copy this link: <br/>{{cta_url}}</p>'
+ || '<hr style="border:none;border-top:1px solid #e6e8ec;margin:24px 0"/>'
+ || '<p style="margin:0;font-size:12px;color:#9ca3af">Sent by {{site_name}}</p>'
+ || '</div></body></html>';
+
+  v_order_html :=
+    '<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>'
+ || '<body style="font-family: -apple-system, BlinkMacSystemFont, ''Segoe UI'', Roboto, sans-serif; background-color: #f9fafb; margin: 0; padding: 40px 20px;">'
+ || '<div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">'
+ || '<div style="background-color: #18181b; padding: 32px; text-align: center;">'
+ || '<h1 style="color: #ffffff; margin: 0; font-size: 24px;">Order confirmation</h1>'
+ || '</div>'
+ || '<div style="padding: 32px;">'
+ || '<p style="color: #374151; font-size: 16px; line-height: 1.6; margin: 0 0 24px;">Hello{{#customer_name}} {{customer_name}}{{/customer_name}}!</p>'
+ || '<p style="color: #374151; font-size: 16px; line-height: 1.6; margin: 0 0 24px;">Thank you for your order! We have received your payment and your order is now being processed.</p>'
+ || '<div style="background-color: #f9fafb; border-radius: 8px; padding: 20px; margin-bottom: 24px;">'
+ || '<h2 style="color: #18181b; font-size: 18px; margin: 0 0 16px;">Order details</h2>'
+ || '<table style="width: 100%; border-collapse: collapse;">'
+ || '<thead><tr style="background-color: #e5e7eb;">'
+ || '<th style="padding: 12px; text-align: left; font-size: 14px;">Product</th>'
+ || '<th style="padding: 12px; text-align: center; font-size: 14px;">Quantity</th>'
+ || '<th style="padding: 12px; text-align: right; font-size: 14px;">Price</th>'
+ || '</tr></thead>'
+ || '<tbody>{{items_rows}}</tbody>'
+ || '<tfoot><tr>'
+ || '<td colspan="2" style="padding: 16px 12px; font-weight: bold; font-size: 16px;">Total</td>'
+ || '<td style="padding: 16px 12px; font-weight: bold; font-size: 16px; text-align: right;">{{total}}</td>'
+ || '</tr></tfoot></table></div>'
+ || '<div style="background-color: #f9fafb; border-radius: 8px; padding: 20px; margin-bottom: 24px;">'
+ || '<h3 style="color: #18181b; font-size: 14px; margin: 0 0 12px;">Order information</h3>'
+ || '<p style="color: #6b7280; font-size: 14px; margin: 0; line-height: 1.8;">'
+ || '<strong>Order ID:</strong> {{order_ref}}…<br>'
+ || '<strong>Email:</strong> {{customer_email}}<br>'
+ || '<strong>Date:</strong> {{order_date}}</p></div>'
+ || '<p style="color: #6b7280; font-size: 14px; line-height: 1.6; margin: 0;">If you have any questions, please don''t hesitate to contact us.</p>'
+ || '</div>'
+ || '<div style="background-color: #f9fafb; padding: 24px; text-align: center; border-top: 1px solid #e5e7eb;">'
+ || '<p style="color: #9ca3af; font-size: 12px; margin: 0;">{{site_name}} — This is an automated message. Please do not reply to this email.</p>'
+ || '</div></div></body></html>';
+
+  INSERT INTO email_templates (name, locale, subject, html, category, variables, active)
+  SELECT 'invoice_email', 'en',
+         'Invoice {{invoice_number}} from {{site_name}}',
+         replace(replace(v_invoice_html,
+           '{{heading}}', 'Invoice {{invoice_number}}'),
+           '{{intro}}', 'Please find your invoice attached. You can also view and pay it online.'),
+         'billing',
+         '["invoice_number","site_name","items_rows","subtotal","tax","total","due_date","cta_url","custom_block"]'::jsonb,
+         true
+  WHERE NOT EXISTS (SELECT 1 FROM email_templates WHERE name = 'invoice_email' AND locale = 'en');
+
+  INSERT INTO email_templates (name, locale, subject, html, category, variables, active)
+  SELECT 'invoice_reminder', 'en',
+         'Reminder: Invoice {{invoice_number}} from {{site_name}}',
+         replace(replace(v_invoice_html,
+           '{{heading}}', 'Reminder: Invoice {{invoice_number}}'),
+           '{{intro}}', 'This is a friendly reminder that the invoice below is awaiting payment.'),
+         'billing',
+         '["invoice_number","site_name","items_rows","subtotal","tax","total","due_date","cta_url","custom_block"]'::jsonb,
+         true
+  WHERE NOT EXISTS (SELECT 1 FROM email_templates WHERE name = 'invoice_reminder' AND locale = 'en');
+
+  INSERT INTO email_templates (name, locale, subject, html, category, variables, active)
+  SELECT 'order_confirmation', 'en',
+         'Order confirmation — {{order_ref}}',
+         v_order_html,
+         'commerce',
+         '["customer_name","items_rows","total","order_ref","customer_email","order_date","site_name"]'::jsonb,
+         true
+  WHERE NOT EXISTS (SELECT 1 FROM email_templates WHERE name = 'order_confirmation' AND locale = 'en');
+END $$;
+
+-- ── Bevisas där den körs ───────────────────────────────────────────────────
+DO $$
+DECLARE v jsonb; kind text; v_html text;
+BEGIN
+  PERFORM set_config('request.jwt.claims', '{"role":"service_role"}', true);
+  FOREACH kind IN ARRAY ARRAY['invoice_email','invoice_reminder','order_confirmation'] LOOP
+    -- En svensk mottagare på en sajt utan svensk version ska ändå få ETT mejl.
+    v := public.resolve_email_template(kind, 'sv');
+    IF NOT coalesce((v ->> 'ok')::boolean, false) THEN
+      RAISE EXCEPTION 'resolve(%): no template resolved at all — an email would not go out', kind;
+    END IF;
+    v_html := v ->> 'html';
+    IF v_html IS NULL OR length(v_html) < 100 THEN
+      RAISE EXCEPTION 'resolve(%): the template came back without a body', kind;
+    END IF;
+    -- Etiketterna måste bo i MALLEN — det är hela flytten.
+    IF kind LIKE 'invoice%' AND v_html NOT LIKE '%Subtotal%' THEN
+      RAISE EXCEPTION 'resolve(%): the labels are not in the template text', kind;
+    END IF;
+    IF kind = 'order_confirmation' AND v_html NOT LIKE '%Quantity%' THEN
+      RAISE EXCEPTION 'resolve(%): the labels are not in the template text', kind;
+    END IF;
+    -- Sektionerna måste vara balanserade åt båda hållen.
+    IF (length(v_html) - length(replace(v_html, '{{#', ''))) / 3
+       <> (length(v_html) - length(replace(v_html, '{{/', ''))) / 3 THEN
+      RAISE EXCEPTION 'resolve(%): unbalanced template sections', kind;
+    END IF;
+  END LOOP;
+  RAISE NOTICE 'invoice + order emails: 3 kinds seeded and resolvable';
+END $$;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260903190000",
-      "migrations_count": 562,
+      "migration_head": "20260903210000",
+      "migrations_count": 563,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2253,6 +2253,10 @@
         {
           "version": "20260903190000",
           "name": "anteckningen-bor-i-mallen"
+        },
+        {
+          "version": "20260903210000",
+          "name": "fakturan-och-ordern-pa-mallralsen"
         }
       ]
     },
@@ -2276,7 +2280,7 @@
         "chat-completion": "sha256:d840d8aa54a221a3a59a3b114285c60a018ef13670f76d8bcb0a71b41ff5437c",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
-        "comms-send": "sha256:3074f89675ae1eb93c7f486298d19b671b6f33a23edd7ef35d11b3991ba63d0c",
+        "comms-send": "sha256:39dc9fde197bf59a92ae372f96263fe368238b212ad5674b299736ec1052d6b6",
         "composio-proxy": "sha256:08477e4658cee04b6a09458a5e8dc45fbf9737c2188f7b972ae954782a4bdc95",
         "composio-webhook": "sha256:27f17b7198bfbab422931ef1c872da083299e095792e43b98b4154ec79c858ca",
         "consultant-match": "sha256:1419717affb3711a2d7f13d44c9a228e1557a3d927e3aa05ee5e179584131e1b",


### PR DESCRIPTION
Samma recept som offerten/avtalet (20260903150000) och bokningen. Därmed är **alla** affärsmejl på mallrälsen.

## Tre sorter seedade på engelska
`invoice_email`, `invoice_reminder` (egen sort, egen ton), `order_confirmation` — `locale='en'` uttryckligen, `WHERE NOT EXISTS (name, locale)`, all språktext i mallen: Item/Amount/Subtotal/Tax/Total/Due, Product/Quantity/Price, knappar och footer. Villkorsdelar som **sektioner**: `{{#due_date}}` och `{{#items_rows}}` stryks när de är tomma, ordern hälsar `{{#customer_name}}` bara när namnet finns (motorn från #409).

## Avsändarna
- Prerendrar bara **data** (rader, belopp, datum, länkar); gamla HTML:en är Law 4-fallback — mejlet uteblir aldrig
- Fakturan: mottagarspråk via `partner_language(invoice.partner_id)` — samma som offerten
- Ordern: ingen part i registret (e-handelskund) → sajtens standardspråk, ärligt i stället för Accept-Language-gissning
- Ordermejlets produktnamn HTML-escapas nu (var rått)

## Bevis
DO-blocket kräver att etiketterna bor i mallen och att sektionerna är balanserade **åt båda hållen** (läxan från #409-granskningen). Manifest regenererat. 3681 tester gröna.

Svenska versioner läggs på Optic via gatewayn efter merge (datasteg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)