### PR TITLE
feat(flowbox): FlowPilots steg inline per rad — ur aktivitetsloggen

### DIFF
--- a/src/hooks/useInboxItems.ts
+++ b/src/hooks/useInboxItems.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import {
-  emailItems, chatItems, ticketItems, formItems, voiceItems, sortQueue,
+  emailItems, chatItems, ticketItems, formItems, voiceItems, sortQueue, attachSteps,
   type InboxItem, type EmailThreadRow, type EmailMessageRow, type ChatConversationRow,
-  type TicketRow, type FormSubmissionRow, type VoiceCallRow,
+  type TicketRow, type FormSubmissionRow, type VoiceCallRow, type AgentActivityRow,
 } from '@/lib/inbox-items';
 
 const WINDOW_DAYS = 30;
@@ -22,13 +22,16 @@ export function useInboxItems() {
     refetchInterval: 30_000,
     queryFn: async (): Promise<InboxItem[]> => {
       const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000).toISOString();
-      const [threads, messages, chats, tickets, forms, calls] = await Promise.all([
+      const [threads, messages, chats, tickets, forms, calls, activity] = await Promise.all([
         supabase.from('email_threads' as never).select('thread_key, subject, last_message_at, message_count, related_entity_type, related_entity_id').gte('last_message_at', since).order('last_message_at', { ascending: false }).limit(LIMIT),
         supabase.from('outbound_communications' as never).select('thread_id, direction, sender, recipient, body_text, created_at, status').eq('channel', 'email').not('thread_id', 'is', null).gte('created_at', since).order('created_at', { ascending: false }).limit(LIMIT * 3),
         supabase.from('chat_conversations' as never).select('id, title, conversation_status, priority, assigned_agent_id, customer_email, customer_name, escalation_reason, channel, updated_at').eq('scope', 'visitor').gte('updated_at', since).order('updated_at', { ascending: false }).limit(LIMIT),
         supabase.from('tickets' as never).select('id, ticket_number, subject, status, priority, assigned_to, contact_name, contact_email, source, updated_at').gte('updated_at', since).order('updated_at', { ascending: false }).limit(LIMIT),
         supabase.from('form_submissions' as never).select('id, form_name, data, created_at, handled_at, lead_id').gte('created_at', since).order('created_at', { ascending: false }).limit(LIMIT),
-        supabase.from('voice_calls' as never).select('id, direction, status, from_number, to_number, started_at, voicemail, callback_status, ai_handled, ai_summary, created_at').gte('created_at', since).order('created_at', { ascending: false }).limit(LIMIT),
+        supabase.from('voice_calls' as never).select('id, direction, status, from_number, to_number, started_at, voicemail, callback_status, ai_handled, ai_summary, conversation_id, created_at').gte('created_at', since).order('created_at', { ascending: false }).limit(LIMIT),
+        // The operator's trail — the same ledger objectives close on. Skill
+        // calls only (log rows carry no skill), newest first, bounded.
+        supabase.from('agent_activity' as never).select('id, created_at, agent, skill_name, status, conversation_id, input, output, error_message, log_message').not('skill_name', 'is', null).gte('created_at', since).order('created_at', { ascending: false }).limit(LIMIT * 3),
       ]);
       // A source that errors (module off, table absent on an older instance)
       // is logged and skipped — the queue must not go blank because one
@@ -37,13 +40,14 @@ export function useInboxItems() {
         if (r.error) { console.warn(`[inbox] ${label} unavailable: ${r.error.message}`); return []; }
         return (r.data ?? []) as T[];
       };
-      return sortQueue([
+      const items = sortQueue([
         ...emailItems(rows<EmailThreadRow>(threads, 'email threads'), rows<EmailMessageRow>(messages, 'email messages')),
         ...chatItems(rows<ChatConversationRow>(chats, 'chat')),
         ...ticketItems(rows<TicketRow>(tickets, 'tickets')),
         ...formItems(rows<FormSubmissionRow>(forms, 'forms')),
         ...voiceItems(rows<VoiceCallRow>(calls, 'voice')),
       ]);
+      return attachSteps(items, rows<AgentActivityRow>(activity, 'agent activity'));
     },
   });
 }

--- a/src/lib/__tests__/inbox-items.test.ts
+++ b/src/lib/__tests__/inbox-items.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { emailItems, chatItems, ticketItems, formItems, voiceItems, sortQueue } from '../inbox-items';
+import { emailItems, chatItems, ticketItems, formItems, voiceItems, sortQueue, attachSteps } from '../inbox-items';
 
 describe('Inbox — one queue, organised by who has it', () => {
   it('email: the latest message decides whose turn it is', () => {
@@ -60,5 +60,25 @@ describe('Inbox — one queue, organised by who has it', () => {
       { key: 'b', channel: 'chat', state: 'human', reason: '', who: '', subject: '', at: '2026-09-02T00:00:00Z', href: '' },
     ]);
     expect(q.map((i) => i.key)).toEqual(['b', 'a']);
+  });
+});
+
+describe('FlowPilot’s steps ride on the row — no hidden steps', () => {
+  it('matches activity by conversation id and by any of the item’s ids in input/output, newest last, capped', () => {
+    const chat = chatItems([{ id: 'conv-1111', title: null, conversation_status: 'active', priority: null, assigned_agent_id: null, customer_email: null, customer_name: 'Eva', escalation_reason: null, channel: 'web', updated_at: '2026-09-02T10:00:00Z' }]);
+    const form = formItems([{ id: 'form-2222', form_name: 'Brief', data: { email: 'a@x.se' }, created_at: '2026-09-02T09:00:00Z', handled_at: null, lead_id: 'lead-3333' }]);
+    const activity = [
+      { id: 'a1', created_at: '2026-09-02T10:01:00Z', agent: 'flowpilot', skill_name: 'search_knowledge', status: 'success', conversation_id: 'conv-1111', input: { q: 'pricing' }, output: { message: 'Found 3 articles' } },
+      { id: 'a2', created_at: '2026-09-02T09:05:00Z', agent: 'flowpilot', skill_name: 'qualify_lead', status: 'success', conversation_id: null, input: { lead_id: 'lead-3333' }, output: { score: 72 } },
+      { id: 'a3', created_at: '2026-09-02T09:01:00Z', agent: 'flowpilot', skill_name: 'ensure_lead_partner', status: 'success', conversation_id: null, input: { lead_id: 'lead-3333' }, output: {} },
+      { id: 'a4', created_at: '2026-09-02T08:00:00Z', agent: 'mcp', skill_name: 'manage_page', status: 'success', conversation_id: null, input: { slug: 'home' }, output: {} },
+    ];
+    const [c] = attachSteps(chat, activity);
+    const [f] = attachSteps(form, activity);
+    expect(c.steps?.map((s) => s.skill)).toEqual(['search_knowledge']);
+    expect(c.steps?.[0].summary).toBe('Found 3 articles');
+    expect(f.steps?.map((s) => s.skill)).toEqual(['ensure_lead_partner', 'qualify_lead']);
+    expect(attachSteps(chat, activity, 1)[0].steps).toHaveLength(1);
+    expect(attachSteps(chat, [])[0].steps).toBeUndefined();
   });
 });

--- a/src/lib/inbox-items.ts
+++ b/src/lib/inbox-items.ts
@@ -41,6 +41,85 @@ export interface InboxItem {
    * reply on my lead" to the seller and "awaiting a reply" to the desk.
    */
   entity?: { type: string; id: string } | null;
+  /**
+   * Ids that identify this item in the operator's trail: the conversation
+   * id, the ticket/lead/call id, the thread key. `attachSteps` matches
+   * agent_activity rows against them, so the row can show what FlowPilot
+   * did — no hidden steps.
+   */
+  matchIds?: string[];
+  steps?: InboxStep[];
+}
+
+/** One thing FlowPilot did on this item, in the order it happened. */
+export interface InboxStep {
+  id: string;
+  at: string;
+  skill: string;
+  status: string;
+  agent?: string | null;
+  summary?: string | null;
+}
+
+export interface AgentActivityRow {
+  id: string;
+  created_at: string;
+  agent?: string | null;
+  skill_name: string | null;
+  status: string | null;
+  conversation_id?: string | null;
+  input?: unknown;
+  output?: unknown;
+  error_message?: string | null;
+  log_message?: string | null;
+}
+
+/** A short, human line out of a skill's output — never the whole payload. */
+function summarize(row: AgentActivityRow): string | null {
+  if (row.error_message) return row.error_message.slice(0, 140);
+  const out = row.output as Record<string, unknown> | null | undefined;
+  if (!out || typeof out !== 'object') return row.log_message?.slice(0, 140) ?? null;
+  for (const k of ['message', 'summary', 'note', 'reason', 'status_text', 'result']) {
+    const v = out[k];
+    if (typeof v === 'string' && v.trim()) return v.trim().slice(0, 140);
+  }
+  return null;
+}
+
+/**
+ * Attach the operator's trail to each item. Matching is by id-in-text:
+ * the row's conversation_id, and any of the item's ids appearing in the
+ * call's input or output. Bounded to the last `max` steps per item, newest
+ * last, so a row reads as a short story: routed → qualified → drafted.
+ */
+export function attachSteps(items: InboxItem[], activity: AgentActivityRow[], max = 5): InboxItem[] {
+  if (activity.length === 0) return items;
+  const blobs = activity.map((a) => ({
+    row: a,
+    text: `${a.conversation_id ?? ''} ${safeJson(a.input)} ${safeJson(a.output)}`,
+  }));
+  return items.map((item) => {
+    const ids = (item.matchIds ?? []).filter((x) => x && x.length >= 6);
+    if (ids.length === 0) return item;
+    const hits = blobs
+      .filter(({ text }) => ids.some((id) => text.includes(id)))
+      .map(({ row }) => ({
+        id: row.id,
+        at: row.created_at,
+        skill: row.skill_name ?? row.log_message ?? 'step',
+        status: row.status ?? 'unknown',
+        agent: row.agent ?? null,
+        summary: summarize(row),
+      }))
+      .sort((a, b) => (a.at < b.at ? -1 : a.at > b.at ? 1 : 0));
+    return hits.length ? { ...item, steps: hits.slice(-max) } : item;
+  });
+}
+
+function safeJson(v: unknown): string {
+  if (v == null) return '';
+  if (typeof v === 'string') return v;
+  try { return JSON.stringify(v); } catch { return ''; }
 }
 
 // ─── Email ───────────────────────────────────────────────────────────────────
@@ -92,6 +171,7 @@ export function emailItems(threads: EmailThreadRow[], messages: EmailMessageRow[
       at: t.last_message_at,
       href: `/admin/email?tab=threads&thread=${encodeURIComponent(t.thread_key)}`,
       entity,
+      matchIds: [t.thread_key, ...(entity ? [entity.id] : [])],
     };
   });
 }
@@ -131,6 +211,7 @@ export function chatItems(rows: ChatConversationRow[]): InboxItem[] {
       href: `/admin/live-support?conversation=${c.id}`,
       priority: c.priority,
       assignedTo: c.assigned_agent_id,
+      matchIds: [c.id],
     };
   });
 }
@@ -168,6 +249,7 @@ export function ticketItems(rows: TicketRow[]): InboxItem[] {
       href: `/admin/tickets?ticket=${t.id}`,
       priority: t.priority,
       assignedTo: t.assigned_to,
+      matchIds: [t.id],
     };
   });
 }
@@ -204,6 +286,7 @@ export function formItems(rows: FormSubmissionRow[]): InboxItem[] {
     preview: f.data ? Object.entries(f.data).filter(([, v]) => typeof v === 'string').map(([k, v]) => `${k}: ${v}`).join(' · ').slice(0, 140) : null,
     at: f.created_at,
     href: f.lead_id ? `/admin/contacts?lead=${f.lead_id}` : '/admin/forms',
+    matchIds: [f.id, ...(f.lead_id ? [f.lead_id] : [])],
   }));
 }
 
@@ -220,6 +303,7 @@ export interface VoiceCallRow {
   callback_status: string | null;
   ai_handled: boolean | null;
   ai_summary: string | null;
+  conversation_id?: string | null;
   created_at: string;
 }
 
@@ -240,6 +324,7 @@ export function voiceItems(rows: VoiceCallRow[]): InboxItem[] {
       subject: v.ai_summary?.slice(0, 120) || (v.direction === 'inbound' ? 'Incoming call' : 'Outgoing call'),
       at: v.started_at || v.created_at,
       href: v.voicemail ? '/admin/live-support?tab=voicemail' : '/admin/live-support?tab=callbacks',
+      matchIds: [v.id, ...(v.conversation_id ? [v.conversation_id] : [])],
     };
   });
 }

--- a/src/pages/admin/FlowBoxPage.tsx
+++ b/src/pages/admin/FlowBoxPage.tsx
@@ -97,6 +97,7 @@ function QueueTab() {
   const { data: items = [], isLoading } = useInboxItems();
   const [channel, setChannel] = useState<InboxChannel | 'all'>('all');
   const [showDone, setShowDone] = useState(false);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
 
   const filtered = useMemo(() => items.filter((i) => channel === 'all' || i.channel === channel), [items, channel]);
   const grouped = useMemo(() => {
@@ -154,8 +155,10 @@ function QueueTab() {
                     <CardContent className="p-0 divide-y">
                       {rows.map((i) => {
                         const CIcon = CHANNEL_META[i.channel].icon;
+                        const open = expanded.has(i.key);
                         return (
-                          <Link key={i.key} to={i.href} className="flex items-start gap-3 px-4 py-3 hover:bg-accent/50">
+                          <div key={i.key}>
+                          <Link to={i.href} className="flex items-start gap-3 px-4 py-3 hover:bg-accent/50">
                             <CIcon className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
                             <div className="min-w-0 flex-1">
                               <div className="flex items-center gap-2">
@@ -182,6 +185,40 @@ function QueueTab() {
                               {formatDistanceToNow(new Date(i.at), { addSuffix: true })}
                             </span>
                           </Link>
+                          {/* FlowPilot's steps on this item — the trail out of
+                              agent_activity, matched by the item's ids. Folded
+                              by default; the chip says how many. No hidden steps. */}
+                          {!!i.steps?.length && (
+                            <div className="px-4 pb-2 -mt-1">
+                              <button
+                                type="button"
+                                onClick={() => setExpanded((s) => { const n = new Set(s); n.has(i.key) ? n.delete(i.key) : n.add(i.key); return n; })}
+                                className="inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
+                              >
+                                <Bot className="h-3 w-3" />
+                                {open ? 'Hide' : `FlowPilot · ${i.steps.length} step${i.steps.length === 1 ? '' : 's'}`}
+                                {!open && (
+                                  <span className="text-muted-foreground">
+                                    {' '}· last: {i.steps[i.steps.length - 1].skill.replace(/_/g, ' ')}
+                                  </span>
+                                )}
+                              </button>
+                              {open && (
+                                <ol className="mt-1.5 ml-1 border-l border-border pl-3 space-y-1">
+                                  {i.steps.map((s) => (
+                                    <li key={s.id} className="text-xs">
+                                      <span className={cn('font-medium', s.status === 'success' ? 'text-foreground' : s.status === 'pending_approval' ? 'text-warning' : s.status === 'failed' || s.status === 'error' ? 'text-destructive' : 'text-muted-foreground')}>
+                                        {s.status === 'success' ? '✓' : s.status === 'pending_approval' ? '◐' : s.status === 'failed' || s.status === 'error' ? '✗' : '·'} {s.skill.replace(/_/g, ' ')}
+                                      </span>
+                                      <span className="text-muted-foreground"> · {formatDistanceToNow(new Date(s.at), { addSuffix: true })}{s.agent && s.agent !== 'flowpilot' ? ` · ${s.agent}` : ''}</span>
+                                      {s.summary && <div className="text-muted-foreground truncate">{s.summary}</div>}
+                                    </li>
+                                  ))}
+                                </ol>
+                              )}
+                            </div>
+                          )}
+                          </div>
                         );
                       })}
                     </CardContent>


### PR DESCRIPTION
## Vad
- `attachSteps(items, activity)`: matchar `agent_activity` (skill-anrop, 30 dagar, bundet) mot radens id:n (conversation_id, ärende/lead/samtal, trådnyckel) och fäster de senaste fem stegen.
- FlowBox-raden visar chip "FlowPilot · n steps · last: …", uppfällbar lista med status, tid, agent och kort sammanfattning ur utdatan.

## Verifiering
Enhetstest för matchning (conversation_id, id-i-input/output, ordning, tak, tom logg); `tsc` grön; statusfärgs-ratchet och övriga vakter gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)