### PR TITLE
feat(email): inkorgen läsbar och svarbar — och den är sidans förstaflik

### DIFF
--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -131,8 +131,17 @@ export function AdminSidebar() {
 
   const isItemActive = (href: string) => {
     // Menyposter får djuplänka med ?tab= — aktiv-markeringen gäller sidan.
-    const path = href.split("?")[0];
-    return location.pathname === path || (path !== "/admin" && location.pathname.startsWith(path));
+    const [path, query] = href.split("?");
+    const onPage = location.pathname === path || (path !== "/admin" && location.pathname.startsWith(path));
+    if (!onPage) return false;
+    // Två poster på SAMMA sida (Inbox → /admin/email, Email → ?tab=templates):
+    // den med query är aktiv när queryn står i adressen; den utan är aktiv
+    // när ingen syskonquery gör det. Poster utan syskon rörs inte.
+    const siblings = navigationGroups
+      .flatMap((g) => g.items)
+      .filter((i) => i.href !== href && i.href.split("?")[0] === path && i.href.includes("?"));
+    if (query) return location.search.includes(query);
+    return !siblings.some((s) => location.search.includes(s.href.split("?")[1]));
   };
 
   // Role → module access map (from DB). Admin bypasses all role checks.

--- a/src/components/admin/adminNavigation.ts
+++ b/src/components/admin/adminNavigation.ts
@@ -160,8 +160,10 @@ export const navigationGroups: NavGroup[] = [
       { name: "WebMeet", href: "/admin/webmeet", icon: Video, moduleId: "webmeet" },
       { name: "Forms", href: "/admin/forms", icon: Inbox, moduleId: "forms" },
       { name: "Communications", href: "/admin/communications", icon: Mail, moduleId: "email" },
-      { name: "Email", href: "/admin/email", icon: MailOpen, moduleId: "email" },
-      { name: "Inbox", href: "/admin/email?tab=threads", icon: Inbox, moduleId: "email" },
+      // The inbox is what the person watching email opens first — it is the
+      // page's default tab; templates and signatures sit behind their own link.
+      { name: "Inbox", href: "/admin/email", icon: Inbox, moduleId: "email" },
+      { name: "Email", href: "/admin/email?tab=templates", icon: MailOpen, moduleId: "email" },
     ],
   },
   {

--- a/src/components/admin/email/EmailBody.tsx
+++ b/src/components/admin/email/EmailBody.tsx
@@ -1,0 +1,82 @@
+import { useMemo, useState } from 'react';
+import DOMPurify from 'dompurify';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { formatPlainEmail } from '@/lib/email-body';
+import { cn } from '@/lib/utils';
+
+/**
+ * One message body in the inbox thread. Two inputs, one look:
+ *  - HTML (the sender's own alternative, or our own HTML send): sanitised
+ *    with DOMPurify — no scripts, styles, forms or iframes, links open in a
+ *    new tab. Rendered under the same prose classes as everything else.
+ *  - Plain text: escaped, linkified, paragraphed; the quoted earlier thread
+ *    folds behind a toggle and the "-- " signature is dimmed.
+ * Until 2026-09-02 the page put body_html ?? body_text straight into
+ * innerHTML: one grey brick for text, and a stranger's markup executed.
+ */
+const PURIFY_OPTS = {
+  USE_PROFILES: { html: true },
+  FORBID_TAGS: ['style', 'script', 'iframe', 'form', 'input', 'button', 'object', 'embed', 'link', 'meta'],
+  FORBID_ATTR: ['style', 'onerror', 'onload', 'onclick'],
+  ADD_ATTR: ['target', 'rel'],
+};
+
+let hooked = false;
+function ensureLinkHook() {
+  if (hooked) return;
+  hooked = true;
+  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.tagName === 'A') {
+      node.setAttribute('target', '_blank');
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
+}
+
+export function EmailBody({ html, text, className }: { html?: string | null; text?: string | null; className?: string }) {
+  const [showQuoted, setShowQuoted] = useState(false);
+
+  const content = useMemo(() => {
+    if (html && html.trim()) {
+      ensureLinkHook();
+      return { kind: 'html' as const, html: DOMPurify.sanitize(html, PURIFY_OPTS) };
+    }
+    return { kind: 'text' as const, ...formatPlainEmail(text) };
+  }, [html, text]);
+
+  const prose = 'prose prose-sm dark:prose-invert max-w-none break-words [&_p]:my-2 [&_a]:break-all';
+
+  if (content.kind === 'html') {
+    return <div className={cn(prose, className)} dangerouslySetInnerHTML={{ __html: content.html }} />;
+  }
+
+  return (
+    <div className={className}>
+      <div className={prose} dangerouslySetInnerHTML={{ __html: content.main }} />
+      {content.signature && (
+        <div
+          className={cn(prose, 'mt-3 pt-2 border-t border-dashed text-muted-foreground text-xs [&_p]:my-1')}
+          dangerouslySetInnerHTML={{ __html: content.signature }}
+        />
+      )}
+      {content.quoted && (
+        <div className="mt-3">
+          <button
+            type="button"
+            onClick={() => setShowQuoted((v) => !v)}
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {showQuoted ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+            {showQuoted ? 'Hide quoted text' : 'Show quoted text'}
+          </button>
+          {showQuoted && (
+            <div
+              className={cn(prose, 'mt-2 pl-3 border-l-2 border-border text-muted-foreground')}
+              dangerouslySetInnerHTML={{ __html: content.quoted }}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/email/ThreadReply.tsx
+++ b/src/components/admin/email/ThreadReply.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Loader2, Reply, Send } from 'lucide-react';
+import { toast } from 'sonner';
+import { supabase } from '@/integrations/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { escapeHtml } from '@/lib/email-body';
+
+interface ThreadMessage {
+  id: string;
+  direction?: string | null;
+  sender?: string | null;
+  recipient?: string | null;
+  subject?: string | null;
+  message_id_header?: string | null;
+  in_reply_to?: string | null;
+  metadata?: { references?: string | null } | null;
+  related_entity_type?: string | null;
+  related_entity_id?: string | null;
+  created_at?: string;
+}
+
+/** "Anna <anna@x.se>" → "anna@x.se"; a bare address passes through. */
+export function addressOf(raw: string | null | undefined): string {
+  const m = (raw ?? '').match(/<([^>]+)>/);
+  return (m ? m[1] : raw ?? '').trim();
+}
+
+/** RFC 5322 References for a reply: the parent's References plus its own id. */
+export function replyReferences(parent: ThreadMessage): string | undefined {
+  const chain = [parent.metadata?.references, parent.message_id_header].filter(Boolean) as string[];
+  return chain.length ? chain.join(' ') : undefined;
+}
+
+/**
+ * Reply from the inbox thread. Not a mail client: one textarea, one send,
+ * through the same email-send rail every other surface uses (Composio/Gmail
+ * when connected — that is the rail that threads: In-Reply-To, References,
+ * Gmail thread id — so the answer lands in the visitor's own conversation
+ * and comes back here when they answer again). The reply binds to the same
+ * CRM record the inbound message resolved to.
+ */
+export function ThreadReply({ threadKey, messages }: { threadKey: string; messages: ThreadMessage[] }) {
+  const qc = useQueryClient();
+  const [text, setText] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const parent = useMemo(
+    () => [...messages].reverse().find((m) => m.direction === 'inbound') ?? null,
+    [messages],
+  );
+  if (!parent) return null;
+
+  const to = addressOf(parent.sender);
+  const baseSubject = (parent.subject ?? '').replace(/^\s*(re|sv|aw|fwd?)\s*:\s*/i, '');
+  const subject = `Re: ${baseSubject || '(no subject)'}`;
+
+  const send = async () => {
+    const body = text.trim();
+    if (!body || !to) return;
+    setSending(true);
+    try {
+      const html = body
+        .split('\n')
+        .map((line) => (line.trim() === '' ? '<br>' : `<p>${escapeHtml(line)}</p>`))
+        .join('');
+      const { data, error } = await supabase.functions.invoke('email-send', {
+        body: {
+          to,
+          subject,
+          html,
+          text: body,
+          expects_reply: true,
+          source: 'inbox-reply',
+          inReplyTo: parent.message_id_header ?? undefined,
+          references: replyReferences(parent),
+          threadId: threadKey,
+          ...(parent.related_entity_type && parent.related_entity_id
+            ? { related_entity_type: parent.related_entity_type, related_entity_id: parent.related_entity_id }
+            : {}),
+          tags: { source: 'inbox-reply' },
+        },
+      });
+      if (error) throw error;
+      if (data && data.success === false) throw new Error(data.error || 'Send failed');
+      setText('');
+      toast.success(`Reply sent to ${to}`);
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['email-thread-messages', threadKey] }),
+        qc.invalidateQueries({ queryKey: ['email-threads'] }),
+      ]);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Reply failed');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-dashed p-3 space-y-2">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Reply className="h-3.5 w-3.5" />
+        <span>Reply to <span className="font-medium text-foreground">{to}</span> · {subject}</span>
+      </div>
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Write your reply… plain text, sent as a threaded email"
+        rows={4}
+        onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void send(); }}
+      />
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] text-muted-foreground">Sent through the platform email rail and logged on this thread. ⌘⏎ to send.</span>
+        <Button size="sm" onClick={send} disabled={sending || !text.trim()} className="gap-1.5">
+          {sending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+          Send reply
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useEmailModule.ts
+++ b/src/hooks/useEmailModule.ts
@@ -144,7 +144,9 @@ export function useThreadMessages(threadKey?: string) {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('outbound_communications' as any)
-        .select('id, subject, recipient, sender, direction, status, sent_at, body_html, body_text, created_at')
+        // Header fields ride along so a reply from the thread can thread
+        // itself (In-Reply-To/References) and bind to the same CRM record.
+        .select('id, subject, recipient, sender, direction, status, sent_at, body_html, body_text, created_at, message_id_header, in_reply_to, metadata, related_entity_type, related_entity_id')
         .eq('channel', 'email')
         .eq('thread_id', threadKey!)
         .order('created_at', { ascending: true });

--- a/src/lib/__tests__/email-body.test.ts
+++ b/src/lib/__tests__/email-body.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { formatPlainEmail, linkify, escapeHtml } from '../email-body';
+
+describe('formatPlainEmail — readable, not a mail client', () => {
+  it('turns CRLF text into paragraphs and folds the "-- " signature away (the GitHub case)', () => {
+    const r = formatPlainEmail('Merged #429 into main.\r\n\r\n-- \r\nReply to this email directly or view it on GitHub:\r\nhttps://github.com/x/y/pull/429\r\n');
+    expect(r.main).toBe('<p>Merged #429 into main.</p>');
+    expect(r.signature).toContain('<a href="https://github.com/x/y/pull/429"');
+    expect(r.quoted).toBeNull();
+  });
+
+  it('folds the quoted reply below "On … wrote:" and "Den … skrev:"', () => {
+    const en = formatPlainEmail('Thanks, works now.\n\nOn Tue, Sep 2, 2026 at 10:00 Anna <anna@x.se> wrote:\n> Did the fix land?\n> /Anna');
+    expect(en.main).toBe('<p>Thanks, works now.</p>');
+    expect(en.quoted).toContain('Did the fix land?');
+    // the "> " quote prefixes are stripped; the header's <address> stays (escaped)
+    expect(en.quoted).not.toContain('&gt; Did');
+    expect(en.quoted).toContain('&lt;anna@x.se&gt;');
+    const sv = formatPlainEmail('Tack!\n\nDen tis 2 sep. 2026 kl 10:00 skrev Anna <anna@x.se>:\n> Landade fixen?');
+    expect(sv.main).toBe('<p>Tack!</p>');
+    expect(sv.quoted).toContain('Landade fixen?');
+  });
+
+  it('a trailing run of "> " lines is quoted even without a header', () => {
+    const r = formatPlainEmail('Yes.\n\n> original\n> text');
+    expect(r.main).toBe('<p>Yes.</p>');
+    expect(r.quoted).toBe('<p>original<br>text</p>');
+  });
+
+  it('escapes markup before linking — a stranger’s HTML never executes', () => {
+    const r = formatPlainEmail('<img src=x onerror=alert(1)> see https://a.b/c?x=1&y=2');
+    expect(r.main).not.toContain('<img');
+    expect(r.main).toContain('&lt;img');
+    expect(r.main).toContain('<a href="https://a.b/c?x=1&amp;y=2" target="_blank" rel="noopener noreferrer">');
+  });
+
+  it('links e-mail addresses and keeps single newlines as line breaks inside a paragraph', () => {
+    expect(linkify(escapeHtml('write anna@x.se'))).toContain('<a href="mailto:anna@x.se">anna@x.se</a>');
+    expect(formatPlainEmail('line one\nline two').main).toBe('<p>line one<br>line two</p>');
+  });
+
+  it('empty input is empty output, not a crash', () => {
+    expect(formatPlainEmail(null)).toEqual({ main: '', quoted: null, signature: null });
+  });
+});

--- a/src/lib/__tests__/email-body.test.ts
+++ b/src/lib/__tests__/email-body.test.ts
@@ -15,7 +15,7 @@ describe('formatPlainEmail — readable, not a mail client', () => {
     expect(en.quoted).toContain('Did the fix land?');
     // the "> " quote prefixes are stripped; the header's <address> stays (escaped)
     expect(en.quoted).not.toContain('&gt; Did');
-    expect(en.quoted).toContain('&lt;anna@x.se&gt;');
+    expect(en.quoted).toContain('href="mailto:anna@x.se"');
     const sv = formatPlainEmail('Tack!\n\nDen tis 2 sep. 2026 kl 10:00 skrev Anna <anna@x.se>:\n> Landade fixen?');
     expect(sv.main).toBe('<p>Tack!</p>');
     expect(sv.quoted).toContain('Landade fixen?');

--- a/src/lib/email-body.ts
+++ b/src/lib/email-body.ts
@@ -21,7 +21,7 @@ export interface FormattedEmail {
 
 const QUOTE_HEADER = [
   /^On .{3,200}? wrote:\s*$/i,                       // Gmail (en)
-  /^Den .{3,200}? skrev:\s*$/i,                      // Gmail (sv)
+  /^Den .{3,200}? skrev\b.*:\s*$/i,                  // Gmail (sv): "Den tis 2 sep. 2026 kl 10:00 skrev Anna <…>:"
   /^Am .{3,200}? schrieb .*:\s*$/i,                  // Gmail (de)
   /^Le .{3,200}? a écrit\s*:\s*$/i,                  // Gmail (fr)
   /^-{2,}\s*(Original Message|Ursprungligt meddelande|Vidarebefordrat meddelande|Forwarded message)\s*-{2,}\s*$/i,

--- a/src/lib/email-body.ts
+++ b/src/lib/email-body.ts
@@ -1,0 +1,95 @@
+/**
+ * Plain-text email → readable HTML, without pretending to be a mail client.
+ *
+ * An inbound message from Composio/Gmail is stored as text: CRLF line ends,
+ * the quoted reply below "On … wrote:" / "Den … skrev:", a "-- " signature,
+ * bare URLs. Rendered raw into innerHTML (as the Email page did until
+ * 2026-09-02) that collapses into one grey brick — and, worse, executes
+ * whatever HTML a stranger put in the body. This does four cheap things:
+ * escape, paragraphs, links, and fold the quoted tail and the signature
+ * away from the part someone actually wrote.
+ */
+
+export interface FormattedEmail {
+  /** The part the sender wrote, as HTML (escaped, linkified, paragraphs). */
+  main: string;
+  /** The quoted earlier conversation, as HTML — collapsed by the UI. */
+  quoted: string | null;
+  /** The "-- " signature, as HTML — dimmed by the UI. */
+  signature: string | null;
+}
+
+const QUOTE_HEADER = [
+  /^On .{3,200}? wrote:\s*$/i,                       // Gmail (en)
+  /^Den .{3,200}? skrev:\s*$/i,                      // Gmail (sv)
+  /^Am .{3,200}? schrieb .*:\s*$/i,                  // Gmail (de)
+  /^Le .{3,200}? a écrit\s*:\s*$/i,                  // Gmail (fr)
+  /^-{2,}\s*(Original Message|Ursprungligt meddelande|Vidarebefordrat meddelande|Forwarded message)\s*-{2,}\s*$/i,
+  /^_{10,}\s*$/,                                     // Outlook divider
+  /^(From|Från|Von|De):\s.+$/,                       // Outlook header block
+];
+
+export function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+const URL_RE = /\bhttps?:\/\/[^\s<>"')\]]+[^\s<>"')\].,;:!?]/g;
+const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+
+/** Escape first, then link — so a URL in the text can never carry markup. */
+export function linkify(escaped: string): string {
+  return escaped
+    .replace(URL_RE, (u) => `<a href="${u}" target="_blank" rel="noopener noreferrer">${u}</a>`)
+    .replace(EMAIL_RE, (m) => (m.includes('href=') ? m : `<a href="mailto:${m}">${m}</a>`));
+}
+
+function paragraphs(lines: string[]): string {
+  const out: string[] = [];
+  let buf: string[] = [];
+  const flush = () => {
+    if (buf.length) out.push(`<p>${buf.map((l) => linkify(escapeHtml(l))).join('<br>')}</p>`);
+    buf = [];
+  };
+  for (const line of lines) {
+    if (line.trim() === '') flush();
+    else buf.push(line);
+  }
+  flush();
+  return out.join('\n');
+}
+
+export function formatPlainEmail(text: string | null | undefined): FormattedEmail {
+  const lines = (text ?? '').replace(/\r\n?/g, '\n').split('\n');
+
+  // 1. Quoted tail: from the first header line, or the first run of "> " lines
+  //    that continues to the end, everything below is the earlier thread.
+  let quoteAt = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const l = lines[i].trim();
+    if (QUOTE_HEADER.some((re) => re.test(l))) { quoteAt = i; break; }
+    if (l.startsWith('>') && lines.slice(i).every((x) => x.trim() === '' || x.trim().startsWith('>'))) { quoteAt = i; break; }
+  }
+  const own = quoteAt >= 0 ? lines.slice(0, quoteAt) : lines;
+  const quoted = quoteAt >= 0 ? lines.slice(quoteAt) : [];
+
+  // 2. Signature: the RFC 3676 "-- " line, only in the part the sender wrote.
+  let sigAt = -1;
+  for (let i = 0; i < own.length; i++) {
+    if (/^-- ?$/.test(own[i])) { sigAt = i; break; }
+  }
+  const body = sigAt >= 0 ? own.slice(0, sigAt) : own;
+  const signature = sigAt >= 0 ? own.slice(sigAt + 1) : [];
+
+  const trimEdges = (ls: string[]) => {
+    let a = 0, b = ls.length;
+    while (a < b && ls[a].trim() === '') a++;
+    while (b > a && ls[b - 1].trim() === '') b--;
+    return ls.slice(a, b);
+  };
+
+  return {
+    main: paragraphs(trimEdges(body)),
+    quoted: quoted.length ? paragraphs(trimEdges(quoted.map((l) => l.replace(/^\s*>+\s?/, '')))) : null,
+    signature: signature.length ? paragraphs(trimEdges(signature)) : null,
+  };
+}

--- a/src/pages/admin/EmailPage.tsx
+++ b/src/pages/admin/EmailPage.tsx
@@ -3,6 +3,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { EmailTemplatePreview, EmailLogoNotice } from '@/components/admin/email/EmailTemplatePreview';
+import { EmailBody } from '@/components/admin/email/EmailBody';
+import { ThreadReply } from '@/components/admin/email/ThreadReply';
 import { buildSampleValues, detectTokens } from '@/lib/email-preview';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -31,7 +33,10 @@ export default function EmailPage() {
   // Djuplänkar (?tab=…) från proveniensrader ska landa rätt — en länk som
   // öppnar fel flik är en ratt som inte gör vad etiketten säger.
   const requestedTab = searchParams.get('tab');
-  const initialTab = requestedTab && ['templates', 'threads', 'signatures', 'suppressions'].includes(requestedTab) ? requestedTab : 'templates';
+  // The inbox opens first: the person watching email also watches forms,
+  // tickets and the live chat — the conversations are the work, templates
+  // are the setup.
+  const initialTab = requestedTab && ['templates', 'threads', 'signatures', 'suppressions'].includes(requestedTab) ? requestedTab : 'threads';
   return (
     <AdminLayout>
       <div className="space-y-6">
@@ -41,8 +46,8 @@ export default function EmailPage() {
         </div>
         <Tabs defaultValue={initialTab} className="space-y-4">
           <TabsList>
+            <TabsTrigger value="threads"><MessagesSquare className="h-4 w-4 mr-1" /> Inbox</TabsTrigger>
             <TabsTrigger value="templates"><FileText className="h-4 w-4 mr-1" /> Templates</TabsTrigger>
-            <TabsTrigger value="threads"><MessagesSquare className="h-4 w-4 mr-1" /> Threads</TabsTrigger>
             <TabsTrigger value="signatures"><PenLine className="h-4 w-4 mr-1" /> Signatures</TabsTrigger>
             <TabsTrigger value="suppressions"><ShieldOff className="h-4 w-4 mr-1" /> Suppressions</TabsTrigger>
           </TabsList>
@@ -320,9 +325,10 @@ function ThreadsTab() {
                       <span>{m.sent_at ? formatDistanceToNow(new Date(m.sent_at), { addSuffix: true }) : ''}</span>
                     </div>
                     <div className="font-medium mt-1">{m.subject ?? '(no subject)'}</div>
-                    <div className="mt-2 text-sm prose dark:prose-invert prose-sm max-w-none" dangerouslySetInnerHTML={{ __html: m.body_html ?? m.body_text ?? '' }} />
+                    <EmailBody html={m.body_html} text={m.body_text} className="mt-2 text-sm" />
                   </div>
                 ))}
+                <ThreadReply threadKey={openKey} messages={msgs!} />
               </div>
             )}
         </CardContent>

--- a/supabase/functions/_shared/email/ingest-gmail.ts
+++ b/supabase/functions/_shared/email/ingest-gmail.ts
@@ -45,16 +45,29 @@ function decodeBase64Url(data: string): string {
   }
 }
 
-function extractText(part: any): string {
+function extractPart(part: any, mimeType: string): string {
   if (!part) return '';
-  if (part.mimeType === 'text/plain' && part.body?.data) return decodeBase64Url(part.body.data);
+  if (part.mimeType === mimeType && part.body?.data) return decodeBase64Url(part.body.data);
   if (Array.isArray(part.parts)) {
     for (const p of part.parts) {
-      const t = extractText(p);
+      const t = extractPart(p, mimeType);
       if (t) return t;
     }
   }
   return '';
+}
+
+function extractText(part: any): string {
+  return extractPart(part, 'text/plain');
+}
+
+/**
+ * The HTML alternative, when the sender included one. Stored next to the
+ * text so the inbox can render a formatted message (sanitised on the way
+ * out) instead of the text/plain fallback with its collapsed line breaks.
+ */
+function extractHtml(part: any): string {
+  return extractPart(part, 'text/html');
 }
 
 async function fetchFullMessage(messageId: string, accountId?: string | null): Promise<any> {
@@ -198,6 +211,7 @@ export async function ingestGmailMessage(
     snippet ||
     ''
   ).slice(0, 50000);
+  const bodyHtml = extractHtml(fullMessage?.payload).slice(0, 200000) || null;
 
   // Second dedupe pass now that we know the RFC Message-ID.
   if (messageIdHeader && (await isAlreadyIngested(supabase, messageId, messageIdHeader))) {
@@ -247,6 +261,7 @@ export async function ingestGmailMessage(
     sender: fromEmail,
     subject,
     body_text: bodyText,
+    body_html: bodyHtml,
     source,
     thread_id: threadId,
     message_id_header: messageIdHeader,

--- a/supabase/functions/composio-proxy/index.ts
+++ b/supabase/functions/composio-proxy/index.ts
@@ -7,6 +7,10 @@ async function logComposioOutbound(row: {
   recipient: string;
   subject?: string | null;
   body_text?: string | null;
+  body_html?: string | null;
+  /** Gmail thread the message belongs to — what the inbox thread view groups on. */
+  thread_id?: string | null;
+  in_reply_to?: string | null;
   status: string;
   direction?: 'inbound' | 'outbound';
   related_entity_type?: string | null;
@@ -26,7 +30,9 @@ async function logComposioOutbound(row: {
       recipient: row.recipient,
       subject: row.subject ?? null,
       body_text: row.body_text ?? null,
-      body_html: null,
+      body_html: row.body_html ?? null,
+      thread_id: row.thread_id ?? null,
+      in_reply_to: row.in_reply_to ?? null,
       source: row.source ?? 'composio-proxy',
       related_entity_type: row.related_entity_type ?? null,
       related_entity_id: row.related_entity_id ?? null,
@@ -375,7 +381,14 @@ Deno.serve(async (req) => {
         channel: 'email',
         recipient: to,
         subject,
-        body_text: emailBody,
+        // An HTML send is stored as HTML, so the thread view renders it as
+        // such instead of showing the tags as text.
+        body_text: is_html ? null : emailBody,
+        body_html: is_html ? emailBody : null,
+        // The reply joins its thread: Gmail's thread id (echoed back by the
+        // send when we did not know it) plus the header it answers.
+        thread_id: thread_id ?? data?.data?.response_data?.threadId ?? null,
+        in_reply_to: in_reply_to ?? null,
         status: success ? 'sent' : 'failed',
         direction: 'outbound',
         related_entity_type: related_entity_type ?? null,

--- a/supabase/functions/email-send/index.ts
+++ b/supabase/functions/email-send/index.ts
@@ -25,6 +25,10 @@ const corsHeaders = {
 type Provider = "smtp" | "resend" | "composio";
 
 interface SendBody {
+  /** Threading for a reply from the inbox — only the Composio/Gmail rail honours these. */
+  inReplyTo?: string;
+  references?: string;
+  threadId?: string;
   to: string | string[];
   subject?: string;
   html?: string;
@@ -497,6 +501,12 @@ serve(async (req: Request) => {
             to: recipients.join(", "),
             subject: body.subject,
             extra_headers: recipients.length === 1 ? await unsubscribeHeaders(recipients[0]) : undefined,
+            // Threading for a reply from the inbox: the proxy turns these into
+            // In-Reply-To/References headers and Gmail's thread_id, so the
+            // answer lands in the same conversation on both ends.
+            in_reply_to: body.inReplyTo ?? undefined,
+            references: body.references ?? undefined,
+            thread_id: body.threadId ?? undefined,
             // Gmail send expects an HTML body — pass the html (proxy forwards as `body`).
             body: body.html,
             // This rail only ever sends rendered HTML, so say so rather than

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2287,7 +2287,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:9350030a2720a114bb2abd5ae51c026e0507d1bbfed80d3fdbfa79101bb24c32",
+      "shared_hash": "sha256:36244b85ff00487395e62711ddb01c7c4b846352035301264860264c0b8146be",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
@@ -2301,7 +2301,7 @@
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
         "comms-send": "sha256:39dc9fde197bf59a92ae372f96263fe368238b212ad5674b299736ec1052d6b6",
-        "composio-proxy": "sha256:08477e4658cee04b6a09458a5e8dc45fbf9737c2188f7b972ae954782a4bdc95",
+        "composio-proxy": "sha256:dfe9792b9628e727f8a90f7450287e68ea4fe29e780fe852a106e79af102664d",
         "composio-webhook": "sha256:27f17b7198bfbab422931ef1c872da083299e095792e43b98b4154ec79c858ca",
         "consultant-match": "sha256:19f388f6c2b0abcdadaef40912fc00ea6c49982f2e2c05f2252b486548326160",
         "content-api": "sha256:64c03bcaa94f7e17575c9e36611830c049cdcf372747ed2af264eb03c70bce42",
@@ -2318,7 +2318,7 @@
         "document-sign-request": "sha256:1df2d2989368c711d2ad0dbac629c754804bde795f0e081ae9c7892f0a193be3",
         "dunning-processor": "sha256:e05e55a6624859ed9f36f296aa5eccbb313f5d70f861a84067af4a4738b12679",
         "elks46-ingest": "sha256:7c9211df6847396b20cc5d1bf537a61767119e48c0c2bfb5e40bc10e2b9f075f",
-        "email-send": "sha256:3d52b70a3ebe9d7dfce8f00525089f48e60354a024fa340221ff1a2a7a74eb68",
+        "email-send": "sha256:fd6c46718a606502d54fa40087f6a8b7477c84aad25696cbbdad8ecda3eab4d7",
         "email-webhook": "sha256:2593b55c6730a00efc698b948de37f7aace1f916e8d2ee1dafd9f3014d5cf1a4",
         "event-dispatcher": "sha256:1226b1ce317cb70cfdae46441f59499f8559b159fd08ee5063105ebfd98e5aa0",
         "extract-pdf-text": "sha256:80474c20ca8c39ba6bbf8bcb7e2be777632b312915a4c48a13a92fb2dcc0cdfe",


### PR DESCRIPTION
## Vad
- **Läsbar text**: `formatPlainEmail` (escape, stycken, länkar, citat bakom toggle, signatur dämpad) + sanerad HTML via DOMPurify i ny `EmailBody`. Tidigare gick `body_html ?? body_text` osanerat in i innerHTML.
- **Gmail-ingesten** sparar nu `body_html` när avsändaren skickat en HTML-del.
- **Svar i tråden** (`ThreadReply`): via `email-send` → Composio med `inReplyTo`/`references`/`threadId`; proxyn loggar `thread_id`/`in_reply_to`/`body_html` på utgående raden så svaret syns i tråden och trådar i Gmail.
- **Inbox som förstaflik**, meny Inbox → `/admin/email`, Email → `?tab=templates`; sidopanelen skiljer syskonposter med query.

## Verifiering
Enhetstester för textformateraren (GitHub-signatur, "On … wrote:", "Den … skrev:", XSS-escape, länkar). `tsc` grön, guardrails gröna, `deno check` grön på email-send, oförändrat på composio-proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)