### PR TITLE
feat(flowbox): formulär stängs från raden — svara eller markera hanterad

### DIFF
--- a/src/components/admin/flowbox/FormHandle.tsx
+++ b/src/components/admin/flowbox/FormHandle.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { CheckCircle2, Loader2, Send } from 'lucide-react';
+import { toast } from 'sonner';
+import { supabase } from '@/integrations/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { escapeHtml } from '@/lib/email-body';
+
+/**
+ * Close a form submission from the FlowBox queue. Two things the Forms page
+ * can do, done where the queue is: mark it handled (the same handled_at /
+ * handled_by stamp, RLS on the forms module), and — when the submission
+ * carries an address — answer the sender by email on the platform rail,
+ * bound to the submission so the reply shows in the message log. Sending a
+ * reply marks the submission handled: answering IS handling it.
+ */
+export function FormHandle({ submissionId, formName, contactEmail, contactName, fields }: {
+  submissionId: string;
+  formName: string;
+  contactEmail?: string | null;
+  contactName?: string | null;
+  fields: Record<string, unknown> | null;
+}) {
+  const qc = useQueryClient();
+  const [text, setText] = useState('');
+  const [busy, setBusy] = useState<'handle' | 'send' | null>(null);
+
+  const entries = Object.entries(fields ?? {}).filter(([, v]) => typeof v === 'string' && (v as string).trim());
+
+  const done = async () => {
+    await Promise.all([
+      qc.invalidateQueries({ queryKey: ['inbox-items'] }),
+      qc.invalidateQueries({ queryKey: ['form-submissions'] }),
+    ]);
+  };
+
+  const markHandled = async () => {
+    const { data: auth } = await supabase.auth.getUser();
+    // Cast: the generated types predate the handled columns; DB + RLS decide.
+    const { error, data } = await (supabase.from('form_submissions') as never as {
+      update: (p: object) => { eq: (c: string, v: string) => { select: (c: string) => { single: () => Promise<{ error: { message: string } | null; data: unknown }> } } };
+    }).update({ handled_at: new Date().toISOString(), handled_by: auth?.user?.id ?? null }).eq('id', submissionId).select('id').single();
+    if (error) throw new Error(error.message);
+    if (!data) throw new Error('The submission was not updated — no row matched');
+  };
+
+  const handle = async () => {
+    setBusy('handle');
+    try {
+      await markHandled();
+      toast.success('Marked as handled — find it under Show done');
+      await done();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Could not mark as handled');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const send = async () => {
+    const body = text.trim();
+    if (!body || !contactEmail) return;
+    setBusy('send');
+    try {
+      const html = body.split('\n').map((l) => (l.trim() === '' ? '<br>' : `<p>${escapeHtml(l)}</p>`)).join('');
+      const { data, error } = await supabase.functions.invoke('email-send', {
+        body: {
+          to: contactEmail,
+          toName: contactName || undefined,
+          subject: `Re: ${formName}`,
+          html,
+          text: body,
+          expects_reply: true,
+          source: 'form-reply',
+          related_entity_type: 'form_submission',
+          related_entity_id: submissionId,
+          tags: { source: 'form-reply' },
+        },
+      });
+      if (error) throw error;
+      if (data && data.success === false) throw new Error(data.error || 'Email failed');
+      await markHandled();
+      setText('');
+      toast.success(`Reply sent to ${contactEmail} — submission handled`);
+      await done();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Could not reply');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-dashed p-3 space-y-2">
+      {entries.length > 0 && (
+        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs max-h-40 overflow-y-auto">
+          {entries.map(([k, v]) => (
+            <div key={k} className="contents">
+              <dt className="text-muted-foreground truncate">{k}</dt>
+              <dd className="break-words">{String(v)}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      {contactEmail && (
+        <Textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={`Reply to ${contactEmail}… sending marks the submission handled`}
+          rows={2}
+          onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void send(); }}
+        />
+      )}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[11px] text-muted-foreground">
+          {contactEmail ? 'Answer by email, or just mark it handled.' : 'No address on this submission — mark it handled when done.'}
+        </span>
+        <div className="flex items-center gap-2 ml-auto">
+          <Button size="sm" variant="outline" onClick={handle} disabled={busy !== null} className="gap-1.5">
+            {busy === 'handle' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <CheckCircle2 className="h-3.5 w-3.5" />}
+            Mark handled
+          </Button>
+          {contactEmail && (
+            <Button size="sm" onClick={send} disabled={busy !== null || !text.trim()} className="gap-1.5">
+              {busy === 'send' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+              Send reply
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/__tests__/inbox-items.test.ts
+++ b/src/lib/__tests__/inbox-items.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { emailItems, chatItems, ticketItems, formItems, voiceItems, sortQueue, attachSteps } from '../inbox-items';
+import { emailItems, chatItems, ticketItems, formItems, voiceItems, sortQueue, attachSteps, guessEmail } from '../inbox-items';
 
 describe('Inbox — one queue, organised by who has it', () => {
   it('email: the latest message decides whose turn it is', () => {
@@ -64,11 +64,17 @@ describe('Inbox — one queue, organised by who has it', () => {
     expect(t('open', 'u1').assignedTo).toBe('u1');
   });
 
-  it('forms: unhandled needs a person; a lead FlowPilot created says so', () => {
+  it('forms: unhandled needs a person and carries the sender; a lead FlowPilot created is handled — the follow-up lives on the lead', () => {
+    const open = formItems([{ id: 'g', form_name: 'Brief', data: { Namn: 'Bo', 'E-post': 'bo@y.se', msg: 'Hej' }, created_at: '2026-09-02T10:00:00Z', handled_at: null, lead_id: null }])[0];
+    expect(open.state).toBe('human');
+    expect(open.sourceId).toBe('g');
+    expect(open.contact?.email).toBe('bo@y.se');
+    expect(guessEmail({ note: 'skriv till x@y.se' })).toBeNull();
     const f = formItems([{ id: 'f', form_name: 'Brief', data: { name: 'Anna', email: 'a@x.se' }, created_at: '2026-09-02T10:00:00Z', handled_at: null, lead_id: 'L1' }])[0];
-    expect(f.state).toBe('human');
+    expect(f.state).toBe('done');
     expect(f.who).toBe('Anna');
     expect(f.reason).toContain('FlowPilot created the lead');
+    expect(f.contact?.email).toBe('a@x.se');
     expect(f.href).toContain('L1');
   });
 

--- a/src/lib/inbox-items.ts
+++ b/src/lib/inbox-items.ts
@@ -57,6 +57,8 @@ export interface InboxItem {
   needsClaim?: boolean;
   /** Email: FlowPilot filed a draft reply on the thread — the reply box opens with it. */
   hasDraft?: boolean;
+  /** Form: the submitted fields, shown where the submission is handled. */
+  fields?: Record<string, unknown> | null;
 }
 
 /** One thing FlowPilot did on this item, in the order it happened. */
@@ -300,18 +302,47 @@ function guessWho(data: Record<string, unknown> | null): string {
 }
 
 export function formItems(rows: FormSubmissionRow[]): InboxItem[] {
-  return rows.map((f) => ({
-    key: `form:${f.id}`,
-    channel: 'form',
-    state: f.handled_at ? 'done' : 'human',
-    reason: f.handled_at ? 'handled' : (f.lead_id ? 'FlowPilot created the lead — needs a follow-up' : 'new submission'),
-    who: guessWho(f.data),
-    subject: f.form_name || 'Form submission',
-    preview: f.data ? Object.entries(f.data).filter(([, v]) => typeof v === 'string').map(([k, v]) => `${k}: ${v}`).join(' · ').slice(0, 140) : null,
-    at: f.created_at,
-    href: f.lead_id ? `/admin/contacts?lead=${f.lead_id}` : '/admin/forms',
-    matchIds: [f.id, ...(f.lead_id ? [f.lead_id] : [])],
-  }));
+  // Handled = the same rule the Forms page reads: provenance first (FlowPilot
+  // made a lead — the follow-up lives on the lead, in the CRM), a person's
+  // handled stamp second. One fact, one reader — the queue must not count a
+  // submission as open that the Forms page shows as done.
+  return rows.map((f) => {
+    const handled = !!f.lead_id || !!f.handled_at;
+    return {
+      key: `form:${f.id}`,
+      channel: 'form',
+      state: handled ? 'done' : 'human',
+      reason: f.handled_at ? 'handled' : (f.lead_id ? 'FlowPilot created the lead — follow up there' : 'new submission — answer or mark handled'),
+      who: guessWho(f.data),
+      subject: f.form_name || 'Form submission',
+      preview: f.data ? Object.entries(f.data).filter(([, v]) => typeof v === 'string').map(([k, v]) => `${k}: ${v}`).join(' · ').slice(0, 140) : null,
+      at: f.created_at,
+      href: f.lead_id ? `/admin/contacts?lead=${f.lead_id}` : '/admin/forms',
+      matchIds: [f.id, ...(f.lead_id ? [f.lead_id] : [])],
+      sourceId: f.id,
+      contact: { email: guessEmail(f.data), name: guessName(f.data) },
+      fields: f.data,
+    };
+  });
+}
+
+/** The sender's address, from the field names forms actually use. */
+export function guessEmail(data: Record<string, unknown> | null): string | null {
+  if (!data) return null;
+  for (const [k, v] of Object.entries(data)) {
+    if (/^(e-?mail|epost|e-post|mail)$/i.test(k) && typeof v === 'string' && /\S+@\S+\.\S+/.test(v)) return v.trim();
+  }
+  const any = Object.values(data).find((v) => typeof v === 'string' && /^\S+@\S+\.\S+$/.test(v.trim()));
+  return typeof any === 'string' ? any.trim() : null;
+}
+
+function guessName(data: Record<string, unknown> | null): string | null {
+  if (!data) return null;
+  for (const k of ['name', 'full_name', 'fullName', 'namn']) {
+    const v = data[k];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return null;
 }
 
 // ─── Voice ───────────────────────────────────────────────────────────────────

--- a/src/pages/admin/FlowBoxPage.tsx
+++ b/src/pages/admin/FlowBoxPage.tsx
@@ -17,6 +17,7 @@ import { RoutingLenses } from '@/components/admin/flowbox/RoutingLenses';
 import { MessageLogTab } from '@/components/admin/flowbox/MessageLogTab';
 import { ChatReply } from '@/components/admin/flowbox/ChatReply';
 import { EmailReply } from '@/components/admin/flowbox/EmailReply';
+import { FormHandle } from '@/components/admin/flowbox/FormHandle';
 import { TicketReply } from '@/components/admin/flowbox/TicketReply';
 import { CallbacksPanel } from '@/components/admin/live-support/CallbacksPanel';
 import { VoicemailPanel } from '@/components/admin/live-support/VoicemailPanel';
@@ -238,11 +239,12 @@ function QueueTab({ live, openKey }: { live: boolean; openKey?: string | null })
                               )}
                             </div>
                           )}
-                          {/* Answer where the work is: email, chat and tickets
-                              reply inline. Email opens with FlowPilot's draft
-                              when one is waiting. Forms and calls keep their
-                              own surfaces. */}
-                          {(i.channel === 'email' || i.channel === 'chat' || i.channel === 'ticket') && i.sourceId && i.state !== 'done' && (
+                          {/* Answer where the work is: email, chat, tickets
+                              and forms are handled inline. Email opens with
+                              FlowPilot's draft when one is waiting; a form is
+                              answered or marked handled. Calls keep the Calls
+                              tab. */}
+                          {(i.channel === 'email' || i.channel === 'chat' || i.channel === 'ticket' || i.channel === 'form') && i.sourceId && i.state !== 'done' && (
                             <div className="px-4 pb-3">
                               <button
                                 type="button"
@@ -250,11 +252,13 @@ function QueueTab({ live, openKey }: { live: boolean; openKey?: string | null })
                                 className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
                               >
                                 {i.hasDraft ? <Bot className="h-3 w-3 text-primary" /> : <Reply className="h-3 w-3" />}
-                                {replying.has(i.key) ? 'Close' : i.hasDraft ? 'Review FlowPilot’s draft' : 'Reply here'}
+                                {replying.has(i.key) ? 'Close' : i.hasDraft ? 'Review FlowPilot’s draft' : i.channel === 'form' ? 'Handle here' : 'Reply here'}
                               </button>
                               {replying.has(i.key) && (
                                 <div className="mt-2">
-                                  {i.channel === 'email' ? (
+                                  {i.channel === 'form' ? (
+                                    <FormHandle submissionId={i.sourceId} formName={i.subject} contactEmail={i.contact?.email} contactName={i.contact?.name} fields={i.fields ?? null} />
+                                  ) : i.channel === 'email' ? (
                                     <EmailReply threadKey={i.sourceId} />
                                   ) : i.channel === 'chat' ? (
                                     <ChatReply conversationId={i.sourceId} needsClaim={!!i.needsClaim} live={live} />


### PR DESCRIPTION
## Vad
- **FormHandle** i FlowBox-raden: fälten, **Mark handled** (samma stämpel som Forms-sidan, RLS forms-modulen), och **Send reply** när inskicket har en adress (email-send, `related_entity_type: form_submission`). Skickat svar markerar hanterad.
- **En fakta, en läsare**: `formItems` läser nu Forms-sidans regel — lead finns → done ("follow up there"). Kön dubbelräknade tidigare.
- `guessEmail`/`guessName` ur fältnamnen forms faktiskt använder (email, e-post, epost, namn …).

## Verifiering
tsc grön, eslint rent, kötester + vakter gröna (21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)