### PR TITLE
fix(sales-intelligence): sidan säger vad poängen vilar på — innan första poängen

### DIFF
--- a/src/components/admin/sales-intelligence/SalesIntelligenceReadiness.tsx
+++ b/src/components/admin/sales-intelligence/SalesIntelligenceReadiness.tsx
@@ -42,17 +42,34 @@ function StatusIcon({ ok, required }: { ok: boolean; required: boolean }) {
  * is the "denied permission rendered as absent data" class: sales was told
  * nothing at all rather than "your ICP is missing, ask an admin".
  */
-export function SalesIntelligenceReadiness() {
-  const { data: status, isLoading } = useIntegrationStatus();
-  const { profile } = useCompanyInsights();
-  const { canAccess, isAdmin } = useModuleAccess();
-  const canReach = (req: Requirement) =>
-    isAdmin || (req.moduleId ? canAccess(req.moduleId) : false);
-
+/**
+ * The three facts the Setup tab diagnoses, as one hook — so the Research tab
+ * can say "your fit scores rest on an ICP that isn't there" BEFORE anyone
+ * clicks Setup to find out. One reader of each fact; the card and the hint
+ * can never disagree about what is rigged.
+ */
+export function useSalesIntelligenceReadiness() {
+  const { data: status, isLoading: integrationsLoading } = useIntegrationStatus();
+  const { profile, isLoading: profileLoading } = useCompanyInsights();
   const integrations = status?.integrations;
   const hasAi = !!(integrations?.openai || integrations?.gemini || integrations?.local_llm);
   const hasIcp = !!profile?.icp?.trim();
   const hasPositioning = !!(profile?.value_proposition?.trim() || (profile?.services?.length ?? 0) > 0);
+  return {
+    integrations,
+    hasAi,
+    hasIcp,
+    hasPositioning,
+    ready: hasAi && hasIcp && hasPositioning,
+    isLoading: integrationsLoading || !!profileLoading,
+  };
+}
+
+export function SalesIntelligenceReadiness() {
+  const { integrations, hasAi, hasIcp, hasPositioning, isLoading } = useSalesIntelligenceReadiness();
+  const { canAccess, isAdmin } = useModuleAccess();
+  const canReach = (req: Requirement) =>
+    isAdmin || (req.moduleId ? canAccess(req.moduleId) : false);
 
   const required: Requirement[] = [
     {

--- a/src/pages/admin/SalesIntelligencePage.tsx
+++ b/src/pages/admin/SalesIntelligencePage.tsx
@@ -9,12 +9,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { callSkill } from "@/lib/call-skill";
 import { toast } from "sonner";
-import { Search, Loader2, Target, Sparkles } from "lucide-react";
+import { Search, Loader2, Target, Sparkles, AlertTriangle } from "lucide-react";
 import { ResearchResultCards } from "@/components/admin/sales-intelligence/ResearchResultCards";
 import { FitAnalysisCard } from "@/components/admin/sales-intelligence/FitAnalysisCard";
 import { SalesProfileSetup } from "@/components/admin/sales-intelligence/SalesProfileSetup";
 import { ResearchHistory } from "@/components/admin/sales-intelligence/ResearchHistory";
-import { SalesIntelligenceReadiness } from "@/components/admin/sales-intelligence/SalesIntelligenceReadiness";
+import { SalesIntelligenceReadiness, useSalesIntelligenceReadiness } from "@/components/admin/sales-intelligence/SalesIntelligenceReadiness";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useProspectFit, loadSavedFit } from "@/hooks/useProspectFit";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { ResearchResult, FitAnalysisResult } from "@/components/admin/sales-intelligence/types";
@@ -25,6 +26,7 @@ export default function SalesIntelligencePage() {
   const [isResearching, setIsResearching] = useState(false);
   const { analyze, isAnalyzing } = useProspectFit();
   const [result, setResult] = useState<ResearchResult | null>(null);
+  const readiness = useSalesIntelligenceReadiness();
   const [fitResult, setFitResult] = useState<FitAnalysisResult | null>(null);
   // Deep-linkable tabs: the Profile page points sellers straight at their
   // sender profile (?tab=profiles), which is otherwise three clicks deep.
@@ -114,6 +116,36 @@ export default function SalesIntelligencePage() {
           </TabsList>
 
           <TabsContent value="research" className="space-y-4">
+            {/* What the scores rest on — said here, before the first score,
+                not discovered by clicking Setup. Every fit score is measured
+                against the ICP in Business Identity; with no ICP the page
+                still "works" and quietly scores from data alone. */}
+            {!readiness.isLoading && !readiness.ready && (
+              <Alert>
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Fit scores are measured against your Business Identity — and it isn't set up yet</AlertTitle>
+                <AlertDescription className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                  <span>
+                    Missing:{' '}
+                    {[
+                      !readiness.hasAi && 'an AI provider',
+                      !readiness.hasIcp && 'an Ideal Customer Profile',
+                      !readiness.hasPositioning && 'positioning & services',
+                    ].filter(Boolean).join(', ')}
+                    . Until then, scores come from data only.
+                  </span>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    className="h-auto p-0"
+                    onClick={() => setSearchParams({ tab: 'setup' }, { replace: true })}
+                  >
+                    Open Setup
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            )}
+
             {/* Research Input */}
             <Card>
               <CardHeader className="pb-3">
@@ -174,7 +206,7 @@ export default function SalesIntelligencePage() {
                       <div>
                         <p className="text-sm font-medium">Next step: Run Fit Analysis</p>
                         <p className="text-xs text-muted-foreground">
-                          Score this prospect, map problems to your services, and generate an intro letter
+                          Score this prospect against the ICP in your Business Identity, map its problems to your services, and generate an intro letter
                         </p>
                       </div>
                       <Button


### PR DESCRIPTION
## Vad
Research-fliken visar överst vad fit-poängen mäts mot (Business Identity: ICP + positionering + AI-leverantör) och exakt vad som saknas, med länk till Setup — i stället för att man upptäcker det genom att klicka på Setup. Nästa-steg-kortet namnger ICP:n som måttstock.

Tekniskt: Setup-kortets tre fakta lyfts till `useSalesIntelligenceReadiness()` som kortet och hinten båda läser (one fact, one reader).

## Verifiering
`tsc -p tsconfig.app.json` grön; guardrails (no-swallowed-errors, one-default-per-setting, hardcoded-visitor-text) gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)