### PR TITLE
feat(flowbox): svara på chatt och ärende direkt i kön

### DIFF
--- a/src/components/admin/flowbox/ChatReply.tsx
+++ b/src/components/admin/flowbox/ChatReply.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { Loader2, Send } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { useConversationMessages, useSupportConversations } from '@/hooks/useSupportConversations';
+import { cn } from '@/lib/utils';
+
+/**
+ * Reply to a visitor's chat from the FlowBox queue. The same two writes
+ * Live Support makes — claim the conversation (it becomes yours,
+ * `with_agent`) and insert an agent message that the widget receives over
+ * broadcast — without leaving the queue. The last few messages are shown so
+ * the answer is written in context; the full transcript is one click away.
+ */
+export function ChatReply({ conversationId, needsClaim, live }: { conversationId: string; needsClaim: boolean; live: boolean }) {
+  const { messages = [], isLoading, sendMessage } = useConversationMessages(conversationId);
+  const { claimConversation } = useSupportConversations();
+  const [text, setText] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const recent = messages.slice(-6);
+
+  const send = async () => {
+    const body = text.trim();
+    if (!body) return;
+    setSending(true);
+    try {
+      if (needsClaim) await claimConversation.mutateAsync(conversationId);
+      await sendMessage.mutateAsync(body);
+      setText('');
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Could not send');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-dashed p-3 space-y-2">
+      {isLoading ? (
+        <p className="text-xs text-muted-foreground">Loading conversation…</p>
+      ) : (
+        <div className="space-y-1 max-h-48 overflow-y-auto">
+          {recent.length === 0 && <p className="text-xs text-muted-foreground">No messages yet.</p>}
+          {recent.map((m) => (
+            <div key={m.id} className={cn('text-xs rounded-md px-2 py-1 max-w-[90%]', m.role === 'user' ? 'bg-muted' : m.role === 'agent' ? 'bg-primary/10 ml-auto' : 'bg-accent/40 ml-auto')}>
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground mr-1">{m.role === 'user' ? 'visitor' : m.role === 'agent' ? 'you/colleague' : 'FlowPilot'}</span>
+              {m.content}
+            </div>
+          ))}
+        </div>
+      )}
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder={needsClaim ? 'Reply — this takes the conversation over from FlowPilot' : 'Reply…'}
+        rows={2}
+        onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void send(); }}
+      />
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] text-muted-foreground">
+          {needsClaim ? 'Sending claims the chat for you. ' : ''}
+          {!live ? 'You are not live: this reply goes out, but new hand-offs will not ring you.' : ''}
+        </span>
+        <Button size="sm" onClick={send} disabled={sending || !text.trim()} className="gap-1.5">
+          {sending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+          Send
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/flowbox/TicketReply.tsx
+++ b/src/components/admin/flowbox/TicketReply.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import { Loader2, Send } from 'lucide-react';
+import { toast } from 'sonner';
+import { supabase } from '@/integrations/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { useAuth } from '@/hooks/useAuth';
+import { useAddTicketComment, useTicketComments } from '@/hooks/useTickets';
+import { escapeHtml } from '@/lib/email-body';
+import { cn } from '@/lib/utils';
+
+/**
+ * Answer a ticket from the FlowBox queue. One write the ticket already
+ * knows — a comment, public or internal — and, when the ticket has a
+ * contact address, the same email rail every other surface uses, bound to
+ * the ticket so the reply shows in its trail and in the message log. The
+ * customer also sees public comments in their portal.
+ */
+export function TicketReply({ ticketId, subject, contactEmail, contactName }: { ticketId: string; subject: string; contactEmail?: string | null; contactName?: string | null }) {
+  const { user, profile } = useAuth();
+  const { data: comments = [], isLoading } = useTicketComments(ticketId);
+  const addComment = useAddTicketComment();
+  const [text, setText] = useState('');
+  const [internal, setInternal] = useState(false);
+  const [email, setEmail] = useState(!!contactEmail);
+  const [sending, setSending] = useState(false);
+
+  const recent = comments.slice(-4);
+
+  const send = async () => {
+    const body = text.trim();
+    if (!body) return;
+    setSending(true);
+    try {
+      await addComment.mutateAsync({
+        ticket_id: ticketId,
+        content: body,
+        is_internal: internal,
+        author_id: user?.id,
+        author_name: profile?.full_name ?? profile?.email ?? undefined,
+      });
+      if (!internal && email && contactEmail) {
+        const html = body.split('\n').map((l) => (l.trim() === '' ? '<br>' : `<p>${escapeHtml(l)}</p>`)).join('');
+        const { data, error } = await supabase.functions.invoke('email-send', {
+          body: {
+            to: contactEmail,
+            toName: contactName || undefined,
+            subject: /^\s*re:/i.test(subject) ? subject : `Re: ${subject}`,
+            html,
+            text: body,
+            expects_reply: true,
+            source: 'ticket-reply',
+            related_entity_type: 'ticket',
+            related_entity_id: ticketId,
+            tags: { source: 'ticket-reply' },
+          },
+        });
+        if (error) throw error;
+        if (data && data.success === false) throw new Error(data.error || 'Email failed');
+      }
+      setText('');
+      toast.success(internal ? 'Note added' : email && contactEmail ? `Reply sent to ${contactEmail}` : 'Reply added to the ticket');
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Could not reply');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-dashed p-3 space-y-2">
+      {isLoading ? (
+        <p className="text-xs text-muted-foreground">Loading…</p>
+      ) : recent.length > 0 && (
+        <div className="space-y-1 max-h-40 overflow-y-auto">
+          {recent.map((c) => (
+            <div key={c.id} className={cn('text-xs rounded-md px-2 py-1', c.is_internal ? 'bg-warning/10' : c.author_type === 'agent' ? 'bg-primary/10' : 'bg-muted')}>
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground mr-1">
+                {c.is_internal ? 'internal' : c.author_type}{c.author_name ? ` · ${c.author_name}` : ''} · {formatDistanceToNow(new Date(c.created_at), { addSuffix: true })}
+              </span>
+              {c.content}
+            </div>
+          ))}
+        </div>
+      )}
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder={internal ? 'Internal note — the customer never sees this' : 'Reply to the customer…'}
+        rows={2}
+        onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void send(); }}
+      />
+      <div className="flex flex-wrap items-center gap-4 text-[11px] text-muted-foreground">
+        <label className="inline-flex items-center gap-1.5"><Switch checked={internal} onCheckedChange={setInternal} aria-label="Internal note" /> Internal note</label>
+        {contactEmail && !internal && (
+          <label className="inline-flex items-center gap-1.5"><Switch checked={email} onCheckedChange={setEmail} aria-label="Email the customer" /> Also email {contactEmail}</label>
+        )}
+        <Button size="sm" onClick={send} disabled={sending || !text.trim()} className="gap-1.5 ml-auto">
+          {sending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+          {internal ? 'Add note' : 'Send'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/inbox-items.ts
+++ b/src/lib/inbox-items.ts
@@ -49,6 +49,12 @@ export interface InboxItem {
    */
   matchIds?: string[];
   steps?: InboxStep[];
+  /** The source row's own id (conversation, ticket…) — what an inline reply targets. */
+  sourceId?: string;
+  /** Who to answer, when the channel needs an address. */
+  contact?: { email?: string | null; name?: string | null } | null;
+  /** Chat only: the conversation is not yet a person's — replying claims it. */
+  needsClaim?: boolean;
 }
 
 /** One thing FlowPilot did on this item, in the order it happened. */
@@ -212,6 +218,9 @@ export function chatItems(rows: ChatConversationRow[]): InboxItem[] {
       priority: c.priority,
       assignedTo: c.assigned_agent_id,
       matchIds: [c.id],
+      sourceId: c.id,
+      contact: { email: c.customer_email, name: c.customer_name },
+      needsClaim: s !== 'with_agent',
     };
   });
 }
@@ -250,6 +259,8 @@ export function ticketItems(rows: TicketRow[]): InboxItem[] {
       priority: t.priority,
       assignedTo: t.assigned_to,
       matchIds: [t.id],
+      sourceId: t.id,
+      contact: { email: t.contact_email, name: t.contact_name },
     };
   });
 }

--- a/src/pages/admin/FlowBoxPage.tsx
+++ b/src/pages/admin/FlowBoxPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
-import { Bot, Headphones, Inbox, Loader2, Mail, MessageSquare, Phone, FileText, Ticket, UserRound, Hourglass, CheckCircle2, Route, ScrollText } from 'lucide-react';
+import { Bot, Headphones, Inbox, Loader2, Mail, MessageSquare, Phone, FileText, Ticket, UserRound, Hourglass, CheckCircle2, Route, ScrollText, Reply } from 'lucide-react';
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { AdminPageContainer } from '@/components/admin/AdminPageContainer';
@@ -15,6 +15,8 @@ import { useSupportPresence } from '@/hooks/useSupportPresence';
 import { STATE_ORDER, type InboxChannel, type InboxItem, type InboxState } from '@/lib/inbox-items';
 import { RoutingLenses } from '@/components/admin/flowbox/RoutingLenses';
 import { MessageLogTab } from '@/components/admin/flowbox/MessageLogTab';
+import { ChatReply } from '@/components/admin/flowbox/ChatReply';
+import { TicketReply } from '@/components/admin/flowbox/TicketReply';
 import { cn } from '@/lib/utils';
 
 /**
@@ -69,7 +71,7 @@ export default function FlowBoxPage() {
             <TabsTrigger value="routing"><Route className="h-4 w-4 mr-1" /> Routing</TabsTrigger>
             <TabsTrigger value="log"><ScrollText className="h-4 w-4 mr-1" /> Message log</TabsTrigger>
           </TabsList>
-          <TabsContent value="queue"><QueueTab /></TabsContent>
+          <TabsContent value="queue"><QueueTab live={live} /></TabsContent>
           <TabsContent value="routing"><RoutingLenses /></TabsContent>
           <TabsContent value="log"><MessageLogTab /></TabsContent>
         </Tabs>
@@ -93,11 +95,14 @@ const STATE_META: Record<InboxState, { label: string; hint: string; icon: React.
   done: { label: 'Done', hint: 'Closed or handled in the last 30 days.', icon: CheckCircle2, tone: 'text-muted-foreground' },
 };
 
-function QueueTab() {
+function QueueTab({ live }: { live: boolean }) {
   const { data: items = [], isLoading } = useInboxItems();
   const [channel, setChannel] = useState<InboxChannel | 'all'>('all');
   const [showDone, setShowDone] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [replying, setReplying] = useState<Set<string>>(() => new Set());
+  const toggle = (set: React.Dispatch<React.SetStateAction<Set<string>>>, key: string) =>
+    set((s) => { const n = new Set(s); if (n.has(key)) n.delete(key); else n.add(key); return n; });
 
   const filtered = useMemo(() => items.filter((i) => channel === 'all' || i.channel === channel), [items, channel]);
   const grouped = useMemo(() => {
@@ -192,7 +197,7 @@ function QueueTab() {
                             <div className="px-4 pb-2 -mt-1">
                               <button
                                 type="button"
-                                onClick={() => setExpanded((s) => { const n = new Set(s); n.has(i.key) ? n.delete(i.key) : n.add(i.key); return n; })}
+                                onClick={() => toggle(setExpanded, i.key)}
                                 className="inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
                               >
                                 <Bot className="h-3 w-3" />
@@ -215,6 +220,29 @@ function QueueTab() {
                                     </li>
                                   ))}
                                 </ol>
+                              )}
+                            </div>
+                          )}
+                          {/* Answer where the work is: chat and tickets reply
+                              inline, the way email already does on its thread.
+                              Forms and calls keep their own surfaces. */}
+                          {(i.channel === 'chat' || i.channel === 'ticket') && i.sourceId && i.state !== 'done' && (
+                            <div className="px-4 pb-3">
+                              <button
+                                type="button"
+                                onClick={() => toggle(setReplying, i.key)}
+                                className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+                              >
+                                <Reply className="h-3 w-3" /> {replying.has(i.key) ? 'Close' : 'Reply here'}
+                              </button>
+                              {replying.has(i.key) && (
+                                <div className="mt-2">
+                                  {i.channel === 'chat' ? (
+                                    <ChatReply conversationId={i.sourceId} needsClaim={!!i.needsClaim} live={live} />
+                                  ) : (
+                                    <TicketReply ticketId={i.sourceId} subject={i.subject.replace(/^#\d+\s+/, '')} contactEmail={i.contact?.email} contactName={i.contact?.name} />
+                                  )}
+                                </div>
                               )}
                             </div>
                           )}


### PR DESCRIPTION
## Vad
- **ChatReply**: kontext (senaste 6), claim vid behov (`claimConversation`) + `sendMessage` (broadcast till widgeten), hint när man inte är live.
- **TicketReply**: kommentar (publik/intern) via `useAddTicketComment`, och e-post till kontakten via `email-send` bundet till ärendet (`related_entity_type: 'ticket'`).
- Raden bär `sourceId`, `contact` och `needsClaim`; "Reply here" under chatt- och ärenderader som inte är done.

## Verifiering
`tsc` grön, eslint rent på nya filer, vakter gröna (inbox-items, status-tokens, no-swallowed-errors, absence-is-not-a-silence, provider-belongs-to-the-router). Livevy kräver inloggning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)