### PR TITLE
feat(inbox): EN kö över mejl, chat, ärenden, formulär och samtal — FlowPilot går först

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ const FormSubmissionsPage = lazy(() => import("./pages/admin/FormSubmissionsPage
 const NewsletterPage = lazy(() => import("./pages/admin/NewsletterPage"));
 const CommunicationsPage = lazy(() => import("./pages/admin/CommunicationsPage"));
 const EmailPage = lazy(() => import("./pages/admin/EmailPage"));
+const InboxPage = lazy(() => import("./pages/admin/InboxPage"));
 const BlogPage = lazy(() => import("./pages/admin/BlogPage"));
 const BlogPostEditorPage = lazy(() => import("./pages/admin/BlogPostEditorPage"));
 const ModulesPage = lazy(() => import("./pages/admin/ModulesPage"));
@@ -353,6 +354,7 @@ const router = createBrowserRouter([
       { path: "/admin/newsletter", element: <NewsletterPage /> },
       { path: "/admin/communications", element: <CommunicationsPage /> },
       { path: "/admin/email", element: <EmailPage /> },
+      { path: "/admin/inbox", element: <InboxPage /> },
       { path: "/admin/leads", element: <LeadsPage /> },
       { path: "/admin/leads/:id", element: <LeadDetailPage /> },
       { path: "/admin/contacts", element: <LeadsPage /> },

--- a/src/components/admin/adminNavigation.ts
+++ b/src/components/admin/adminNavigation.ts
@@ -160,10 +160,11 @@ export const navigationGroups: NavGroup[] = [
       { name: "WebMeet", href: "/admin/webmeet", icon: Video, moduleId: "webmeet" },
       { name: "Forms", href: "/admin/forms", icon: Inbox, moduleId: "forms" },
       { name: "Communications", href: "/admin/communications", icon: Mail, moduleId: "email" },
-      // The inbox is what the person watching email opens first — it is the
-      // page's default tab; templates and signatures sit behind their own link.
-      { name: "Inbox", href: "/admin/email", icon: Inbox, moduleId: "email" },
-      { name: "Email", href: "/admin/email?tab=templates", icon: MailOpen, moduleId: "email" },
+      // The Inbox is ONE queue over email, chat, tickets, forms and calls,
+      // organised by who has it — FlowPilot first. The Email page keeps the
+      // mail threads, templates and signatures.
+      { name: "Inbox", href: "/admin/inbox", icon: Inbox, moduleId: "email" },
+      { name: "Email", href: "/admin/email", icon: MailOpen, moduleId: "email" },
     ],
   },
   {

--- a/src/hooks/useInboxItems.ts
+++ b/src/hooks/useInboxItems.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import {
+  emailItems, chatItems, ticketItems, formItems, voiceItems, sortQueue,
+  type InboxItem, type EmailThreadRow, type EmailMessageRow, type ChatConversationRow,
+  type TicketRow, type FormSubmissionRow, type VoiceCallRow,
+} from '@/lib/inbox-items';
+
+const WINDOW_DAYS = 30;
+const LIMIT = 200;
+
+/**
+ * Five bounded reads, merged in the client. Bounded twice: a time window and
+ * a row cap per source, so the queue never becomes the 1000-row silent
+ * truncation PostgREST hands out to an unbounded select. A source the role
+ * cannot read comes back empty through RLS — that is the matrix speaking,
+ * not an error, and the other channels still show.
+ */
+export function useInboxItems() {
+  return useQuery({
+    queryKey: ['inbox-items'],
+    refetchInterval: 30_000,
+    queryFn: async (): Promise<InboxItem[]> => {
+      const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000).toISOString();
+      const [threads, messages, chats, tickets, forms, calls] = await Promise.all([
+        supabase.from('email_threads' as never).select('thread_key, subject, last_message_at, message_count, related_entity_type, related_entity_id').gte('last_message_at', since).order('last_message_at', { ascending: false }).limit(LIMIT),
+        supabase.from('outbound_communications' as never).select('thread_id, direction, sender, recipient, body_text, created_at, status').eq('channel', 'email').not('thread_id', 'is', null).gte('created_at', since).order('created_at', { ascending: false }).limit(LIMIT * 3),
+        supabase.from('chat_conversations' as never).select('id, title, conversation_status, priority, assigned_agent_id, customer_email, customer_name, escalation_reason, channel, updated_at').eq('scope', 'visitor').gte('updated_at', since).order('updated_at', { ascending: false }).limit(LIMIT),
+        supabase.from('tickets' as never).select('id, ticket_number, subject, status, priority, assigned_to, contact_name, contact_email, source, updated_at').gte('updated_at', since).order('updated_at', { ascending: false }).limit(LIMIT),
+        supabase.from('form_submissions' as never).select('id, form_name, data, created_at, handled_at, lead_id').gte('created_at', since).order('created_at', { ascending: false }).limit(LIMIT),
+        supabase.from('voice_calls' as never).select('id, direction, status, from_number, to_number, started_at, voicemail, callback_status, ai_handled, ai_summary, created_at').gte('created_at', since).order('created_at', { ascending: false }).limit(LIMIT),
+      ]);
+      // A source that errors (module off, table absent on an older instance)
+      // is logged and skipped — the queue must not go blank because one
+      // channel is not installed.
+      const rows = <T,>(r: { data: unknown; error: { message: string } | null }, label: string): T[] => {
+        if (r.error) { console.warn(`[inbox] ${label} unavailable: ${r.error.message}`); return []; }
+        return (r.data ?? []) as T[];
+      };
+      return sortQueue([
+        ...emailItems(rows<EmailThreadRow>(threads, 'email threads'), rows<EmailMessageRow>(messages, 'email messages')),
+        ...chatItems(rows<ChatConversationRow>(chats, 'chat')),
+        ...ticketItems(rows<TicketRow>(tickets, 'tickets')),
+        ...formItems(rows<FormSubmissionRow>(forms, 'forms')),
+        ...voiceItems(rows<VoiceCallRow>(calls, 'voice')),
+      ]);
+    },
+  });
+}

--- a/src/lib/__tests__/inbox-items.test.ts
+++ b/src/lib/__tests__/inbox-items.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { emailItems, chatItems, ticketItems, formItems, voiceItems, sortQueue } from '../inbox-items';
+
+describe('Inbox — one queue, organised by who has it', () => {
+  it('email: the latest message decides whose turn it is', () => {
+    const items = emailItems(
+      [
+        { thread_key: 't1', subject: 'Offert', last_message_at: '2026-09-02T10:00:00Z', message_count: 2 },
+        { thread_key: 't2', subject: 'Hej', last_message_at: '2026-09-02T09:00:00Z', message_count: 2 },
+      ],
+      [
+        { thread_id: 't1', direction: 'inbound', sender: 'anna@x.se', recipient: null, body_text: 'Kan ni?', created_at: '2026-09-02T10:00:00Z' },
+        { thread_id: 't1', direction: 'outbound', sender: null, recipient: 'anna@x.se', body_text: 'Hej', created_at: '2026-09-01T10:00:00Z' },
+        { thread_id: 't2', direction: 'outbound', sender: null, recipient: 'bo@y.se', body_text: 'Svar', created_at: '2026-09-02T09:00:00Z' },
+      ],
+    );
+    expect(items.find((i) => i.key === 'email:t1')?.state).toBe('human');
+    expect(items.find((i) => i.key === 'email:t1')?.who).toBe('anna@x.se');
+    expect(items.find((i) => i.key === 'email:t2')?.state).toBe('customer');
+  });
+
+  it('chat: FlowPilot has it unless a person was asked for, escalated, or already on it', () => {
+    const base = { title: null, priority: null, assigned_agent_id: null, customer_email: null, customer_name: 'Eva', escalation_reason: null, channel: 'web', updated_at: '2026-09-02T10:00:00Z' };
+    const s = (conversation_status: string) => chatItems([{ id: 'c', conversation_status, ...base }])[0];
+    expect(s('active').state).toBe('agent');
+    expect(s('waiting_agent').state).toBe('human');
+    expect(s('escalated').state).toBe('human');
+    expect(s('with_agent').state).toBe('human');
+    expect(s('closed').state).toBe('done');
+  });
+
+  it('tickets: waiting is the customer’s turn, resolved/closed is done, the rest needs a person', () => {
+    const t = (status: string, assigned_to: string | null = null) => ticketItems([{ id: 'k', ticket_number: 7, subject: 'Faktura', status, priority: 'normal', assigned_to, contact_name: 'Bo', contact_email: null, source: 'email', updated_at: '2026-09-02T10:00:00Z' }])[0];
+    expect(t('new').state).toBe('human');
+    expect(t('new').reason).toContain('FlowPilot');
+    expect(t('waiting').state).toBe('customer');
+    expect(t('closed').state).toBe('done');
+    expect(t('open', 'u1').assignedTo).toBe('u1');
+  });
+
+  it('forms: unhandled needs a person; a lead FlowPilot created says so', () => {
+    const f = formItems([{ id: 'f', form_name: 'Brief', data: { name: 'Anna', email: 'a@x.se' }, created_at: '2026-09-02T10:00:00Z', handled_at: null, lead_id: 'L1' }])[0];
+    expect(f.state).toBe('human');
+    expect(f.who).toBe('Anna');
+    expect(f.reason).toContain('FlowPilot created the lead');
+    expect(f.href).toContain('L1');
+  });
+
+  it('voice: callbacks and voicemail need a person, an AI-handled call is the agent’s, others are done', () => {
+    const v = (over: Partial<Parameters<typeof voiceItems>[0][0]>) => voiceItems([{ id: 'v', direction: 'inbound', status: 'completed', from_number: '+46', to_number: null, started_at: '2026-09-02T10:00:00Z', voicemail: false, callback_status: 'none', ai_handled: false, ai_summary: null, created_at: '2026-09-02T10:00:00Z', ...over }])[0];
+    expect(v({ callback_status: 'pending' }).state).toBe('human');
+    expect(v({ voicemail: true }).state).toBe('human');
+    expect(v({ ai_handled: true }).state).toBe('agent');
+    expect(v({}).state).toBe('done');
+  });
+
+  it('the queue is newest first', () => {
+    const q = sortQueue([
+      { key: 'a', channel: 'email', state: 'human', reason: '', who: '', subject: '', at: '2026-09-01T00:00:00Z', href: '' },
+      { key: 'b', channel: 'chat', state: 'human', reason: '', who: '', subject: '', at: '2026-09-02T00:00:00Z', href: '' },
+    ]);
+    expect(q.map((i) => i.key)).toEqual(['b', 'a']);
+  });
+});

--- a/src/lib/inbox-items.ts
+++ b/src/lib/inbox-items.ts
@@ -1,0 +1,254 @@
+/**
+ * The Inbox is ONE queue over five existing truths — email threads, chat
+ * conversations, tickets, form submissions, voice calls. No sixth table: each
+ * row here is a read of a row that already exists, and every action links
+ * back to the surface that owns it.
+ *
+ * The queue's organising question is not "which channel" but "who has it":
+ *   - `agent`     — FlowPilot is on it (answering the chat, handled the call,
+ *                   routed the mail). Visible, never hidden — the human can
+ *                   read every step, but nothing is waiting on them.
+ *   - `human`     — a person is needed: the operator escalated, a visitor
+ *                   asked for one, a form came in, a callback is due, mail
+ *                   awaits an answer.
+ *   - `customer`  — the ball is with the customer.
+ *   - `done`      — closed / answered / handled.
+ * FlowPilot goes first: `human` is only what it could not or was not allowed
+ * to finish (trust dial), so the queue is the operator's hand-off list.
+ */
+
+export type InboxChannel = 'email' | 'chat' | 'ticket' | 'form' | 'voice';
+export type InboxState = 'agent' | 'human' | 'customer' | 'done';
+
+export interface InboxItem {
+  key: string;
+  channel: InboxChannel;
+  state: InboxState;
+  /** Why it is in that state, in words a human reads ("visitor asked for a person"). */
+  reason: string;
+  who: string;
+  subject: string;
+  preview?: string | null;
+  at: string; // ISO — last activity
+  href: string;
+  priority?: string | null;
+  /** Who holds it when a human does. */
+  assignedTo?: string | null;
+  /**
+   * The CRM record the item is bound to — the seller's lens. A seller's
+   * outbound mail and the reply that comes back map to THEIR lead; the Inbox
+   * shows that binding and links to it, so the same message reads as "a
+   * reply on my lead" to the seller and "awaiting a reply" to the desk.
+   */
+  entity?: { type: string; id: string } | null;
+}
+
+// ─── Email ───────────────────────────────────────────────────────────────────
+
+export interface EmailThreadRow {
+  thread_key: string;
+  subject: string | null;
+  last_message_at: string;
+  message_count: number | null;
+  related_entity_type?: string | null;
+  related_entity_id?: string | null;
+}
+export interface EmailMessageRow {
+  thread_id: string | null;
+  direction: string | null;
+  sender: string | null;
+  recipient: string | null;
+  body_text: string | null;
+  created_at: string;
+  status?: string | null;
+}
+
+export function emailItems(threads: EmailThreadRow[], messages: EmailMessageRow[]): InboxItem[] {
+  // Latest message per thread decides whose turn it is.
+  const latest = new Map<string, EmailMessageRow>();
+  for (const m of messages) {
+    if (!m.thread_id) continue;
+    const cur = latest.get(m.thread_id);
+    if (!cur || m.created_at > cur.created_at) latest.set(m.thread_id, m);
+  }
+  return threads.map((t) => {
+    const last = latest.get(t.thread_key);
+    const inboundLast = last?.direction === 'inbound';
+    const who = inboundLast ? (last?.sender ?? '') : (last?.recipient ?? '');
+    const entity = t.related_entity_type && t.related_entity_id
+      ? { type: t.related_entity_type, id: t.related_entity_id }
+      : null;
+    const onLead = entity ? ` on ${entity.type === 'lead' ? 'a lead' : entity.type}` : '';
+    return {
+      key: `email:${t.thread_key}`,
+      channel: 'email',
+      state: last ? (inboundLast ? 'human' : 'customer') : 'done',
+      reason: last
+        ? (inboundLast ? `reply in${onLead || ' — awaiting an answer'}` : `sent${onLead} — waiting on them`)
+        : 'no messages',
+      who,
+      subject: t.subject || '(no subject)',
+      preview: last?.body_text?.replace(/\s+/g, ' ').slice(0, 140) ?? null,
+      at: t.last_message_at,
+      href: `/admin/email?tab=threads&thread=${encodeURIComponent(t.thread_key)}`,
+      entity,
+    };
+  });
+}
+
+// ─── Chat ────────────────────────────────────────────────────────────────────
+
+export interface ChatConversationRow {
+  id: string;
+  title: string | null;
+  conversation_status: string | null;
+  priority: string | null;
+  assigned_agent_id: string | null;
+  customer_email: string | null;
+  customer_name: string | null;
+  escalation_reason: string | null;
+  channel: string | null;
+  updated_at: string;
+}
+
+export function chatItems(rows: ChatConversationRow[]): InboxItem[] {
+  return rows.map((c) => {
+    const s = c.conversation_status ?? 'active';
+    let state: InboxState = 'agent';
+    let reason = 'FlowPilot is answering';
+    if (s === 'waiting_agent') { state = 'human'; reason = 'visitor asked for a person'; }
+    else if (s === 'escalated') { state = 'human'; reason = c.escalation_reason ? `escalated: ${c.escalation_reason}` : 'escalated by FlowPilot'; }
+    else if (s === 'with_agent') { state = 'human'; reason = 'with a colleague'; }
+    else if (s === 'closed' || s === 'resolved') { state = 'done'; reason = 'closed'; }
+    return {
+      key: `chat:${c.id}`,
+      channel: 'chat',
+      state,
+      reason,
+      who: c.customer_name || c.customer_email || 'Visitor',
+      subject: c.title || 'Chat conversation',
+      at: c.updated_at,
+      href: `/admin/live-support?conversation=${c.id}`,
+      priority: c.priority,
+      assignedTo: c.assigned_agent_id,
+    };
+  });
+}
+
+// ─── Tickets ─────────────────────────────────────────────────────────────────
+
+export interface TicketRow {
+  id: string;
+  ticket_number: number | string | null;
+  subject: string;
+  status: string;
+  priority: string | null;
+  assigned_to: string | null;
+  contact_name: string | null;
+  contact_email: string | null;
+  source: string | null;
+  updated_at: string;
+}
+
+export function ticketItems(rows: TicketRow[]): InboxItem[] {
+  return rows.map((t) => {
+    let state: InboxState = 'human';
+    let reason = t.assigned_to ? 'assigned' : 'unassigned';
+    if (t.status === 'waiting') { state = 'customer'; reason = 'waiting on the customer'; }
+    else if (t.status === 'resolved' || t.status === 'closed') { state = 'done'; reason = t.status; }
+    else if (t.status === 'new') { reason = t.source === 'email' ? 'FlowPilot opened it from an email' : 'new ticket'; }
+    return {
+      key: `ticket:${t.id}`,
+      channel: 'ticket',
+      state,
+      reason,
+      who: t.contact_name || t.contact_email || '—',
+      subject: `${t.ticket_number ? `#${t.ticket_number} ` : ''}${t.subject}`,
+      at: t.updated_at,
+      href: `/admin/tickets?ticket=${t.id}`,
+      priority: t.priority,
+      assignedTo: t.assigned_to,
+    };
+  });
+}
+
+// ─── Forms ───────────────────────────────────────────────────────────────────
+
+export interface FormSubmissionRow {
+  id: string;
+  form_name: string | null;
+  data: Record<string, unknown> | null;
+  created_at: string;
+  handled_at: string | null;
+  lead_id: string | null;
+}
+
+function guessWho(data: Record<string, unknown> | null): string {
+  if (!data) return '—';
+  for (const k of ['name', 'full_name', 'fullName', 'email', 'company']) {
+    const v = data[k];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  const firstString = Object.values(data).find((v) => typeof v === 'string' && (v as string).trim());
+  return (firstString as string | undefined)?.trim().slice(0, 60) ?? '—';
+}
+
+export function formItems(rows: FormSubmissionRow[]): InboxItem[] {
+  return rows.map((f) => ({
+    key: `form:${f.id}`,
+    channel: 'form',
+    state: f.handled_at ? 'done' : 'human',
+    reason: f.handled_at ? 'handled' : (f.lead_id ? 'FlowPilot created the lead — needs a follow-up' : 'new submission'),
+    who: guessWho(f.data),
+    subject: f.form_name || 'Form submission',
+    preview: f.data ? Object.entries(f.data).filter(([, v]) => typeof v === 'string').map(([k, v]) => `${k}: ${v}`).join(' · ').slice(0, 140) : null,
+    at: f.created_at,
+    href: f.lead_id ? `/admin/contacts?lead=${f.lead_id}` : '/admin/forms',
+  }));
+}
+
+// ─── Voice ───────────────────────────────────────────────────────────────────
+
+export interface VoiceCallRow {
+  id: string;
+  direction: string | null;
+  status: string | null;
+  from_number: string | null;
+  to_number: string | null;
+  started_at: string | null;
+  voicemail: boolean | null;
+  callback_status: string | null;
+  ai_handled: boolean | null;
+  ai_summary: string | null;
+  created_at: string;
+}
+
+export function voiceItems(rows: VoiceCallRow[]): InboxItem[] {
+  return rows.map((v) => {
+    let state: InboxState = 'done';
+    let reason = v.status ?? 'call';
+    if (v.callback_status === 'pending' || v.callback_status === 'scheduled') { state = 'human'; reason = `callback ${v.callback_status}`; }
+    else if (v.voicemail) { state = 'human'; reason = 'voicemail to listen to'; }
+    else if (v.ai_handled) { state = 'agent'; reason = 'FlowPilot took the call'; }
+    else if (v.status === 'missed' || v.status === 'no_answer') { state = 'human'; reason = 'missed call'; }
+    return {
+      key: `voice:${v.id}`,
+      channel: 'voice',
+      state,
+      reason,
+      who: (v.direction === 'inbound' ? v.from_number : v.to_number) || '—',
+      subject: v.ai_summary?.slice(0, 120) || (v.direction === 'inbound' ? 'Incoming call' : 'Outgoing call'),
+      at: v.started_at || v.created_at,
+      href: v.voicemail ? '/admin/live-support?tab=voicemail' : '/admin/live-support?tab=callbacks',
+    };
+  });
+}
+
+// ─── Queue ───────────────────────────────────────────────────────────────────
+
+export const STATE_ORDER: InboxState[] = ['human', 'agent', 'customer', 'done'];
+
+/** Newest first within a state; the caller groups by state. */
+export function sortQueue(items: InboxItem[]): InboxItem[] {
+  return [...items].sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));
+}

--- a/src/pages/admin/EmailPage.tsx
+++ b/src/pages/admin/EmailPage.tsx
@@ -288,7 +288,9 @@ function TemplateDialog({ open, onOpenChange, template }: { open: boolean; onOpe
 
 function ThreadsTab() {
   const { data, isLoading } = useEmailThreads();
-  const [openKey, setOpenKey] = useState<string | null>(null);
+  // Deep link from the Inbox: ?thread=<key> opens that conversation.
+  const [params] = useSearchParams();
+  const [openKey, setOpenKey] = useState<string | null>(params.get('thread'));
   const { data: msgs } = useThreadMessages(openKey ?? undefined);
 
   return (

--- a/src/pages/admin/InboxPage.tsx
+++ b/src/pages/admin/InboxPage.tsx
@@ -1,0 +1,168 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { formatDistanceToNow } from 'date-fns';
+import { Bot, Headphones, Inbox, Loader2, Mail, MessageSquare, Phone, FileText, Ticket, UserRound, Hourglass, CheckCircle2 } from 'lucide-react';
+import { AdminLayout } from '@/components/admin/AdminLayout';
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
+import { AdminPageContainer } from '@/components/admin/AdminPageContainer';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { useInboxItems } from '@/hooks/useInboxItems';
+import { useSupportPresence } from '@/hooks/useSupportPresence';
+import { STATE_ORDER, type InboxChannel, type InboxItem, type InboxState } from '@/lib/inbox-items';
+import { cn } from '@/lib/utils';
+
+/**
+ * The Inbox: everything that reached the company, in one queue, organised by
+ * who has it. FlowPilot goes first — the "needs a person" group is what it
+ * escalated, was not allowed to finish, or a visitor explicitly asked for.
+ *
+ * Presence is a toggle here, not a separate room. Offline you read and catch
+ * up — every step FlowPilot took is visible. "Live" means chat hand-offs and
+ * calls can ring to you. Answering an email or a ticket never needs it:
+ * sellers reply to mail while logged in without having "gone live".
+ */
+const CHANNEL_META: Record<InboxChannel, { label: string; icon: React.ComponentType<{ className?: string }> }> = {
+  email: { label: 'Email', icon: Mail },
+  chat: { label: 'Chat', icon: MessageSquare },
+  ticket: { label: 'Tickets', icon: Ticket },
+  form: { label: 'Forms', icon: FileText },
+  voice: { label: 'Calls', icon: Phone },
+};
+
+const STATE_META: Record<InboxState, { label: string; hint: string; icon: React.ComponentType<{ className?: string }>; tone: string }> = {
+  human: { label: 'Needs a person', hint: 'Escalated, asked for, or not allowed to finish — your hand-off list.', icon: UserRound, tone: 'text-destructive' },
+  agent: { label: 'With FlowPilot', hint: 'Being handled by the operator. Nothing hidden — open any row to read every step.', icon: Bot, tone: 'text-primary' },
+  customer: { label: 'Waiting on the customer', hint: 'Answered; the ball is with them.', icon: Hourglass, tone: 'text-muted-foreground' },
+  done: { label: 'Done', hint: 'Closed or handled in the last 30 days.', icon: CheckCircle2, tone: 'text-muted-foreground' },
+};
+
+export default function InboxPage() {
+  const { data: items = [], isLoading } = useInboxItems();
+  const { agentRecord, onlineAgents, goOnline, goOffline, isUpdating } = useSupportPresence();
+  const [channel, setChannel] = useState<InboxChannel | 'all'>('all');
+  const [showDone, setShowDone] = useState(false);
+
+  const live = agentRecord?.status === 'online';
+  const filtered = useMemo(() => items.filter((i) => channel === 'all' || i.channel === channel), [items, channel]);
+  const grouped = useMemo(() => {
+    const g: Record<InboxState, InboxItem[]> = { human: [], agent: [], customer: [], done: [] };
+    for (const i of filtered) g[i.state].push(i);
+    return g;
+  }, [filtered]);
+  const channelCounts = useMemo(() => {
+    const c: Record<string, number> = {};
+    for (const i of items) if (i.state !== 'done') c[i.channel] = (c[i.channel] ?? 0) + 1;
+    return c;
+  }, [items]);
+
+  return (
+    <AdminLayout>
+      <AdminPageContainer>
+        <AdminPageHeader
+          title="Inbox"
+          description="Everything that reached the company — email, chat, tickets, forms, calls — in one queue. FlowPilot goes first; what needs a person is at the top."
+        >
+          {/* Presence: a visible toggle, not a separate room. */}
+          <div className={cn('flex items-center gap-3 rounded-md border px-3 py-2', live ? 'border-green-600/40 bg-green-600/10' : 'bg-muted/40')}>
+            <Headphones className={cn('h-4 w-4', live ? 'text-green-600' : 'text-muted-foreground')} />
+            <div className="text-sm leading-tight">
+              <div className="font-medium">{live ? 'You are live' : 'You are reading'}</div>
+              <div className="text-xs text-muted-foreground">
+                {live ? 'Chat hand-offs and calls can reach you.' : 'Catch up; nothing rings you. Flip to take chats and calls.'}
+                {onlineAgents.length > 0 && ` · ${onlineAgents.length} live now`}
+              </div>
+            </div>
+            {isUpdating ? <Loader2 className="h-4 w-4 animate-spin" /> : (
+              <Switch checked={live} onCheckedChange={(v) => (v ? goOnline() : goOffline())} aria-label="Go live" />
+            )}
+          </div>
+        </AdminPageHeader>
+
+        {/* Channel filter — counts exclude done */}
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant={channel === 'all' ? 'default' : 'outline'} size="sm" onClick={() => setChannel('all')}>
+            <Inbox className="h-3.5 w-3.5 mr-1.5" /> All
+          </Button>
+          {(Object.keys(CHANNEL_META) as InboxChannel[]).map((c) => {
+            const Icon = CHANNEL_META[c].icon;
+            return (
+              <Button key={c} variant={channel === c ? 'default' : 'outline'} size="sm" onClick={() => setChannel(c)}>
+                <Icon className="h-3.5 w-3.5 mr-1.5" /> {CHANNEL_META[c].label}
+                {channelCounts[c] ? <Badge variant="secondary" className="ml-1.5 text-[10px] px-1.5 py-0">{channelCounts[c]}</Badge> : null}
+              </Button>
+            );
+          })}
+          <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+            <Switch checked={showDone} onCheckedChange={setShowDone} aria-label="Show done" />
+            Show done
+          </div>
+        </div>
+
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading the queue…</p>
+        ) : (
+          <div className="space-y-6">
+            {STATE_ORDER.filter((s) => s !== 'done' || showDone).map((state) => {
+              const meta = STATE_META[state];
+              const Icon = meta.icon;
+              const rows = grouped[state];
+              return (
+                <section key={state} className="space-y-2">
+                  <div className="flex items-baseline gap-2">
+                    <Icon className={cn('h-4 w-4 self-center', meta.tone)} />
+                    <h2 className="font-medium">{meta.label}</h2>
+                    <span className="text-xs text-muted-foreground">{rows.length}</span>
+                    <span className="text-xs text-muted-foreground hidden md:inline">· {meta.hint}</span>
+                  </div>
+                  {rows.length === 0 ? (
+                    <p className="text-sm text-muted-foreground pl-6">Nothing here.</p>
+                  ) : (
+                    <Card>
+                      <CardContent className="p-0 divide-y">
+                        {rows.map((i) => {
+                          const CIcon = CHANNEL_META[i.channel].icon;
+                          return (
+                            <Link key={i.key} to={i.href} className="flex items-start gap-3 px-4 py-3 hover:bg-accent/50">
+                              <CIcon className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+                              <div className="min-w-0 flex-1">
+                                <div className="flex items-center gap-2">
+                                  <span className="font-medium text-sm truncate">{i.subject}</span>
+                                  {i.priority && i.priority !== 'normal' && (
+                                    <Badge variant={i.priority === 'urgent' || i.priority === 'high' ? 'destructive' : 'outline'} className="text-[10px] px-1.5 py-0 capitalize">{i.priority}</Badge>
+                                  )}
+                                </div>
+                                <div className="text-xs text-muted-foreground truncate">
+                                  <span className="text-foreground/80">{i.who}</span> · {i.reason}
+                                  {i.preview ? ` · ${i.preview}` : ''}
+                                </div>
+                              </div>
+                              {i.entity && (
+                                <Link
+                                  to={i.entity.type === 'lead' ? `/admin/contacts?lead=${i.entity.id}` : i.entity.type === 'company' ? `/admin/companies/${i.entity.id}` : '#'}
+                                  onClick={(e) => e.stopPropagation()}
+                                  className="shrink-0"
+                                >
+                                  <Badge variant="outline" className="text-[10px] px-1.5 py-0 capitalize hover:bg-accent">{i.entity.type}</Badge>
+                                </Link>
+                              )}
+                              <span className="text-xs text-muted-foreground shrink-0 whitespace-nowrap">
+                                {formatDistanceToNow(new Date(i.at), { addSuffix: true })}
+                              </span>
+                            </Link>
+                          );
+                        })}
+                      </CardContent>
+                    </Card>
+                  )}
+                </section>
+              );
+            })}
+          </div>
+        )}
+      </AdminPageContainer>
+    </AdminLayout>
+  );
+}


### PR DESCRIPTION
## Vad
- **/admin/inbox**: en kö över `email_threads`, `chat_conversations`, `tickets`, `form_submissions`, `voice_calls`, grupperad efter vem som har ärendet (needs a person / with FlowPilot / waiting on customer / done). Ingen ny tabell.
- **Närvaro som toggle** på sidan ("You are reading" / "You are live") via `support_agents`; läsning kräver aldrig live.
- **Säljarens lins**: mejltrådens lead/bolag visas och länkas.
- Kanalfilter, "show done", djuplänk till mejltråd (`?thread=`), Inbox i menyn.

## Verifiering
Mapper-tester per kanal (`inbox-items.test.ts`), `tsc` grön, guardrails gröna. Livevy kräver inloggning — provas på labs1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)