### PR TITLE
docs(admin): språkkortet berättar hela sanningen — tre platser, ärlig default-flip

### DIFF
--- a/src/components/admin/settings/SiteLanguagesSettings.tsx
+++ b/src/components/admin/settings/SiteLanguagesSettings.tsx
@@ -204,8 +204,19 @@ export function SiteLanguagesSettings() {
           nothing appears to visitors until you do.
         </p>
         <p className="text-sm text-muted-foreground">
-          Changing the default decides which version a visitor lands on. It does not move any
-          page — every language keeps its own address, so existing links go on working.
+          Changing the default decides which version a visitor lands on, and which language
+          owns the root addresses: the default lives at <code>/about</code>, every other
+          language under its prefix (<code>/en/about</code>). Links to page slugs keep
+          working after a change; old <code>/xx/…</code> prefix links for the new default
+          stop resolving — so treat changing the default as a launch decision, not a toggle.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Pages are one of three places language lives. Visitor-facing interface strings
+          (buttons, empty states) are translated per language in the <strong>Translations</strong>{' '}
+          table below, and outbound email has one template per language under{' '}
+          <strong>Email → Templates</strong>. Removing a language here never deletes any of
+          them — it only closes the visitor-facing door; re-adding the language brings
+          everything back.
         </p>
       </CardContent>
     </Card>


### PR DESCRIPTION
Ur Magnus i18n-granskning: *"försvinner allt engelskt om man kryssar bort en? Får man en are-you-sure?"*

Vakterna fanns redan och är hårdare än en bekräftelsedialog: default-språket kan inte tas bort, ett språk **med sidor** (utkast inräknade) stoppas med sidräkning i klartext, och ingenting raderas någonsin — krysset är presentation. Men kortet **sa** inte det, och två pedagogiska luckor fanns:

1. **Default-bytet** beskrevs som ofarligt — sant för slug-länkar, men gamla `/xx/`-prefixlänkar för nya defaulten slutar lösa (prefix räknas bara för deklarerade icke-default-språk). Nu ärligt: *"a launch decision, not a toggle"*.
2. **Sidor är en av tre platser** språk bor. Kortet pekar nu på Translations-tabellen (chrome-strängar) och Email → Templates (mejlmallar), och säger uttryckligen: borttagning stänger besökardörren, återaktivering öppnar den — ingenting försvinner.

Ren copy-ändring i admin (engelska per policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)