### PR TITLE
fix(consultants): modulen bootstrapas vid mallinstall — och matchern sopar stale profiler själv

### DIFF
--- a/src/hooks/useTemplateInstaller.ts
+++ b/src/hooks/useTemplateInstaller.ts
@@ -20,6 +20,7 @@ import { packForCountry } from '@/lib/locale-packs';
 import { createDocumentFromText } from '@/lib/tiptap-utils';
 import type { ContentBlock } from '@/types/cms';
 import type { Json } from '@/integrations/supabase/types';
+import { bootstrapModule } from '@/lib/module-bootstrap';
 
 export type InstallStep = 'idle' | 'creating' | 'done';
 
@@ -416,12 +417,29 @@ export function useTemplateInstaller() {
         const wanted = template.requiredModules.includes('*' as never)
           ? (Object.keys(updatedModules) as (keyof ModulesSettings)[])
           : template.requiredModules;
+        const newlyEnabled: (keyof ModulesSettings)[] = [];
         for (const moduleId of wanted) {
           if (updatedModules[moduleId]) {
+            if (!updatedModules[moduleId].enabled) newlyEnabled.push(moduleId as keyof ModulesSettings);
             updatedModules[moduleId] = { ...updatedModules[moduleId], enabled: true };
           }
         }
         await updateModules.mutateAsync(updatedModules);
+        // "Enabled" has two writers — the Modules page toggle bootstraps the
+        // module (skills + automations), this path only flipped the flag. On
+        // demo.labs1100.com the consultants module came on with the template,
+        // so its 10-minute reindex automation was never seeded and every
+        // profile stayed `stale`: the matcher answered from keywords alone,
+        // no semantic score (Magnus, 2026-09-02). Same writer, same effect.
+        // Non-fatal: a bootstrap failure must never fail the install.
+        for (const moduleId of newlyEnabled) {
+          setProgress({ currentPage: 0, totalPages: 1, currentStep: `Bootstrapping ${String(moduleId)}...` });
+          try {
+            await bootstrapModule(moduleId, updatedModules, { triggeredBy: 'template-install' });
+          } catch (err) {
+            logger.warn(`[TemplateInstaller] bootstrap of ${String(moduleId)} failed (non-fatal):`, err);
+          }
+        }
       }
 
       // Auto-cleanup previous template using manifest

--- a/supabase/functions/consultant-match/index.ts
+++ b/supabase/functions/consultant-match/index.ts
@@ -99,6 +99,48 @@ function anonymizeMatch(m: any, mode: AnonMode) {
   return { ...safe, name: anonymizeName(m.name, mode) };
 }
 
+/**
+ * Embed a batch of profiles and mark them fresh (or `empty` when there is no
+ * text to embed). Shared by the reindex actions and the pre-search sweep so
+ * the two can never drift on what "embedded" means.
+ */
+async function embedProfiles(
+  supabase: any,
+  provider: ReturnType<typeof resolveEmbeddingProvider>,
+  profiles: any[],
+): Promise<{ processed: number; errors: Array<{ id: string; error: string }> }> {
+  let processed = 0;
+  const errors: Array<{ id: string; error: string }> = [];
+  for (const p of profiles) {
+    try {
+      const text = buildProfileText(p);
+      if (!text.trim()) {
+        await supabase
+          .from('consultant_profiles')
+          .update({ embedding_status: 'empty', embedded_at: new Date().toISOString() })
+          .eq('id', p.id);
+        continue;
+      }
+      const { embedding, model } = await embedText(text, provider);
+      // Use RPC-free direct update — bypass the stale trigger by NOT touching text columns
+      const { error: upErr } = await supabase
+        .from('consultant_profiles')
+        .update({
+          embedding: embedding as any,
+          embedding_model: `${provider.provider}:${model}`,
+          embedding_status: 'fresh',
+          embedded_at: new Date().toISOString(),
+        })
+        .eq('id', p.id);
+      if (upErr) throw upErr;
+      processed++;
+    } catch (e: any) {
+      errors.push({ id: p.id, error: e?.message || String(e) });
+    }
+  }
+  return { processed, errors };
+}
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
 
@@ -123,36 +165,7 @@ serve(async (req) => {
 
       const { settings, integrations, preferred } = await loadProviderSettings(supabase);
       const provider = resolveEmbeddingProvider(settings, integrations, preferred);
-
-      let processed = 0;
-      const errors: Array<{ id: string; error: string }> = [];
-      for (const p of stale) {
-        try {
-          const text = buildProfileText(p);
-          if (!text.trim()) {
-            await supabase
-              .from('consultant_profiles')
-              .update({ embedding_status: 'empty', embedded_at: new Date().toISOString() })
-              .eq('id', p.id);
-            continue;
-          }
-          const { embedding, model } = await embedText(text, provider);
-          // Use RPC-free direct update — bypass the stale trigger by NOT touching text columns
-          const { error: upErr } = await supabase
-            .from('consultant_profiles')
-            .update({
-              embedding: embedding as any,
-              embedding_model: `${provider.provider}:${model}`,
-              embedding_status: 'fresh',
-              embedded_at: new Date().toISOString(),
-            })
-            .eq('id', p.id);
-          if (upErr) throw upErr;
-          processed++;
-        } catch (e: any) {
-          errors.push({ id: p.id, error: e?.message || String(e) });
-        }
-      }
+      const { processed, errors } = await embedProfiles(supabase, provider, stale);
 
       return json({ success: true, processed, errors, provider: provider.provider, model: provider.model });
     }
@@ -203,14 +216,37 @@ serve(async (req) => {
     // Try to get a query embedding. If no provider, gracefully fall back to text-only search.
     let queryEmbedding: number[] | null = null;
     let usedProvider: string | null = null;
+    let provider: ReturnType<typeof resolveEmbeddingProvider> | null = null;
     try {
       const { settings, integrations, preferred } = await loadProviderSettings(supabase);
-      const provider = resolveEmbeddingProvider(settings, integrations, preferred);
+      provider = resolveEmbeddingProvider(settings, integrations, preferred);
       const r = await embedText(jobDescription, provider);
       queryEmbedding = r.embedding;
       usedProvider = `${provider.provider}:${provider.model}`;
     } catch (e) {
       console.warn('[consultant-match] embedding unavailable, falling back to text-only:', e);
+    }
+    // Fail forward (Law 4): a provider that can embed the QUERY can embed the
+    // profiles too. The 10-minute reindex automation is seeded by module
+    // bootstrap — on an instance where the module came on some other way
+    // (template install, hand-edited settings) it was never there, and every
+    // profile sat `stale` for weeks: keyword hits, no semantic rank, nobody
+    // told (demo.labs1100.com, 2026-09-02). A small bounded sweep here means
+    // the first search after a profile change already sees it. Non-fatal.
+    if (queryEmbedding && provider) {
+      try {
+        const { data: stale } = await supabase
+          .from('consultant_profiles')
+          .select('id, name, title, summary, bio, skills, certifications, languages, experience_years')
+          .eq('embedding_status', 'stale')
+          .limit(10);
+        if (stale?.length) {
+          const { processed, errors } = await embedProfiles(supabase, provider, stale);
+          console.log(`[consultant-match] swept ${processed} stale profile(s) before search`, errors.length ? errors : '');
+        }
+      } catch (e) {
+        console.warn('[consultant-match] stale sweep skipped:', e);
+      }
     }
 
     const { data: matches, error: rpcErr } = await supabase.rpc('match_consultants', {

--- a/supabase/functions/consultant-match/index.ts
+++ b/supabase/functions/consultant-match/index.ts
@@ -235,11 +235,12 @@ serve(async (req) => {
     // the first search after a profile change already sees it. Non-fatal.
     if (queryEmbedding && provider) {
       try {
-        const { data: stale } = await supabase
+        const { data: stale, error: staleErr } = await supabase
           .from('consultant_profiles')
           .select('id, name, title, summary, bio, skills, certifications, languages, experience_years')
           .eq('embedding_status', 'stale')
           .limit(10);
+        if (staleErr) throw staleErr;
         if (stale?.length) {
           const { processed, errors } = await embedProfiles(supabase, provider, stale);
           console.log(`[consultant-match] swept ${processed} stale profile(s) before search`, errors.length ? errors : '');

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260905090000",
-      "migrations_count": 567,
+      "migration_head": "20260904140000",
+      "migrations_count": 566,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2269,10 +2269,6 @@
         {
           "version": "20260904140000",
           "name": "kunskapsbasen-far-ett-sprak"
-        },
-        {
-          "version": "20260905090000",
-          "name": "tio-konsulter-i-demoseeden"
         }
       ]
     },

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260904140000",
-      "migrations_count": 566,
+      "migration_head": "20260905090000",
+      "migrations_count": 567,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2269,6 +2269,10 @@
         {
           "version": "20260904140000",
           "name": "kunskapsbasen-far-ett-sprak"
+        },
+        {
+          "version": "20260905090000",
+          "name": "tio-konsulter-i-demoseeden"
         }
       ]
     },
@@ -2295,7 +2299,7 @@
         "comms-send": "sha256:39dc9fde197bf59a92ae372f96263fe368238b212ad5674b299736ec1052d6b6",
         "composio-proxy": "sha256:08477e4658cee04b6a09458a5e8dc45fbf9737c2188f7b972ae954782a4bdc95",
         "composio-webhook": "sha256:27f17b7198bfbab422931ef1c872da083299e095792e43b98b4154ec79c858ca",
-        "consultant-match": "sha256:1419717affb3711a2d7f13d44c9a228e1557a3d927e3aa05ee5e179584131e1b",
+        "consultant-match": "sha256:19f388f6c2b0abcdadaef40912fc00ea6c49982f2e2c05f2252b486548326160",
         "content-api": "sha256:64c03bcaa94f7e17575c9e36611830c049cdcf372747ed2af264eb03c70bce42",
         "contract-billing-cron": "sha256:bd4af2f1f3c05253ae5635af48686f9f662f40a55b1b3097001c1828b35f898a",
         "contract-sign": "sha256:d4e4fb98e51109c626110dfeff57199cd006a62ed39501e0b171f32aec579bd7",


### PR DESCRIPTION
## Vad
- **Installatören bootstrapar** varje modul den slår på (`bootstrapModule`, icke-fatalt). Två skrivare av "enabled" hade olika effekt: Modules-sidan seedade skills+automations, installen bara flaggan → `consultant_reindex_stale` fanns aldrig på labs1100 och profilerna stod `stale` sedan augusti (Anna utan semantisk poäng).
- **consultant-match sopar** upp till 10 stale profiler före sökningen när en embedding-provider finns (Law 4: nyckeln finns → funktionen fungerar). Delad `embedProfiles()` för reindex och sop.

## Verifiering
- `deno check` grön på edge-funktionen; `tsc -p tsconfig.app.json` grön.
- labs1100: manuell `reindex_stale` gav 4/4 embeddade; publik sökning ger nu sem#1 cos 0.486 för Anna. Automationen seedas där via "Re-bootstrap" på consultants-modulen (eller nästa mallinstall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)