### PR TITLE
fix(skills): motorn hittar konsulterna — plural, NOT-for-självskada, svenska "konsult"

### DIFF
--- a/src/lib/__tests__/intent-scorer.guardrails.test.ts
+++ b/src/lib/__tests__/intent-scorer.guardrails.test.ts
@@ -15,7 +15,7 @@
  * the default 25.
  */
 import { describe, expect, it } from 'vitest';
-import { scoreSkillsByIntent, stemSwedish } from '../../../supabase/functions/_shared/skills/intent-scorer';
+import { scoreSkillsByIntent, stemSwedish, stemEnglishPlural } from '../../../supabase/functions/_shared/skills/intent-scorer';
 import artifact from '../../../supabase/seed/module-skills.json';
 
 type Tool = { function: { name: string; description: string } };
@@ -200,5 +200,56 @@ describe('the Swedish stemmer is conservative by construction', () => {
   it('leaves words with no Swedish ending alone', () => {
     expect(stemSwedish('invoice')).toBeNull();
     expect(stemSwedish('blog')).toBeNull();
+  });
+});
+
+describe('the consultant roster is reachable (labs1100, 2026-09-02)', () => {
+  // "kolla konsulter" in FlowChat found nothing, in a catalog with seven
+  // consultant_* skills. Three separate causes, each general:
+  //  1. English plural: "consultants" was only a half-weight substring hit on
+  //     the name word `consultant`, so the seven tied and seed order chose
+  //     which four survived the top-40 cut — the one with `list` lost.
+  //  2. NOT-for self-harm: "NOT for: matching consultants to jobs" fined the
+  //     listing skill -15 for the word that is its own subject.
+  //  3. Swedish: the stem "konsult" had no path to `consultant`.
+  const catalog = (artifact as { modules: Array<{ skills: Array<{ name: string; description?: string }> }> })
+    .modules.flatMap((m) => m.skills.map((s) => ({
+      ...s,
+      function: { name: s.name, description: s.description ?? '' },
+    })));
+  const rank = (query: string, target: string, maxSkills = 40): number => {
+    const ranked = scoreSkillsByIntent(catalog, query, { maxSkills });
+    const idx = ranked.findIndex((s: { function: { name: string } }) => s.function.name === target);
+    return idx === -1 ? Infinity : idx + 1;
+  };
+
+  it.each([
+    ['list consultants', 'manage_consultant_profile'],
+    ['show me our consultants', 'manage_consultant_profile'],
+    ['which consultants are available', 'manage_consultant_profile'],
+    ['kolla konsulter', 'manage_consultant_profile'],
+    ['vilka konsulter har vi', 'manage_consultant_profile'],
+    ['lista konsulterna', 'manage_consultant_profile'],
+    ['hitta en konsult för ett Databricks-uppdrag', 'match_consultant'],
+  ])('"%s" ranks %s in the top 5', (query, target) => {
+    expect(rank(query, target)).toBeLessThanOrEqual(5);
+  });
+
+  it('a NOT-for clause never fines the skill for its own subject word', () => {
+    const skills = [
+      tool('manage_widget_profile', 'Manage widget profiles: list, create, update. Use when: adding a widget. NOT for: matching widgets to jobs (match_widget).'),
+      tool('match_widget', 'Match widgets to a job. Use when: finding a widget for an opening. NOT for: editing widget profiles.'),
+      ...padding,
+    ];
+    expect(rankOf(skills, 'list widgets', 'manage_widget_profile')).toBeLessThanOrEqual(2);
+  });
+
+  it('stemEnglishPlural: regular plurals only, never -ss/-us/-is', () => {
+    expect(stemEnglishPlural('consultants')).toBe('consultant');
+    expect(stemEnglishPlural('companies')).toBe('company');
+    expect(stemEnglishPlural('invoices')).toBe('invoice');
+    expect(stemEnglishPlural('address')).toBeNull();
+    expect(stemEnglishPlural('status')).toBeNull();
+    expect(stemEnglishPlural('analysis')).toBeNull();
   });
 });

--- a/supabase/functions/_shared/skills/intent-scorer.ts
+++ b/supabase/functions/_shared/skills/intent-scorer.ts
@@ -14,6 +14,15 @@
 // ─── Synonym Map ─────────────────────────────────────────────────────────────
 // Maps common user terms (including Swedish) to skill-related keywords
 const SYNONYM_MAP: Record<string, string[]> = {
+  // Konsultdomänen (labs1100 2026-09-02: "kolla konsulter" fann ingenting —
+  // stammen "konsult" hade ingen väg till `consultant`).
+  konsult: ['consultant', 'consultants', 'profile', 'profiles'],
+  konsulterna: ['consultants', 'consultant', 'profiles'],
+  uppdrag: ['assignment', 'assignments', 'engagement'],
+  tillgänglig: ['available', 'availability'],
+  tillgängliga: ['available', 'availability'],
+  kolla: ['check', 'list', 'show', 'view'],
+  vilka: ['which', 'list'],
   // Swedish business nouns → catalog vocabulary (the catalog is English).
   // Query-side expansion feeding the general scorer — the corpus lever, not a
   // routing rule. Added 2026-08-11 when a Swedish FlowWork question ranked
@@ -198,6 +207,22 @@ const SYNONYM_MAP: Record<string, string[]> = {
 const SV_SUFFIXES = ['erna', 'arna', 'orna', 'en', 'et', 'er', 'ar', 'or', 'na', 'n', 't'];
 const SV_MIN_STEM = 4;
 
+/**
+ * English plural → singular for the common regular forms. Added alongside the
+ * raw word (never substituted), like the Swedish stem: "consultants" →
+ * "consultant", "companies" → "company", "invoices" → "invoice". Words that
+ * end in -ss/-us/-is ("address", "status", "analysis") are left alone.
+ */
+export function stemEnglishPlural(word: string): string | null {
+  const w = word.toLowerCase();
+  if (w.length < 5) return null;
+  if (/(ss|us|is)$/.test(w)) return null;
+  if (w.endsWith('ies')) return w.slice(0, -3) + 'y';
+  if (/(ches|shes|xes|ses)$/.test(w)) return w.slice(0, -2);
+  if (w.endsWith('s')) return w.slice(0, -1);
+  return null;
+}
+
 export function stemSwedish(word: string): string | null {
   const w = word.toLowerCase();
   for (const suf of SV_SUFFIXES) {
@@ -310,6 +335,16 @@ export function scoreSkillsByIntent(
       msgWords.push(stem);
       expandedTerms.add(stem);
     }
+    // English plural → singular, the same way: "consultants" must be a DIRECT
+    // hit on the name word `consultant`, not the half-weight substring hit it
+    // was — with seven consultant_* skills tied at half weight, seed order
+    // decided which four of them survived the cut, and the one with `list`
+    // (manage_consultant_profile) was not among them (labs1100, 2026-09-02).
+    const en = stemEnglishPlural(word);
+    if (en && en !== word) {
+      msgWords.push(en);
+      expandedTerms.add(en);
+    }
     for (const key of stem ? [word, stem] : [word]) {
       const synonyms = SYNONYM_MAP[key];
       if (synonyms) {
@@ -358,12 +393,30 @@ export function scoreSkillsByIntent(
       }
     }
 
-    // 4. "NOT for:" negative signal
+    // 4. "NOT for:" negative signal — but never on the skill's OWN subject.
+    //    "NOT for: matching consultants to jobs" names the subject the skill
+    //    is about; a query that says "consultants" was being fined -15 by the
+    //    very skill that lists them (manage_consultant_profile fell out of the
+    //    top 40 for "list consultants", labs1100 2026-09-02). A negative word
+    //    counts only when it is NOT also part of the name or the "Use when:"
+    //    triggers — those are what the clause contrasts against.
     const notForMatch = desc.match(/not for:\s*([^.]*?)(?:\.|$)/i);
     if (notForMatch) {
+      const ownVocab = new Set<string>();
+      for (const w of [...nameWords, ...fnParts]) {
+        ownVocab.add(w);
+        const p = stemEnglishPlural(w); if (p) ownVocab.add(p);
+        ownVocab.add(w + 's');
+      }
+      if (useWhenMatch) {
+        for (const w of useWhenMatch[1].toLowerCase().split(/[\s,;]+/)) {
+          if (w.length > 3) { ownVocab.add(w); const p = stemEnglishPlural(w); if (p) ownVocab.add(p); }
+        }
+      }
       const negatives = notForMatch[1].toLowerCase();
-      const negWords = negatives.split(/[\s,]+/).filter(w => w.length > 3);
+      const negWords = negatives.split(/[\s,;()]+/).filter(w => w.length > 3);
       for (const w of negWords) {
+        if (ownVocab.has(w) || ownVocab.has(stemEnglishPlural(w) ?? '')) continue;
         if (msg.includes(w)) score -= 15;
       }
     }
@@ -372,6 +425,17 @@ export function scoreSkillsByIntent(
     const descWords = desc.split(/\s+/).filter(w => w.length > 5);
     for (const w of descWords) {
       if (expandedMsg.includes(w)) score += 1;
+    }
+
+    // 5b. The skill's own action words. A description opens with what the
+    //     skill DOES ("Manage consultant profiles: list, create, update…") and
+    //     those verbs are short — under the length-5 floor above, so "list"
+    //     and "show" in a query never counted for the skill that lists, while
+    //     `list` did count as a NAME hit for every *pricelist* skill via the
+    //     compound rule. Whole-word, head of the description only, small.
+    const head = desc.split(/use when:/i)[0];
+    for (const mw of msgWords) {
+      if (mw.length >= 4 && mw.length <= 5 && new RegExp(`\\b${mw}\\b`).test(head)) score += 3;
     }
 
     // 6. Historical success rate boost (capped)

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2287,7 +2287,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:36244b85ff00487395e62711ddb01c7c4b846352035301264860264c0b8146be",
+      "shared_hash": "sha256:f03029e2aaef9ff9d5bdaab1dc6a015d380618be3e45b564d8ee4ab600eaaf1c",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",


### PR DESCRIPTION
## Vad
Skill Relevance Engine: (1) engelsk plural stammas (consultants → consultant) som svenskan redan gör, (2) NOT-for-klausulen bötfäller aldrig skillens eget ämnesord, (3) synonymer för konsultdomänen + kolla/vilka, (4) beskrivningens korta handlingsord (list/show) räknas. Inga routingregler.

## Verifiering
28 tester gröna i `intent-scorer.guardrails` (nya: sju konsultfrågor sv+en mot riktiga katalogen ≤ topp 5, NOT-for-fallet, plural-stammen). `deno check` oförändrat mot main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)