### PR TITLE
fix(i18n): cookiepolicyn är ett känt legalt id — footerns tredje standardlänk

### DIFF
--- a/src/components/public/PublicFooter.tsx
+++ b/src/components/public/PublicFooter.tsx
@@ -54,6 +54,7 @@ export function PublicFooter() {
   const legalPack: Record<string, string> = {
     privacy: t('footer.legal.privacy', 'Privacy Policy'),
     accessibility: t('footer.legal.accessibility', 'Accessibility'),
+    cookies: t('footer.legal.cookies', 'Cookie Policy'),
   };
 
   const quickLinksHeading = t('footer.quickLinks', 'Quick Links');

--- a/src/data/ui-text-catalog.json
+++ b/src/data/ui-text-catalog.json
@@ -406,6 +406,11 @@
       "fallback": "Accessibility"
     },
     {
+      "key": "footer.legal.cookies",
+      "group": "footer",
+      "fallback": "Cookie Policy"
+    },
+    {
       "key": "footer.legal.privacy",
       "group": "footer",
       "fallback": "Privacy Policy"


### PR DESCRIPTION
Magnus fann att footerns **"Cookiepolicy"** står kvar på svenska på engelska sidor. Länken bar ett genererat id (`link-17870…`), och okända id:n behåller operatörens etikett med flit — den ärliga gränsen (sajtspecifika länkar ska inte gissas). Men en cookiepolicy är ingen sajtspecifik länk: den är den tredje standardlänken bredvid integritet och tillgänglighet.

`cookies` blir känt id i `legalPack` (`footer.legal.cookies`, fallback *Cookie Policy*). Optics länk-id pekas om till `cookies` som datasteg efter merge. Katalogen 123 → 124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)