### PR TITLE
fix(blocks): typewriter-animationen kapar inte underhängen

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -116,8 +116,12 @@ export default {
           to: { opacity: "1", transform: "translateY(0)" },
         },
         "typewriter": {
-          from: { opacity: "0", clipPath: "inset(0 100% 0 0)" },
-          to: { opacity: "1", clipPath: "inset(0 0 0 0)" },
+          // Vertikalt andrum (-0.25em): forwards låter slutlägets clip-path
+          // sitta kvar för alltid, och vid tajt radhöjd (1.05) sticker
+          // serifens underhäng utanför radboxen — inset(0) kapade g:et i
+          // "ground". Svepet är horisontellt; topp/botten ska aldrig klippa.
+          from: { opacity: "0", clipPath: "inset(-0.25em 100% -0.25em 0)" },
+          to: { opacity: "1", clipPath: "inset(-0.25em 0 -0.25em 0)" },
         },
         "blink": {
           "0%, 100%": { borderColor: "transparent" },


### PR DESCRIPTION
EN-herons titel tappade g:ets underhäng i *"…starts in the ground"*. Kedjan: typewriter-animationen sveper med `clip-path: inset()`, `forwards` låter slutläget `inset(0 0 0 0)` sitta kvar **permanent**, och vid radhöjd 1.05 sticker serifens underhäng utanför radboxen — exakt-vid-kanten-klippet kapade det. Syns bara på `/en` eftersom bara den heron kör typewriter.

Fix: `-0.25em` vertikalt andrum i båda keyframes — svepet är horisontellt och påverkas inte, topp/botten ska aldrig klippa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)