### PR TITLE
feat(admin): pinsen i headern kan dras i den ordning man vill

### DIFF
--- a/src/components/admin/AdminContentHeader.tsx
+++ b/src/components/admin/AdminContentHeader.tsx
@@ -3,15 +3,14 @@ import {
   LayoutDashboard, BarChart3, FileText, Users, Settings, BookOpen, Image, Mail,
   Puzzle, Webhook, UserCheck, Briefcase, Building2, Package, Library, ShoppingCart,
   CalendarDays, Plug, Bot, Zap, MessageSquare, Headphones, Megaphone, Code2,
-  Video, Target, Rocket, LayoutGrid, Inbox, Menu, UserCircle, LogOut, Pin, PinOff,
-  Github, ArrowUpCircle,
+  Video, Target, Rocket, LayoutGrid, Inbox, Menu, UserCircle, LogOut, Github, ArrowUpCircle,
 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { AdminThemeToggle } from './AdminThemeToggle';
 import { FlowPilotBriefingBell } from './FlowPilotBriefingBell';
 import { NotificationsBell } from './NotificationsBell';
 import { useIsModuleEnabled } from '@/hooks/useModules';
-import { usePinnedPages } from '@/hooks/usePinnedPages';
+import { PinnedPagesBar } from './PinnedPagesBar';
 import { useVersionCheck } from '@/hooks/useVersionCheck';
 import { QuickCreateMenu } from './QuickCreateMenu';
 
@@ -20,10 +19,6 @@ import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem,
   DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import {
-  Tooltip, TooltipContent, TooltipTrigger,
-} from '@/components/ui/tooltip';
-import { cn } from '@/lib/utils';
 
 // Icon registry — resolves the stored lucide icon NAME to its component.
 // The old hand-curated 31-icon map was why some pins had icons and others
@@ -39,7 +34,6 @@ export function AdminContentHeader() {
   const location = useLocation();
   const navigate = useNavigate();
   const { user, profile, signOut } = useAuth();
-  const { pins, removePin } = usePinnedPages(user?.id);
   const { currentVersion, latestVersion, latestReleaseUrl, hasUpdate } = useVersionCheck();
   const fpEnabled = useIsModuleEnabled('flowpilot');
   const GITHUB_RELEASES_URL = 'https://github.com/magnusfroste/flowwink/releases';
@@ -57,48 +51,7 @@ export function AdminContentHeader() {
       {/* Pinned favorites — only in dashboard mode */}
       {!isCopilotMode && (
         <div className="flex-1 flex items-center gap-0.5 overflow-x-auto scrollbar-none min-w-0 ml-1">
-          {pins.map((pin) => {
-            const Icon = iconMap[pin.icon] ?? FileText;
-            const isActive =
-              location.pathname === pin.href ||
-              (pin.href !== '/admin' && location.pathname.startsWith(pin.href));
-
-            return (
-              <Tooltip key={pin.href}>
-                <TooltipTrigger asChild>
-                  <Link
-                    to={pin.href}
-                    className={cn(
-                      'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-colors',
-                      isActive
-                        ? 'bg-accent text-accent-foreground'
-                        : 'text-muted-foreground hover:text-foreground hover:bg-muted',
-                    )}
-                  >
-                    {Icon && <Icon className="h-3.5 w-3.5 shrink-0" />}
-                    <span className="hidden sm:inline">{pin.name}</span>
-                  </Link>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="flex items-center gap-2">
-                  {pin.name}
-                  <button
-                    onClick={(e) => {
-                      e.preventDefault();
-                      removePin(pin.href);
-                    }}
-                    className="text-muted-foreground hover:text-destructive"
-                  >
-                    <PinOff className="h-3 w-3" />
-                  </button>
-                </TooltipContent>
-              </Tooltip>
-            );
-          })}
-          {pins.length === 0 && (
-            <span className="text-xs text-muted-foreground/50 ml-1 select-none">
-              Pin pages here for quick access
-            </span>
-          )}
+          <PinnedPagesBar userId={user?.id} />
         </div>
       )}
 

--- a/src/components/admin/PinnedPagesBar.tsx
+++ b/src/components/admin/PinnedPagesBar.tsx
@@ -1,0 +1,129 @@
+import { Link, useLocation } from 'react-router-dom';
+import { FileText, PinOff } from 'lucide-react';
+import * as LucideIcons from 'lucide-react';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { movePin, usePinnedPages, type PinnedPage } from '@/hooks/usePinnedPages';
+import { cn } from '@/lib/utils';
+
+const iconMap = LucideIcons as unknown as Record<string, React.ComponentType<{ className?: string }>>;
+
+/**
+ * The header's pinned pages — now in the order the user wants them.
+ *
+ * Order is the array in profiles.preferences.pinned_pages; dragging just
+ * rewrites it through the same optimistic write pin/unpin already uses.
+ * Three things keep this from being the slow, flaky drag-and-drop people
+ * expect: an 8 px activation distance so a click is still a click (pins are
+ * links), no drag at all under the tablet breakpoint where touch-drag fights
+ * page scroll (order there comes from the sidebar), and a list that is at
+ * most eight items wide, which dnd-kit measures for free.
+ */
+export function PinnedPagesBar({ userId }: { userId: string | undefined }) {
+  const { pins, removePin, reorderPins } = usePinnedPages(userId);
+  const isMobile = useIsMobile();
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const onDragEnd = (e: DragEndEvent) => {
+    const { active, over } = e;
+    if (!over || active.id === over.id) return;
+    const from = pins.findIndex((p) => p.href === active.id);
+    const to = pins.findIndex((p) => p.href === over.id);
+    reorderPins(movePin(pins, from, to));
+  };
+
+  if (pins.length === 0) {
+    return (
+      <span className="text-xs text-muted-foreground/50 ml-1 select-none">
+        Pin pages here for quick access
+      </span>
+    );
+  }
+
+  const items = pins.map((pin) => (
+    <PinItem key={pin.href} pin={pin} draggable={!isMobile} onRemove={() => removePin(pin.href)} />
+  ));
+
+  if (isMobile) return <>{items}</>;
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+      <SortableContext items={pins.map((p) => p.href)} strategy={horizontalListSortingStrategy}>
+        {items}
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+function PinItem({ pin, draggable, onRemove }: { pin: PinnedPage; draggable: boolean; onRemove: () => void }) {
+  const location = useLocation();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: pin.href,
+    disabled: !draggable,
+  });
+  const Icon = iconMap[pin.icon] ?? FileText;
+  // dnd-kit hands out role="button" for a sortable; a pin IS a link and
+  // screen readers should keep hearing it as one.
+  const { role: _sortableRole, ...a11y } = attributes;
+  const isActive =
+    location.pathname === pin.href ||
+    (pin.href !== '/admin' && location.pathname.startsWith(pin.href));
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Link
+          ref={setNodeRef}
+          to={pin.href}
+          style={{ transform: CSS.Transform.toString(transform), transition }}
+          {...a11y}
+          {...listeners}
+          // A drag that ended over the same spot still counts as a click for
+          // the pointer sensor; a real drag (past the 8 px threshold) does not
+          // — but the link's own navigation must be stopped while dragging.
+          onClick={(e) => { if (isDragging) e.preventDefault(); }}
+          className={cn(
+            'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-colors touch-none',
+            draggable && 'cursor-grab active:cursor-grabbing',
+            isDragging && 'opacity-60 shadow-md bg-background z-10',
+            isActive
+              ? 'bg-accent text-accent-foreground'
+              : 'text-muted-foreground hover:text-foreground hover:bg-muted',
+          )}
+        >
+          <Icon className="h-3.5 w-3.5 shrink-0" />
+          <span className="hidden sm:inline">{pin.name}</span>
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="flex items-center gap-2">
+        {pin.name}
+        <button
+          onClick={(e) => { e.preventDefault(); onRemove(); }}
+          className="text-muted-foreground hover:text-destructive"
+          aria-label={`Unpin ${pin.name}`}
+        >
+          <PinOff className="h-3 w-3" />
+        </button>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/hooks/__tests__/usePinnedPages.reorder.test.ts
+++ b/src/hooks/__tests__/usePinnedPages.reorder.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { movePin, sameSet, type PinnedPage } from '../usePinnedPages';
+
+const pin = (href: string): PinnedPage => ({ href, name: href, icon: 'FileText' });
+const pins = ['/admin/pages', '/admin/leads', '/admin/quotes', '/admin/invoices'].map(pin);
+
+describe('header pins reorder by drag — order is the array', () => {
+  it('moves an item forward and backward without losing any', () => {
+    expect(movePin(pins, 0, 2).map((p) => p.href)).toEqual(['/admin/leads', '/admin/quotes', '/admin/pages', '/admin/invoices']);
+    expect(movePin(pins, 3, 0).map((p) => p.href)).toEqual(['/admin/invoices', '/admin/pages', '/admin/leads', '/admin/quotes']);
+  });
+  it('is a no-op for the same spot or an index off the list', () => {
+    expect(movePin(pins, 1, 1)).toBe(pins);
+    expect(movePin(pins, -1, 2)).toBe(pins);
+    expect(movePin(pins, 1, 9)).toBe(pins);
+  });
+  it('a reorder may never add or drop a pin — a stale drag after an unpin is refused', () => {
+    expect(sameSet(pins, movePin(pins, 0, 3))).toBe(true);
+    expect(sameSet(pins, pins.slice(1))).toBe(false);
+    expect(sameSet(pins, [...pins.slice(1), pin('/admin/other')])).toBe(false);
+  });
+});

--- a/src/hooks/usePinnedPages.ts
+++ b/src/hooks/usePinnedPages.ts
@@ -113,5 +113,35 @@ export function usePinnedPages(userId: string | undefined) {
     [pins],
   );
 
-  return { pins, addPin, removePin, isPinned };
+  /**
+   * Reorder — the header's drag-and-drop. Order IS the array; nothing new is
+   * stored. Refused when the set differs (a stale drag after a pin/unpin
+   * elsewhere must not resurrect or drop a pin).
+   */
+  const reorderPins = useCallback(
+    (next: PinnedPage[]) => {
+      if (!userId) return;
+      if (!sameSet(pins, next)) return;
+      write.mutate(next);
+    },
+    [userId, pins, write],
+  );
+
+  return { pins, addPin, removePin, isPinned, reorderPins };
+}
+
+/** Same pins, any order. */
+export function sameSet(a: PinnedPage[], b: PinnedPage[]): boolean {
+  if (a.length !== b.length) return false;
+  const hrefs = new Set(a.map((p) => p.href));
+  return b.every((p) => hrefs.has(p.href));
+}
+
+/** Pure move used by the header: item at `from` lands at `to`. */
+export function movePin(pins: PinnedPage[], from: number, to: number): PinnedPage[] {
+  if (from === to || from < 0 || to < 0 || from >= pins.length || to >= pins.length) return pins;
+  const next = pins.slice();
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
 }


### PR DESCRIPTION
## Vad
Dra-och-släpp-ordning för pinnade sidor i admin-headern (`PinnedPagesBar`, dnd-kit sortable, horisontell). Ordningen sparas i samma `pinned_pages`-array som redan finns; `reorderPins` vägrar ändra mängden pins. 8 px aktiveringsavstånd, avstängt under 768 px, tangentbordsstöd, länksemantik bevarad.

## Verifiering
`tsc` grön; enhetstest för `movePin`/`sameSet`; guardrails gröna. Ingen ny lagring, inget nytt bibliotek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)