### PR TITLE
Fix booking calendar day/month names to follow the visitor's language

### DIFF
--- a/src/components/public/blocks/SmartBookingBlock.tsx
+++ b/src/components/public/blocks/SmartBookingBlock.tsx
@@ -12,6 +12,7 @@ import { cn } from '@/lib/utils';
 import { BookingBlockData } from '@/types/cms';
 import { useBookingServices, useAvailableSlots } from '@/hooks/useBookings';
 import { usePlatformFormat } from '@/hooks/usePlatformFormat';
+import { useVisitorDateFormat } from '@/lib/visitor-date';
 import { webhookEvents } from '@/lib/webhook-utils';
 import { format, addDays, startOfWeek, addWeeks, isSameDay, isToday, isBefore, startOfDay } from 'date-fns';
 import { FALLBACK_CURRENCY } from '@/lib/platform-fallbacks';
@@ -27,7 +28,10 @@ type BookingStep = 'service' | 'datetime' | 'details' | 'confirmed';
 
 export function SmartBookingBlock({ data, blockId, pageId }: SmartBookingBlockProps) {
   const t = useUiText();
-  const { formatCurrency, formatDate } = usePlatformFormat();
+  const { formatCurrency } = usePlatformFormat();
+  // Veckodags- och månadsNAMN är språk, inte format: kalendern läses på sidans
+  // språk, inte i platform_locale — annars står "mån, tis" på en engelsk sida.
+  const { formatDate } = useVisitorDateFormat();
   const [step, setStep] = useState<BookingStep>('service');
   // Sant först när comms-send SVARAT att mailet gick (inte skipped/blocked) —
   // skärmen lovar bara det inkorgen faktiskt håller.

--- a/src/lib/__tests__/visitor-date.guardrails.test.ts
+++ b/src/lib/__tests__/visitor-date.guardrails.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { formatVisitorDate } from '../visitor-date';
+
+/**
+ * Bokningskalenderns dag- och månadsnamn följer BESÖKARENS språk.
+ *
+ * Verifierat live 2026-08-31: /en/booking visade "mån, tis, ons" och
+ * "31 aug. 2026 - 6 sep. 2026" — namnen red med platform_locale (sv-SE),
+ * som är ett formatval, inte ett språk (docs/architecture/language.md §0).
+ *
+ * Fast klocka: varje datum är en fryst UTC-ankrad konstant. Date.now() per
+ * rad har flakat förr — se page-language-grouping.guardrails.test.ts.
+ */
+const MON = new Date(Date.UTC(2026, 7, 31)); // måndag 31 aug 2026 — live-buggens vecka
+const SUN = new Date(Date.UTC(2026, 8, 6));
+
+describe('besökarens språk styr datumnamnen', () => {
+  it('veckoradens korta veckodagsnamn', () => {
+    const weekday = { weekday: 'short', year: undefined, month: undefined, day: undefined } as const;
+    expect(formatVisitorDate('sv', MON, weekday)).toBe('mån');
+    expect(formatVisitorDate('en', MON, weekday)).toBe('Mon');
+  });
+
+  it('veckonavigeringens intervall — exakt strängen från live-buggen', () => {
+    const from = formatVisitorDate('en', MON, { year: undefined, month: 'short', day: 'numeric' });
+    const to = formatVisitorDate('en', SUN, { year: 'numeric', month: 'short', day: 'numeric' });
+    expect(`${from} - ${to}`).toBe('Aug 31 - Sep 6, 2026');
+    expect(formatVisitorDate('sv', MON)).toBe('31 aug. 2026'); // så såg /en/booking ut
+  });
+
+  it('bekräftelsens fullständiga datum', () => {
+    const full = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' } as const;
+    expect(formatVisitorDate('en', MON, full)).toBe('Monday, August 31, 2026');
+    expect(formatVisitorDate('sv', MON, full)).toBe('måndag 31 augusti 2026');
+  });
+
+  it('samma UTC-ankare som plattformsformatteraren — datumet driver aldrig en dag', () => {
+    // En date-only-sträng renderas ordagrant oavsett testmiljöns tidszon.
+    expect(formatVisitorDate('en', '2026-09-06', { year: undefined, month: undefined, day: 'numeric' })).toBe('6');
+    expect(formatVisitorDate('en', null)).toBe('—');
+    expect(formatVisitorDate('en', 'inte-ett-datum')).toBe('inte-ett-datum');
+  });
+});
+
+describe('kopplingen i SmartBookingBlock', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../components/public/blocks/SmartBookingBlock.tsx'),
+    'utf-8',
+  );
+
+  it('datumen kommer från useVisitorDateFormat, inte usePlatformFormat', () => {
+    expect(src).toContain('useVisitorDateFormat()');
+    // Plattformshooken får finnas kvar för valuta — men inte äga formatDate.
+    const platformDestructure = src.match(/const\s*{([^}]*)}\s*=\s*usePlatformFormat\(\)/)?.[1] ?? '';
+    expect(
+      platformDestructure.includes('formatDate'),
+      'SmartBookingBlock tar formatDate från usePlatformFormat igen — då visar '
+      + '/en/booking "mån, tis" på nytt. Datumnamn ska gå via useVisitorDateFormat.',
+    ).toBe(false);
+  });
+});

--- a/src/lib/visitor-date.ts
+++ b/src/lib/visitor-date.ts
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+import { useUiTextLanguage } from '@/lib/ui-text';
+
+/**
+ * Date rendering that follows the VISITOR's language, not the platform locale.
+ *
+ * Weekday and month NAMES are language, not format. `usePlatformFormat` is the
+ * right owner of grouping, currency symbols and timezone — but its locale is
+ * `platform_locale`, which is a formatting setting (see
+ * docs/architecture/language.md §0: "not language; never confuse the two").
+ * A visitor on the English version of a page was reading "mån, tis, ons" and
+ * "31 aug. 2026" in the booking calendar because the names rode along with the
+ * format locale.
+ *
+ * This formatter keeps `formatDate`'s exact semantics — date-only, UTC-anchored
+ * so a value can never drift across a day boundary, same defaults, same
+ * options-merge behaviour — and takes ONLY the locale from the language the
+ * visitor is currently reading (`useUiTextLanguage().lang`, which already
+ * resolves to the site's own language when the page did not say).
+ *
+ * Scope: visitor-facing name-bearing dates (a booking calendar's weekday row,
+ * a "Monday, September 7, 2026" confirmation). Numbers, currency and admin
+ * surfaces stay on `usePlatformFormat`.
+ */
+export function formatVisitorDate(
+  lang: string,
+  dateOnly: string | Date | null | undefined,
+  options?: Omit<Intl.DateTimeFormatOptions, 'timeZone'>,
+): string {
+  if (!dateOnly) return '—';
+  let y: number, m: number, d: number;
+  if (typeof dateOnly === 'string') {
+    const match = dateOnly.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (!match) return dateOnly;
+    [, y, m, d] = match.map(Number) as unknown as [unknown, number, number, number];
+  } else {
+    y = dateOnly.getFullYear();
+    m = dateOnly.getMonth() + 1;
+    d = dateOnly.getDate();
+  }
+  const anchor = new Date(Date.UTC(y, m - 1, d));
+  try {
+    return new Intl.DateTimeFormat(lang, {
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit',
+      ...options,
+      // Applied LAST and non-overridable, same as the platform formatter: the
+      // UTC anchor is what stops a date-only value drifting a day.
+      timeZone: 'UTC',
+    }).format(anchor);
+  } catch {
+    return anchor.toISOString().slice(0, 10);
+  }
+}
+
+/** `formatVisitorDate` bound to the language the visitor is reading. */
+export function useVisitorDateFormat() {
+  const { lang, siteLang } = useUiTextLanguage();
+  const locale = lang || siteLang;
+  return useMemo(
+    () => ({
+      formatDate: (
+        dateOnly: string | Date | null | undefined,
+        options?: Omit<Intl.DateTimeFormatOptions, 'timeZone'>,
+      ) => formatVisitorDate(locale, dateOnly, options),
+    }),
+    [locale],
+  );
+}


### PR DESCRIPTION
## Bug

Verified live 2026-08-31 on optictunnels.se/en/booking: the booking calendar showed Swedish weekday abbreviations ("mån, tis, ons") and the week-navigation range "31 aug. 2026 - 6 sep. 2026" on the **English** page.

Root cause: `SmartBookingBlock` took `formatDate` from `usePlatformFormat`, whose locale is `platform_locale` (sv-SE). But weekday and month **names are language, not format** — `platform_locale` is "not language; never confuse the two" (docs/architecture/language.md §0), and the visitor's language lives in `useUiTextLanguage().lang`.

## Fix

- **New `src/lib/visitor-date.ts`** — `formatVisitorDate(lang, date, options)` plus a `useVisitorDateFormat()` hook whose Intl locale is `useUiTextLanguage().lang` (falls back to `siteLang`, which the context already resolves to when the page didn't declare a language). Keeps the platform `formatDate`'s exact semantics: date-only, UTC-anchored (no day drift), same defaults, same options-merge behaviour.
- **`SmartBookingBlock.tsx`** — `formatDate` now comes from `useVisitorDateFormat()`; all four date call sites (weekday row, week-nav range, booking summary, confirmation) follow the page language with no call-site changes. `formatCurrency` stays on `usePlatformFormat` — number/currency format is untouched, as are admin surfaces (English per policy).
- No public booking surface uses the shadcn/react-day-picker Calendar (the week grid is custom), and `BookingBlock`'s form mode uses native date inputs — so `SmartBookingBlock` was the only surface to fix.

## Guardrail test

`src/lib/__tests__/visitor-date.guardrails.test.ts` pins the exact live-bug strings ("mån"/"Mon", "31 aug. 2026" vs "Aug 31 - Sep 6, 2026") using a **fixed clock** — frozen UTC-anchored date constants, no `Date.now()` per row (the flake pattern noted in `page-language-grouping.guardrails.test.ts`). A second check refuses `SmartBookingBlock` ever destructuring `formatDate` from `usePlatformFormat` again.

## Validation

- `npx tsc -p tsconfig.app.json --noEmit` — clean
- `npx vitest run` — 3686 passed, 5 skipped
- `bun run scripts/lint-correctness-gate.ts` — 0 violations

After merge + fork sync: verify optictunnels.se/en/booking shows "Mon, Tue…" and /booking still shows "mån, tis…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6swUrxAWE53rfFrkUCify

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6swUrxAWE53rfFrkUCify)_