### PR TITLE
fix(blocks): herons bakgrund syns på iPhone — bg-fixed är trasig i iOS Safari

### DIFF
--- a/src/components/public/blocks/HeroBlock.tsx
+++ b/src/components/public/blocks/HeroBlock.tsx
@@ -465,7 +465,7 @@ export function HeroBlock({ data }: HeroBlockProps) {
         <div 
           className={cn(
             "absolute inset-0 bg-cover bg-center",
-            data.parallaxEffect && "bg-fixed"
+            data.parallaxEffect && "hero-parallax"
           )}
           style={{ backgroundImage: `url(${heroImage})` }}
         />

--- a/src/index.css
+++ b/src/index.css
@@ -412,3 +412,13 @@ html[data-scroll-animations="off"] *::after {
   animation: none !important;
   transition: none !important;
 }
+
+/* Parallax via background-attachment: fixed är trasig i iOS Safari
+   (bilden renderas blank tillsammans med bg-cover). Utility:n gäller
+   därför bara enheter med riktig pekare — på touch faller heron
+   tillbaka till vanlig bakgrund: bilden syns, utan parallax. */
+@media (hover: hover) and (pointer: fine) {
+  .hero-parallax {
+    background-attachment: fixed;
+  }
+}


### PR DESCRIPTION
Magnus såg att hero-bilden inte renderas på iPhone medan parallax-banden längre ned fungerar — och den observationen ÄR diagnosen: `parallax-section` kör transform-baserad parallax (`translate3d`, fungerar överallt), heron satte `bg-fixed`, och `background-attachment: fixed` + `bg-cover` renderar **blankt** i iOS Safari. Inte bildstorleken.

Fixen: `.hero-parallax`-utility som bara gäller `@media (hover: hover) and (pointer: fine)` — på touch faller heron tillbaka till vanlig bakgrund (bilden syns, utan effekt), på desktop behålls beteendet. Fail forward, ingen ny rendering på desktop.

Uppgradering till samma transform-teknik som systerblocket (riktig parallax även på mobil) är ett eget senare steg — ParallaxSectionBlock dokumenterar redan mönstret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)