### PR TITLE
fix(i18n): baslagrets språk läses ur deklarationen — platform_locale inverterade en hel sajt

### DIFF
--- a/src/lib/ui-text.tsx
+++ b/src/lib/ui-text.tsx
@@ -91,15 +91,24 @@ export function UiTextProvider({ children }: { children: ReactNode }) {
   // Read directly rather than through useSiteSettings: this provider sits above
   // everything and must not take on the settings module as a dependency.
   const { data: siteLocale } = useQuery({
-    queryKey: ['site-settings', 'platform_locale', 'ui-text'],
+    queryKey: ['site-settings', 'site-language', 'ui-text'],
     queryFn: async () => {
+      // The DECLARED site language is the truth about what the flat base layer
+      // is written in; platform_locale is only the pre-declaration fallback.
+      // Reading platform_locale alone inverted a whole site (nordbrygg,
+      // 2026-09-01): the key was missing, the base layer was assumed English,
+      // so Swedish pages showed English chrome and the English page Swedish.
       const { data, error } = await supabase
-        .from('site_settings').select('value').eq('key', 'platform_locale').maybeSingle();
+        .from('site_settings').select('key, value').in('key', ['site_languages', 'platform_locale']);
       // Degrade, but say so. Without the site's own language the base layer is
       // assumed English, and a Swedish site would quietly lose its chrome
       // strings on every page — worth a line in the log, never a blank UI.
-      if (error) logger.warn('[ui-text] platform_locale unreadable, assuming English base layer', error);
-      return ((data?.value as { default_locale?: string })?.default_locale) || 'en';
+      if (error) logger.warn('[ui-text] site language unreadable, assuming English base layer', error);
+      const byKey: Record<string, unknown> = {};
+      for (const row of data ?? []) byKey[row.key] = row.value;
+      const declared = (byKey.site_languages as { default?: string } | undefined)?.default;
+      const formatLocale = (byKey.platform_locale as { default_locale?: string } | undefined)?.default_locale;
+      return (declared || formatLocale || 'en').toLowerCase();
     },
     staleTime: 10 * 60 * 1000,
     retry: false,


### PR DESCRIPTION
Magnus fann **"Quick Links"** på nordbryggs svenska sidor — och `/en` visade **"Snabblänkar"**. Perfekt inverterat.

Rotorsak: `UiTextProvider` läste sajtens eget språk ur `platform_locale` (arvet från före språkdeklarationen — "the only clue"). Nyckeln saknades på nordbrygg → providern antog engelskt baslager → svenskan hoppades över på svenska sidor och applicerades på den engelska (där `lang === siteLang` råkade bli sant).

**Fixen:** `site_languages.default` är sanningen om baslagrets språk — providern läser den först, `platform_locale` som fallback för instanser före deklarationen, `'en'` sist. Ett anrop hämtar båda nycklarna.

Datafixen (nyckeln satt på nordbrygg) botade instansen direkt; det här botar **klassen** — felet låg latent på varje instans där formatnyckeln saknas men deklarationen finns. (SeoHead var redan rätt — den läser deklarationen.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)