### PR TITLE
feat(blocks): riktig parallax i heron — även på iPhone

### DIFF
--- a/src/components/public/blocks/HeroBlock.tsx
+++ b/src/components/public/blocks/HeroBlock.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useUiText } from '@/lib/ui-text';
+import { useParallaxBackground, parallaxLayerStyle } from '@/hooks/use-parallax-background';
 import { HeroBlockData, HeroTitleSize } from '@/types/cms';
 import { cn } from '@/lib/utils';
 import { ChevronDown, Play, Pause, Volume2, VolumeX } from 'lucide-react';
@@ -129,6 +130,8 @@ export function HeroBlock({ data }: HeroBlockProps) {
      Aliaset gör fältet sant i stället för att avlista det — sidor skrivna
      av äldre composer-utfall fortsätter fungera (Law 4). */
   const heroImage = data.backgroundImage || (data as { imageSrc?: string }).imageSrc;
+  const hasImageParallax = !!data.parallaxEffect && !!heroImage;
+  const { sectionRef, bgRef } = useParallaxBackground(hasImageParallax);
   const [isPlaying, setIsPlaying] = useState(true);
   const [isMuted, setIsMuted] = useState(data.videoMuted !== false);
   const [videoError, setVideoError] = useState(false);
@@ -445,6 +448,7 @@ export function HeroBlock({ data }: HeroBlockProps) {
 
   return (
     <section
+      ref={sectionRef}
       className={cn(
         "relative px-6 overflow-hidden flex",
         backgroundType === 'color' && "bg-primary text-primary-foreground",
@@ -462,12 +466,18 @@ export function HeroBlock({ data }: HeroBlockProps) {
       
       {/* Image Background */}
       {hasImageBackground && (
-        <div 
+        <div
+          ref={hasImageParallax ? bgRef : undefined}
           className={cn(
-            "absolute inset-0 bg-cover bg-center",
-            data.parallaxEffect && "hero-parallax"
+            "bg-cover bg-center",
+            hasImageParallax
+              ? "absolute left-0 w-full will-change-transform"
+              : "absolute inset-0"
           )}
-          style={{ backgroundImage: `url(${heroImage})` }}
+          style={{
+            backgroundImage: `url(${heroImage})`,
+            ...(hasImageParallax ? parallaxLayerStyle : null),
+          }}
         />
       )}
       

--- a/src/components/public/blocks/ParallaxSectionBlock.tsx
+++ b/src/components/public/blocks/ParallaxSectionBlock.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
+import { useParallaxBackground, parallaxLayerStyle } from '@/hooks/use-parallax-background';
 
 export interface ParallaxSectionBlockData {
   backgroundImage?: string;
@@ -29,8 +30,7 @@ const alignmentClasses: Record<string, string> = {
 };
 
 export function ParallaxSectionBlock({ data }: ParallaxSectionBlockProps) {
-  const sectionRef = useRef<HTMLDivElement>(null);
-  const bgRef = useRef<HTMLDivElement>(null);
+  const { sectionRef, bgRef } = useParallaxBackground(!!data.backgroundImage);
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
@@ -50,42 +50,7 @@ export function ParallaxSectionBlock({ data }: ParallaxSectionBlockProps) {
     return () => observer.disconnect();
   }, []);
 
-  // True parallax: the background layer is 30% taller than the section and
-  // translates at a fraction of the scroll delta. The old implementation used
-  // background-attachment: fixed, which is not parallax (the image just sits
-  // still) and which Chrome/iOS silently degrade to a plain static background
-  // on composited layers — the effect never fired for most visitors.
-  useEffect(() => {
-    const section = sectionRef.current;
-    const bg = bgRef.current;
-    if (!section || !bg || !data.backgroundImage) return;
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-
-    let raf = 0;
-    const update = () => {
-      raf = 0;
-      const rect = section.getBoundingClientRect();
-      if (rect.bottom < 0 || rect.top > window.innerHeight) return;
-      // -1 (section below viewport) … +1 (above); 0 when centered.
-      const progress =
-        (rect.top + rect.height / 2 - window.innerHeight / 2) /
-        (window.innerHeight / 2 + rect.height / 2);
-      // The layer is 30% taller, so ±15% of section height stays covered.
-      const shift = -progress * rect.height * 0.15;
-      bg.style.transform = `translate3d(0, ${shift}px, 0)`;
-    };
-    const onScroll = () => {
-      if (!raf) raf = requestAnimationFrame(update);
-    };
-    update();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    window.addEventListener('resize', onScroll, { passive: true });
-    return () => {
-      if (raf) cancelAnimationFrame(raf);
-      window.removeEventListener('scroll', onScroll);
-      window.removeEventListener('resize', onScroll);
-    };
-  }, [data.backgroundImage]);
+  // Delad parallaxmotor — samma som HeroBlock (use-parallax-background).
 
   const isLight = data.textColor !== 'dark';
   const opacity = data.overlayOpacity ?? 50;

--- a/src/hooks/use-parallax-background.ts
+++ b/src/hooks/use-parallax-background.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * True parallax for a section's background layer, shared by HeroBlock and
+ * ParallaxSectionBlock.
+ *
+ * The technique: the background layer is rendered 30% taller than its section
+ * (top: -15%, height: 130%) and translated at a fraction of the scroll delta,
+ * so the image drifts slower than the page. This is the only implementation
+ * that works everywhere — `background-attachment: fixed` renders BLANK in iOS
+ * Safari together with bg-cover (found live on an iPhone, 2026-09-01), and
+ * Chrome silently degrades it to a static background on composited layers.
+ *
+ * Respects prefers-reduced-motion: the layer simply stays put.
+ */
+export function useParallaxBackground(enabled: boolean) {
+  const sectionRef = useRef<HTMLElement | null>(null);
+  const bgRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const section = sectionRef.current;
+    const bg = bgRef.current;
+    if (!enabled || !section || !bg) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    let raf = 0;
+    const update = () => {
+      raf = 0;
+      const rect = section.getBoundingClientRect();
+      if (rect.bottom < 0 || rect.top > window.innerHeight) return;
+      // -1 (section below viewport) … +1 (above); 0 when centered.
+      const progress =
+        (rect.top + rect.height / 2 - window.innerHeight / 2) /
+        (window.innerHeight / 2 + rect.height / 2);
+      // The layer is 30% taller, so ±15% of section height stays covered.
+      const shift = -progress * rect.height * 0.15;
+      bg.style.transform = `translate3d(0, ${shift}px, 0)`;
+    };
+    const onScroll = () => {
+      if (!raf) raf = requestAnimationFrame(update);
+    };
+    update();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll, { passive: true });
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+    };
+  }, [enabled]);
+
+  return { sectionRef, bgRef };
+}
+
+/** Style for the oversized background layer the hook translates. */
+export const parallaxLayerStyle = { top: '-15%', height: '130%' } as const;

--- a/src/index.css
+++ b/src/index.css
@@ -413,12 +413,3 @@ html[data-scroll-animations="off"] *::after {
   transition: none !important;
 }
 
-/* Parallax via background-attachment: fixed är trasig i iOS Safari
-   (bilden renderas blank tillsammans med bg-cover). Utility:n gäller
-   därför bara enheter med riktig pekare — på touch faller heron
-   tillbaka till vanlig bakgrund: bilden syns, utan parallax. */
-@media (hover: hover) and (pointer: fine) {
-  .hero-parallax {
-    background-attachment: fixed;
-  }
-}


### PR DESCRIPTION
Uppföljning på #425: den lät heron falla tillbaka till statisk bakgrund på touch — Magnus ville ha effekten på mobil också, och systerblocket bevisar att det går.

- **Delad motor**: `use-parallax-background` — lagret 30 % högre än sektionen, `translate3d` en bråkdel av scrolldeltat via rAF. Fungerar överallt där `bg-fixed` renderar blankt i iOS Safari.
- **Båda blocken kör den**: ParallaxSectionBlock blev av med sin inline-kopia (identisk logik), HeroBlock fick riktig parallax.
- `prefers-reduced-motion` respekteras; `hero-parallax`-utilityn ur #425 städas bort som död CSS.
- Guardrail-fångst på vägen: naken `data.backgroundImage`-läsning → via `heroImage`-aliaset.

tsc + correctness-gate + 3686 tester gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)