### PR TITLE
feat(blocks): herons knappar får en designväxel — solid/outline/ghost per knapp

### DIFF
--- a/src/components/admin/blocks/HeroBlockEditor.tsx
+++ b/src/components/admin/blocks/HeroBlockEditor.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useBlockEditor } from '@/hooks/useBlockEditor';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Slider } from '@/components/ui/slider';
@@ -613,6 +614,27 @@ export function HeroBlockEditor({ data, onChange, isEditing }: HeroBlockEditorPr
               }
               placeholder="Link"
             />
+            <Select
+              value={localData.primaryButton?.variant || 'default'}
+              onValueChange={(v) =>
+                handleChange({
+                  primaryButton: {
+                    ...localData.primaryButton,
+                    text: localData.primaryButton?.text || '',
+                    url: localData.primaryButton?.url || '',
+                    variant: v === 'default' ? undefined : (v as 'solid' | 'outline' | 'ghost'),
+                  },
+                })
+              }
+            >
+              <SelectTrigger><SelectValue placeholder="Style" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="default">Default (solid)</SelectItem>
+                <SelectItem value="solid">Solid</SelectItem>
+                <SelectItem value="outline">Outline</SelectItem>
+                <SelectItem value="ghost">Ghost (text only)</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
           <div className="space-y-2">
             <Label>Secondary Button</Label>
@@ -634,6 +656,27 @@ export function HeroBlockEditor({ data, onChange, isEditing }: HeroBlockEditorPr
               }
               placeholder="Link"
             />
+            <Select
+              value={localData.secondaryButton?.variant || 'default'}
+              onValueChange={(v) =>
+                handleChange({
+                  secondaryButton: {
+                    ...localData.secondaryButton,
+                    text: localData.secondaryButton?.text || '',
+                    url: localData.secondaryButton?.url || '',
+                    variant: v === 'default' ? undefined : (v as 'solid' | 'outline' | 'ghost'),
+                  },
+                })
+              }
+            >
+              <SelectTrigger><SelectValue placeholder="Style" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="default">Default (outline)</SelectItem>
+                <SelectItem value="solid">Solid</SelectItem>
+                <SelectItem value="outline">Outline</SelectItem>
+                <SelectItem value="ghost">Ghost (text only)</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
         </div>
       </div>

--- a/src/components/public/blocks/HeroBlock.tsx
+++ b/src/components/public/blocks/HeroBlock.tsx
@@ -69,6 +69,26 @@ const alignmentClasses: Record<string, string> = {
   bottom: 'items-end pb-32',
 };
 
+// Per-knapp-design med dagens utseende som default. Två kontexter: split-
+// layouten står på sidyta (tokens), den centrerade på bild/overlay (ljus på
+// mörkt). "ghost" är textknappen — för heros där EN handling ska dominera.
+const heroButtonClasses = (
+  variant: 'solid' | 'outline' | 'ghost' | undefined,
+  fallback: 'solid' | 'outline',
+  onOverlay: boolean,
+): string => {
+  const v = variant ?? fallback;
+  const base = 'inline-flex items-center justify-center px-6 py-3 font-medium rounded-lg transition-colors';
+  if (onOverlay) {
+    if (v === 'solid') return `${base} bg-background text-foreground hover:opacity-90`;
+    if (v === 'outline') return `${base} border border-current hover:bg-foreground/10`;
+    return `${base} underline underline-offset-4 hover:opacity-80`;
+  }
+  if (v === 'solid') return `${base} bg-primary text-primary-foreground hover:bg-primary/90`;
+  if (v === 'outline') return `${base} border border-border text-foreground hover:bg-muted`;
+  return `${base} underline underline-offset-4 text-foreground hover:opacity-80`;
+};
+
 const titleAnimationClasses: Record<string, string> = {
   none: '',
   'fade-in': 'animate-fade-in',
@@ -411,7 +431,7 @@ export function HeroBlock({ data }: HeroBlockProps) {
                   <a
                     href={data.primaryButton.url}
                     onClick={(e) => isAnchorLink(data.primaryButton?.url) && handleAnchorClick(e, data.primaryButton!.url)}
-                    className="inline-flex items-center justify-center px-6 py-3 bg-primary text-primary-foreground font-medium rounded-lg hover:bg-primary/90 transition-colors"
+                    className={heroButtonClasses(data.primaryButton.variant, 'solid', false)}
                   >
                     {data.primaryButton.text}
                   </a>
@@ -420,7 +440,7 @@ export function HeroBlock({ data }: HeroBlockProps) {
                   <a
                     href={data.secondaryButton.url}
                     onClick={(e) => isAnchorLink(data.secondaryButton?.url) && handleAnchorClick(e, data.secondaryButton!.url)}
-                    className="inline-flex items-center justify-center px-6 py-3 border border-border text-foreground font-medium rounded-lg hover:bg-muted transition-colors"
+                    className={heroButtonClasses(data.secondaryButton.variant, 'outline', false)}
                   >
                     {data.secondaryButton.text}
                   </a>
@@ -543,7 +563,7 @@ export function HeroBlock({ data }: HeroBlockProps) {
             <a
               href={data.primaryButton.url}
               onClick={(e) => isAnchorLink(data.primaryButton?.url) && handleAnchorClick(e, data.primaryButton!.url)}
-              className="bg-background text-foreground px-6 py-3 rounded-lg font-medium hover:opacity-90 transition-opacity"
+              className={heroButtonClasses(data.primaryButton.variant, 'solid', true)}
             >
               {data.primaryButton.text}
             </a>
@@ -552,7 +572,7 @@ export function HeroBlock({ data }: HeroBlockProps) {
             <a
               href={data.secondaryButton.url}
               onClick={(e) => isAnchorLink(data.secondaryButton?.url) && handleAnchorClick(e, data.secondaryButton!.url)}
-              className="border border-current px-6 py-3 rounded-lg font-medium hover:bg-foreground/10 transition-colors"
+              className={heroButtonClasses(data.secondaryButton.variant, 'outline', true)}
             >
               {data.secondaryButton.text}
             </a>

--- a/src/types/cms.ts
+++ b/src/types/cms.ts
@@ -421,6 +421,7 @@ export type HeroTextTheme = 'auto' | 'light' | 'dark';
 
 // Design System 2026: Hero title size options
 export type HeroTitleSize = 'default' | 'large' | 'display' | 'massive';
+export type HeroButtonVariant = 'solid' | 'outline' | 'ghost';
 
 export interface HeroBlockData {
   title: string;
@@ -456,9 +457,10 @@ export interface HeroBlockData {
   parallaxEffect?: boolean;
   titleAnimation?: 'none' | 'fade-in' | 'slide-up' | 'typewriter';
   showScrollIndicator?: boolean;
-  // Buttons
-  primaryButton?: { text: string; url: string };
-  secondaryButton?: { text: string; url: string };
+  // Buttons. `variant` växlar designen per knapp; utelämnad = dagens
+  // default (primär fylld, sekundär outline) så inga befintliga heros ändras.
+  primaryButton?: { text: string; url: string; variant?: HeroButtonVariant };
+  secondaryButton?: { text: string; url: string; variant?: HeroButtonVariant };
   // Design System 2026: Premium Typography
   titleSize?: HeroTitleSize;
   gradientTitle?: boolean;


### PR DESCRIPTION
Magnus: *"kan CTA-knapparna växla designen — en knapp för växla?"* Designen var hårdkodad (primär fylld, sekundär outline), och på mörk overlay ser de nästan likadana ut.

- Varje knapp får `variant?: 'solid' | 'outline' | 'ghost'` — **utelämnad = dagens utseende**, så inga befintliga heros ändras
- En delad `heroButtonClasses` ersätter fyra hårdkodade klassträngar (två layouter × två knappar); overlay- och sidyta-kontexterna behåller sina respektive paletter
- **Ghost** är textknappen (understruken) — för heros där EN handling ska dominera och den andra bara viska
- Editorn: en *Style*-väljare under varje knapps länkfält (Default/Solid/Outline/Ghost)

tsc + gate + 3686 tester gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)