### PR TITLE
docs(fleet): forkarnas auto-deploy är verklighet — skills är enda handlagret

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,7 +385,11 @@ Regenerate the artifact (`npm run skills:json`) and sync each instance
 (`npm run sync:skills` dry-run, `-- --apply` to write). Full runbook, the live
 fleet's refs, and fork vs. auto-deploy topology:
 **[docs/operators/provisioning-and-updates.md](docs/operators/provisioning-and-updates.md)**.
-NB: forks (e.g. autoversio.ai) do NOT auto-deploy from a `main` push — notify the owner.
+NB: fork auto-deploy varies — VERIFY, don't assume: autoversio.ai and optictunnels.se
+auto-deploy BOTH Vercel and Supabase (migrations + edge functions) on a fork push
+(verified 2026-08-31: deployed sha == fork main). The layer NO fork rail covers is
+skills — run `DATABASE_URL=… npm run sync:skills -- --apply` per fork, or the
+admin "Sync skills from code" button.
 
 ### Drift & agent-usability learnings (operational)
 

--- a/docs/operators/provisioning-and-updates.md
+++ b/docs/operators/provisioning-and-updates.md
@@ -75,8 +75,11 @@ because that determines how a change reaches it:
 - **The production fleet is still deployed per instance** (the steps below) —
   the auto-deploy above points at ONE ref. Point it at prod, or extend it to a
   matrix, only deliberately.
-- **Forks (autoversio.ai)** need a manual fork-sync + redeploy. Always flag when
-  a change needs to reach a fork.
+- **Forks (autoversio.ai, optictunnels.se)**: `sync-forks.sh` pushes the fork, and
+  both now auto-deploy Vercel AND Supabase (migrations + edge functions) from that
+  push — verified 2026-08-31 (deployed sha == fork main). What NO fork rail covers
+  is the **skills layer**: run `sync:skills -- --apply` against the fork's DB (or
+  the admin "Sync skills from code" button) after changes that add/alter skills.
 
 ## Skill sync — closing the drift gap
 
@@ -143,8 +146,9 @@ After merging a change that touches **skills, handlers, or edge functions**:
    Public/agent-called functions **must** be `--no-verify-jwt` (and listed in
    `supabase/config.toml`) or server-to-server calls 401.
 5. **Sync skills** to every instance: `DATABASE_URL=… npm run sync:skills -- --apply`.
-6. **Forks** (autoversio.ai): sync the fork, then repeat 3–5 against it. **Notify
-   the fork owner** — a `main` push does not reach it.
+6. **Forks** (autoversio.ai): `sync-forks.sh`; migrations/edge auto-deploy from the
+   fork push (verify the fork's "Supabase Deploy" run) — step 5 (skills) is the one
+   you still run by hand against the fork's DB.
 7. **Verify**: `DATABASE_URL=… npm run lint:skill` per instance.
 
 ## Provisioning a brand-new site


### PR DESCRIPTION
*"Forks auto-deployar inte från main-push — notifiera ägaren"* var sant när det skrevs men är inaktuellt: både **autoversio** och **optic** kör Vercel + Supabase Deploy (migrationer + edge-funktioner) på forkens push. Verifierat i kväll: deployad sha == forkens main == vår main (`0d551997d`).

Regeln lurade nästan in en onödig manuell rebuild — och dolde det **verkliga** hålet: skills-lagret täcks inte av någon fork-räls (`list_stale_translations` saknades i autoversions `agent_skills` tills `sync:skills -- --apply` kördes för hand i kväll).

CLAUDE.md + provisioning-runbooken uppdaterade: verifiera deployad sha i stället för att lita på anteckningen; skills är steget som alltid körs per fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)