### PR TITLE
feat(chat): publik chat kan pinnas till en molnleverantör medan systemet kör privat

### DIFF
--- a/src/hooks/useSiteSettings.tsx
+++ b/src/hooks/useSiteSettings.tsx
@@ -217,6 +217,8 @@ const defaultMaintenanceSettings: MaintenanceSettings = {
 
 // Chat settings
 export type ChatAiProvider = 'openai' | 'gemini' | 'local' | 'n8n';
+/** Per-surface provider pin for the public chat; 'system' = follow the AI map. */
+export type ChatProviderOverride = 'system' | 'openai' | 'gemini' | 'anthropic';
 export type ChatSttProvider = 'browser' | 'openai' | 'gemini' | 'local' | 'elevenlabs';
 export type ChatTtsProvider = 'none' | 'openai' | 'gemini' | 'local';
 export type ChatWidgetStyle = 'floating' | 'pill' | 'expanded';
@@ -230,20 +232,20 @@ export interface ChatSettings {
   placeholder: string;
   welcomeMessage: string;
   
-  // AI-leverantör
+  // AI-leverantör: 'n8n' är ett vägval ut ur plattformen; allt annat betyder
+  // "plattformens AI" (historiskt default 'openai' på de flesta rader).
   aiProvider: ChatAiProvider;
-  
-  // OpenAI (model selection only - keys managed via integrations)
-  openaiModel: 'gpt-4o' | 'gpt-4o-mini' | 'gpt-3.5-turbo';
-  openaiBaseUrl: string;
-  
-  // Google Gemini (model selection only - keys managed via integrations)
-  geminiModel: 'gemini-2.0-flash-exp' | 'gemini-1.5-pro' | 'gemini-1.5-flash';
-  
-  // Local AI - endpoint config (keys managed via integrations or Supabase secrets)
-  localEndpoint: string;
-  localModel: string;
-  
+  /**
+   * Chattens egen LEVERANTÖR — aldrig modell. 'system' följer AI-kartan
+   * (site_settings.system_ai); en molnleverantör pinnar bara den publika
+   * chatten dit medan FlowWork, FlowPilot och alla interna skills kör kvar på
+   * kartans leverantör. Modellerna kommer alltid ur kartans tabell per
+   * leverantör. (De gamla modellfälten openaiModel/geminiModel/localEndpoint
+   * m.fl. lästes inte av någon sedan kartan infördes och är borta ur typen;
+   * raderna i DB får behålla dem.)
+   */
+  providerOverride: ChatProviderOverride;
+
   // N8N Integration - webhook config (keys managed via integrations or Supabase secrets)
   n8nWebhookUrl: string;
   n8nWebhookType: 'chat' | 'generic';
@@ -340,11 +342,7 @@ export const defaultChatSettings: ChatSettings = {
   placeholder: 'Ask a question...',
   welcomeMessage: 'Hi! How can I help you today?',
   aiProvider: 'openai',
-  openaiModel: 'gpt-4o-mini',
-  openaiBaseUrl: 'https://api.openai.com/v1',
-  geminiModel: 'gemini-2.0-flash-exp',
-  localEndpoint: '',
-  localModel: '',
+  providerOverride: 'system',
   n8nWebhookUrl: '',
   n8nWebhookType: 'chat',
   n8nTriggerMode: 'always',

--- a/src/lib/__tests__/ai-config-surface-override.test.ts
+++ b/src/lib/__tests__/ai-config-surface-override.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { resolveAiConfig } from '../../../supabase/functions/_shared/ai-config';
+
+/**
+ * "Private system, public chat": the AI map's provider is the default for
+ * every surface; a surface may pin a PROVIDER (never a model) for itself.
+ * The public chat is the surface that does. These pin down the contract so
+ * the split cannot silently invert:
+ *  - no option → the map's provider (here: a private endpoint);
+ *  - pinned provider → that provider, with the MAP's model for it;
+ *  - a pin without a credential → the ladder answers, flagged `fallback`.
+ */
+const ENV: Record<string, string> = { OPENAI_API_KEY: 'sk-test', GEMINI_API_KEY: 'g-test' };
+
+function fakeSupabase(systemAi: Record<string, unknown>, integrations: Record<string, unknown>) {
+  const rows: Record<string, unknown> = { system_ai: systemAi, integrations };
+  return {
+    from: () => ({
+      select: () => ({
+        eq: (_col: string, key: string) => ({
+          maybeSingle: async () => ({ data: { value: rows[key] } }),
+        }),
+      }),
+    }),
+  };
+}
+
+const privateSystem = {
+  provider: 'local',
+  openaiModel: 'gpt-4.1-mini',
+  openaiReasoningModel: 'gpt-4.1',
+  geminiModel: 'gemini-2.5-flash',
+};
+const localLlm = { local_llm: { config: { endpoint: 'http://llm.internal:8000/v1', model: 'llama-3.3-70b' } } };
+
+describe('resolveAiConfig — a surface pins a provider, never a model', () => {
+  beforeAll(() => { (globalThis as any).Deno = { env: { get: (k: string) => ENV[k] } }; });
+  afterAll(() => { delete (globalThis as any).Deno; });
+
+  it('follows the map when no surface pin is given — the private endpoint', async () => {
+    const ai = await resolveAiConfig(fakeSupabase(privateSystem, localLlm), 'fast');
+    expect(ai.provider).toBe('local');
+    expect(ai.model).toBe('llama-3.3-70b');
+    expect(ai.fallback).toBe(false);
+  });
+
+  it('a pinned cloud provider answers with the MAP’s model for that provider', async () => {
+    const ai = await resolveAiConfig(fakeSupabase(privateSystem, localLlm), 'fast', { provider: 'openai' });
+    expect(ai.provider).toBe('openai');
+    expect(ai.model).toBe('gpt-4.1-mini');
+    expect(ai.fallback).toBe(false);
+    const reasoning = await resolveAiConfig(fakeSupabase(privateSystem, localLlm), 'reasoning', { provider: 'openai' });
+    expect(reasoning.model).toBe('gpt-4.1');
+  });
+
+  it('a pin without a credential does not silently pass as the pin — the ladder answers and says so', async () => {
+    const ai = await resolveAiConfig(fakeSupabase(privateSystem, localLlm), 'fast', { provider: 'anthropic' });
+    expect(ai.provider).not.toBe('anthropic');
+    expect(ai.fallback).toBe(true);
+  });
+});

--- a/src/pages/admin/ChatSettingsPage.tsx
+++ b/src/pages/admin/ChatSettingsPage.tsx
@@ -59,10 +59,14 @@ type PlatformAi = {
 function ActiveProviderIndicator({
   selectedProvider,
   platformAi,
+  pinned,
   integrationSettings
 }: {
   selectedProvider: ChatAiProvider;
+  /** The provider THIS chat answers from — the map's, or the chat's own pin. */
   platformAi: PlatformAi;
+  /** True when the chat is pinned to a provider other than the map's. */
+  pinned: boolean;
   integrationSettings: IntegrationsSettings | undefined;
 }) {
   const status = selectedProvider === 'n8n'
@@ -75,13 +79,15 @@ function ActiveProviderIndicator({
         detail: `Mode: ${integrationSettings?.n8n?.config?.webhookType || 'chat'}`,
       }
     : {
-        name: `Platform AI · ${platformAi.label}`,
+        name: pinned ? `This chat · ${platformAi.label}` : `Platform AI · ${platformAi.label}`,
         model: platformAi.model,
         isConfigured: platformAi.isConfigured,
         icon: platformAi.provider === 'local' ? <Server className="h-4 w-4" /> : <Cloud className="h-4 w-4" />,
         settingsTo: '/admin/system#ai',
         detail: platformAi.model
-          ? `Using ${platformAi.model} — from the platform AI map`
+          ? (pinned
+              ? `Using ${platformAi.model} — pinned for this chat; the rest of the platform follows the AI map`
+              : `Using ${platformAi.model} — from the platform AI map`)
           : 'No model set in the platform AI map',
       };
 
@@ -177,6 +183,27 @@ export default function ChatSettingsPage() {
     isAnthropicConfigured,
     isLocalLlmConfigured,
   ]);
+  // The provider THIS chat answers from: the map's, unless the chat pins one.
+  // A pin changes the provider only — the model is still the map's fast-tier
+  // model for that provider (one place to choose models). Anthropic is not
+  // offered: the chat streams OpenAI-style SSE and cannot speak its protocol.
+  const providerOverride = formData?.providerOverride ?? 'system';
+  const pinnedProvider: Exclude<SystemAiProvider, 'local' | 'anthropic'> | null =
+    providerOverride === 'openai' || providerOverride === 'gemini' ? providerOverride : null;
+  const chatAi = useMemo<PlatformAi>(() => {
+    if (!pinnedProvider) return platformAi;
+    const configuredByProvider: Record<'openai' | 'gemini', boolean> = {
+      openai: isOpenAIConfigured === true,
+      gemini: isGeminiConfigured === true,
+    };
+    return {
+      provider: pinnedProvider,
+      label: PLATFORM_PROVIDER_LABEL[pinnedProvider],
+      model: systemAiSettings?.[SYSTEM_AI_MODEL_FIELDS[pinnedProvider].fast] ?? '',
+      isConfigured: configuredByProvider[pinnedProvider],
+    };
+  }, [pinnedProvider, platformAi, systemAiSettings, isOpenAIConfigured, isGeminiConfigured]);
+  const isPinned = pinnedProvider !== null && pinnedProvider !== platformAi.provider;
   const flowpilotReadiness = useModuleReadiness('chat');
   const flowpilotMissing = flowpilotReadiness.flowPilotEnhancedButMissing || flowpilotReadiness.missingFlowPilot;
   // Available external skills for the allow-list
@@ -290,10 +317,10 @@ export default function ChatSettingsPage() {
 
         {/* The credential that matters is the one the model map points at, not a
             provider the chat picked — the chat no longer picks one. */}
-        {formData.aiProvider !== 'n8n' && platformAi.provider === 'openai' && isOpenAIConfigured === false && (
+        {formData.aiProvider !== 'n8n' && chatAi.provider === 'openai' && isOpenAIConfigured === false && (
           <IntegrationWarning integration="openai" />
         )}
-        {formData.aiProvider !== 'n8n' && platformAi.provider === 'gemini' && isGeminiConfigured === false && (
+        {formData.aiProvider !== 'n8n' && chatAi.provider === 'gemini' && isGeminiConfigured === false && (
           <IntegrationWarning integration="gemini" />
         )}
 
@@ -309,7 +336,8 @@ export default function ChatSettingsPage() {
           <CardContent className="pt-0">
             <ActiveProviderIndicator
               selectedProvider={formData.aiProvider}
-              platformAi={platformAi}
+              platformAi={chatAi}
+              pinned={isPinned}
               integrationSettings={integrationSettings}
             />
           </CardContent>
@@ -478,25 +506,58 @@ export default function ChatSettingsPage() {
                     <div className="pt-4 border-t space-y-4">
                       {formData.aiProvider !== 'n8n' && (
                         <>
+                          {/* The chat's ONE decision beyond n8n: which provider
+                              answers visitors. Never a model — those stay in
+                              the map, per provider. The case this exists for:
+                              a private system AI (patient data, contracts,
+                              FlowWork) and a public chat that may run on a
+                              cloud model. Only providers with a credential
+                              are offered; Anthropic is not (the chat streams
+                              OpenAI-style SSE). */}
+                          <div className="space-y-2">
+                            <Label>Provider for this chat</Label>
+                            <Select
+                              value={providerOverride}
+                              onValueChange={(v) => setFormData({ ...formData, providerOverride: v as ChatSettings['providerOverride'] })}
+                            >
+                              <SelectTrigger className="max-w-md">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="system">Follow the platform AI — {platformAi.label}</SelectItem>
+                                {isOpenAIConfigured && platformAi.provider !== 'openai' && (
+                                  <SelectItem value="openai">OpenAI — cloud, for this chat only</SelectItem>
+                                )}
+                                {isGeminiConfigured && platformAi.provider !== 'gemini' && (
+                                  <SelectItem value="gemini">Google Gemini — cloud, for this chat only</SelectItem>
+                                )}
+                              </SelectContent>
+                            </Select>
+                            <p className="text-xs text-muted-foreground">
+                              {isPinned
+                                ? `Visitor messages go to ${chatAi.label}. FlowWork, FlowPilot and every internal skill keep running on ${platformAi.label}.`
+                                : 'The chat answers from the same provider as the rest of the platform. Pin a cloud provider here when the system AI is private and the public chat may not be.'}
+                            </p>
+                          </div>
                           <ProvenanceLine to="/admin/system#ai" linkLabel="System Settings → AI">
                             Model comes from the platform AI map — currently{' '}
-                            {platformAi.model
-                              ? <span className="font-mono">{platformAi.model}</span>
+                            {chatAi.model
+                              ? <span className="font-mono">{chatAi.model}</span>
                               : 'not set'}{' '}
-                            on {platformAi.label}. Configure in System Settings → AI.
+                            on {chatAi.label}. Models are chosen per provider in System Settings → AI.
                           </ProvenanceLine>
-                          {platformAi.isConfigured ? (
+                          {chatAi.isConfigured ? (
                             <Alert className="bg-green-50 border-green-200 dark:bg-green-950 dark:border-green-900">
-                              {platformAi.provider === 'local'
+                              {chatAi.provider === 'local'
                                 ? <Shield className="h-4 w-4 text-green-600" />
                                 : <CheckCircle2 className="h-4 w-4 text-green-600" />}
                               <AlertTitle className="text-green-800 dark:text-green-200">
-                                Platform AI ready — {platformAi.label}
+                                Platform AI ready — {chatAi.label}
                               </AlertTitle>
                               <AlertDescription className="text-green-700 dark:text-green-300">
-                                {platformAi.provider === 'local'
+                                {chatAi.provider === 'local'
                                   ? `Endpoint: ${integrationSettings?.local_llm?.config?.endpoint || 'Not set'}. Data never leaves your infrastructure.`
-                                  : `Fast-tier model: ${platformAi.model || 'not set'}.`}{' '}
+                                  : `Fast-tier model: ${chatAi.model || 'not set'}.`}{' '}
                                 <Link to="/admin/system#ai" className="underline">
                                   Change the model map
                                 </Link>
@@ -505,9 +566,9 @@ export default function ChatSettingsPage() {
                           ) : (
                             <Alert>
                               <XCircle className="h-4 w-4" />
-                              <AlertTitle>{platformAi.label} not configured</AlertTitle>
+                              <AlertTitle>{chatAi.label} not configured</AlertTitle>
                               <AlertDescription>
-                                The model map points at {platformAi.label}, but its credential is
+                                The model map points at {chatAi.label}, but its credential is
                                 missing. Add it in{' '}
                                 <Link to="/admin/integrations#ai" className="text-primary underline">
                                   Integrations → AI
@@ -1435,7 +1496,7 @@ export default function ChatSettingsPage() {
                 {/* Local AI Tool Calling Support Toggle — relevant when the model
                     map points at a self-hosted model, which is now what decides
                     it (the chat no longer selects 'local' itself). */}
-                {formData.toolCallingEnabled && formData.aiProvider !== 'n8n' && platformAi.provider === 'local' && !flowpilotMissing && (
+                {formData.toolCallingEnabled && formData.aiProvider !== 'n8n' && chatAi.provider === 'local' && !flowpilotMissing && (
                   <Card>
                     <CardHeader>
                       <div className="flex items-center justify-between">

--- a/supabase/functions/_shared/ai-config.ts
+++ b/supabase/functions/_shared/ai-config.ts
@@ -37,9 +37,23 @@ export interface ResolvedAiConfig {
   fallback: boolean;
 }
 
+export interface ResolveAiOptions {
+  /**
+   * A SURFACE's own provider choice, overriding the map's default provider —
+   * never the model: models stay in the map's per-provider table, so a
+   * surface that picks OpenAI gets the map's OpenAI models. The one surface
+   * that uses this is the public chat (site_settings.chat.providerOverride):
+   * an instance whose system AI is a private endpoint can still answer
+   * anonymous visitors from a cloud model, and only there. Absent = follow
+   * the map.
+   */
+  provider?: ResolvedAiConfig['provider'];
+}
+
 export async function resolveAiConfig(
   supabase: any,
   tier: AiTier = 'fast',
+  options: ResolveAiOptions = {},
 ): Promise<ResolvedAiConfig> {
   // 1. Read system_ai settings for configured provider
   const { data: settings } = await supabase
@@ -51,7 +65,7 @@ export async function resolveAiConfig(
   const integrations = integrationsRow?.value as Record<string, any> | null;
 
   const cfg = (settings?.value || {}) as Record<string, string>;
-  const primary = cfg.provider as ResolvedAiConfig['provider'] | undefined;
+  const primary = (options.provider ?? cfg.provider) as ResolvedAiConfig['provider'] | undefined;
 
   // For multimodal: if the primary provider can't do vision, transparently
   // fall back to the first vision-capable provider with an env key.

--- a/supabase/functions/chat-completion/index.ts
+++ b/supabase/functions/chat-completion/index.ts
@@ -139,6 +139,16 @@ interface ToolCall {
  */
 interface ChatSettings {
   aiProvider: 'openai' | 'gemini' | 'local' | 'n8n';
+  /**
+   * The chat's own PROVIDER choice — not a model. 'system' (or absent) follows
+   * the platform map; a cloud provider pins this one surface to it while the
+   * rest of the platform (FlowWork, FlowPilot, every internal skill) keeps
+   * running on the map's provider — the "private system, public chat" split.
+   * Models still come from the map's per-provider table. Deliberately a NEW
+   * field: the legacy `aiProvider` value is 'openai' on most rows as a
+   * historical default and must keep meaning "follow the map".
+   */
+  providerOverride?: 'system' | 'openai' | 'gemini' | 'anthropic';
   openaiApiKey?: string;
   openaiModel?: string;
   openaiBaseUrl?: string;
@@ -416,7 +426,16 @@ async function resolveChatProvider(
     console.warn('[chat] aiProvider=n8n but no webhook URL configured — falling back to the model map.');
   }
 
-  const ai = await resolveAiConfig(supabase, 'fast');
+  const pinned = settings?.providerOverride && settings.providerOverride !== 'system'
+    ? settings.providerOverride
+    : undefined;
+  const ai = await resolveAiConfig(supabase, 'fast', pinned ? { provider: pinned } : {});
+  if (pinned && ai.provider !== pinned) {
+    // The pin names a provider whose credential is missing; the map's own
+    // fallback ladder answered instead. Said out loud — a "public chat on
+    // OpenAI" that quietly runs elsewhere is the one thing the pin must not do.
+    console.warn(`[chat] providerOverride=${pinned} has no credential — answered by ${ai.provider} instead.`);
+  }
 
   if (ai.provider === 'anthropic') {
     const { data: sysRow } = await supabase

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2287,7 +2287,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:a3bd5f3b21cc917c1406076efed7d1786b6162255afdd8b9dc9566f982d7ac6f",
+      "shared_hash": "sha256:9350030a2720a114bb2abd5ae51c026e0507d1bbfed80d3fdbfa79101bb24c32",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
@@ -2297,7 +2297,7 @@
         "automation-dispatcher": "sha256:3cb8681d7acce65624bd7957a432b143a2d959d769845dc71696b95c2ea2012b",
         "blog-rss": "sha256:dd57f6386804f1e0a4b8e0db3cdb83abc386c5790a677c7fdfe145067ae51be6",
         "browser-fetch": "sha256:762a956222c98ae99b4a361bec94c3d31fcbde6c0d96512755bd50caefa6d652",
-        "chat-completion": "sha256:d840d8aa54a221a3a59a3b114285c60a018ef13670f76d8bcb0a71b41ff5437c",
+        "chat-completion": "sha256:88105156bea10cd3dcf0ac944886c2d5fef4864dffb037ad6a38fa5a45de2296",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
         "comms-send": "sha256:39dc9fde197bf59a92ae372f96263fe368238b212ad5674b299736ec1052d6b6",


### PR DESCRIPTION
## Vad
- `resolveAiConfig(tier, { provider })`: en yta kan pinna LEVERANTÖR, aldrig modell — modellerna kommer ur AI-kartans tabell per leverantör.
- `chat.providerOverride` (nytt fält, default `system`): publik chat på OpenAI/Gemini medan resten av plattformen kör kartans (privata) leverantör. Legacy `aiProvider` rörs inte (den står på `openai` som historiskt default och betyder "följ kartan").
- Chattinställningar: "Provider for this chat" med bara konfigurerade leverantörer, effektiv leverantör i statusrutorna, proveniensrad om var besökartexten hamnar.
- Döda modellfält bort ur `ChatSettings`-typen.

## Verifiering
Enhetstest på override-kontraktet (följ kartan / pin med kartans modell / pin utan nyckel = fallback), `tsc` grön, guardrails gröna, `deno check` på chat-completion oförändrad (7 förbefintliga fel på main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)