### PR TITLE
fix(i18n): jämförelsetabellens kolumnhuvud följer språket

### DIFF
--- a/src/components/public/blocks/ComparisonBlock.tsx
+++ b/src/components/public/blocks/ComparisonBlock.tsx
@@ -1,4 +1,5 @@
 import { ComparisonBlockData } from '@/types/cms';
+import { useUiText } from '@/lib/ui-text';
 import { Button } from '@/components/ui/button';
 import { Check, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -19,6 +20,7 @@ function CellValue({ value }: { value: boolean | string }) {
 }
 
 export function ComparisonBlock({ data }: ComparisonBlockProps) {
+  const t = useUiText();
   const {
     title,
     subtitle,
@@ -55,7 +57,7 @@ export function ComparisonBlock({ data }: ComparisonBlockProps) {
             <thead className={cn(stickyHeader && 'sticky top-0 z-10')}>
               <tr className="bg-muted/50">
                 <th className="p-4 text-left font-medium text-muted-foreground w-1/4">
-                  Features
+                  {t('comparison.features', 'Features')}
                 </th>
                 {products.map((product) => (
                   <th

--- a/src/data/ui-text-catalog.json
+++ b/src/data/ui-text-catalog.json
@@ -276,6 +276,11 @@
       "fallback": "Close"
     },
     {
+      "key": "comparison.features",
+      "group": "comparison",
+      "fallback": "Features"
+    },
+    {
       "key": "contact.hours",
       "group": "contact",
       "fallback": "Opening Hours"


### PR DESCRIPTION
Hittad i live-svepet: comparison-blockets hörncell skrev **Features** rakt i JSX:en — syns nu på nya landningssidan. Genom `t('comparison.features')`; katalogen 124 → 125. Svenska ('Egenskaper') läggs i instansernas pack som datasteg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)