### PR TITLE
chore(fleet): labs1100-forken in i sync-rälsen

### DIFF
--- a/docs/operators/provisioning-and-updates.md
+++ b/docs/operators/provisioning-and-updates.md
@@ -75,7 +75,7 @@ because that determines how a change reaches it:
 - **The production fleet is still deployed per instance** (the steps below) —
   the auto-deploy above points at ONE ref. Point it at prod, or extend it to a
   matrix, only deliberately.
-- **Forks (autoversio.ai, optictunnels.se)**: `sync-forks.sh` pushes the fork, and
+- **Forks (autoversio.ai, optictunnels.se, demo.labs1100.com)**: `sync-forks.sh` pushes the fork, and
   both now auto-deploy Vercel AND Supabase (migrations + edge functions) from that
   push — verified 2026-08-31 (deployed sha == fork main). What NO fork rail covers
   is the **skills layer**: run `sync:skills -- --apply` against the fork's DB (or

--- a/scripts/sync-forks.sh
+++ b/scripts/sync-forks.sh
@@ -30,7 +30,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-FORKS="WWW OPTIC LITEIT AUTOVERSIO RESTA"
+FORKS="WWW OPTIC LITEIT AUTOVERSIO RESTA LABS1100"
 ONLY="${1:-}"
 
 # Portable uppercase. `${ONLY^^}` is bash 4+, and macOS ships bash 3.2 as


### PR DESCRIPTION
demo.labs1100.com serveras av org-forken `labs1100/flowwink`, hittills synkad för hand i GitHub-UI:t — den stod inte i `FORKS`, så ingen main-push nådde den. Nu står den där; skriptet hoppar den snällt tills `GITHUB_TOKEN_LABS1100`/`GITHUB_REPO_LABS1100` finns i `.env.local` (magnusfroste-kontot saknar push till org-forken — merge-upstream gav 404 — så en token från labs1100-org:en krävs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)