### PR TITLE
fix(forms): formulärblockets besökartext går på textlagret

### DIFF
--- a/src/components/public/blocks/FormBlock.tsx
+++ b/src/components/public/blocks/FormBlock.tsx
@@ -25,6 +25,12 @@ import { createLeadFromForm } from '@/lib/lead-utils';
 import { useUiText, useUiTextLanguage } from '@/lib/ui-text';
 import { operatorText } from '@/lib/operator-text';
 
+/**
+ * Internal label only — the row's form_name and the admin notification's
+ * subject. The visitor never reads it, so it stays out of the ui_text pack.
+ */
+const DEFAULT_FORM_NAME = 'Contact Form';
+
 interface FormBlockProps {
   data: FormBlockData;
   blockId: string;
@@ -152,7 +158,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
           id: submissionId,
           block_id: blockId,
           page_id: pageId || null,
-          form_name: data.title || 'Contact Form',
+          form_name: data.title || DEFAULT_FORM_NAME,
           data: submissionData,
           metadata: {
             submitted_at: new Date().toISOString(),
@@ -182,7 +188,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
           name: nameField ? (formData[nameField.id] as string) : undefined,
           company: companyField ? (formData[companyField.id] as string) : undefined,
           phone: phoneField ? (formData[phoneField.id] as string) : undefined,
-          formName: data.title || 'Contact Form',
+          formName: data.title || DEFAULT_FORM_NAME,
           formData: submissionData as Record<string, unknown>,
           sourceId: blockId,
           pageId: pageId,
@@ -192,7 +198,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
 
       // Trigger webhook for form submission
       webhookEvents.formSubmitted({
-        form_name: data.title || 'Contact Form',
+        form_name: data.title || DEFAULT_FORM_NAME,
         block_id: blockId,
         page_id: pageId,
         data: submissionData as Record<string, unknown>,
@@ -220,7 +226,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
             },
             body: JSON.stringify({
               to: data.notifyEmail.trim(),
-              subject: `New submission: ${data.title || 'Contact Form'}`,
+              subject: `New submission: ${data.title || DEFAULT_FORM_NAME}`,
               body: `A new form submission was received:\n\n${lines}`,
             }),
           });

--- a/src/components/public/blocks/FormBlock.tsx
+++ b/src/components/public/blocks/FormBlock.tsx
@@ -22,6 +22,8 @@ import { cn } from '@/lib/utils';
 import type { Json } from '@/integrations/supabase/types';
 import { webhookEvents } from '@/lib/webhook-utils';
 import { createLeadFromForm } from '@/lib/lead-utils';
+import { useUiText, useUiTextLanguage } from '@/lib/ui-text';
+import { operatorText } from '@/lib/operator-text';
 
 interface FormBlockProps {
   data: FormBlockData;
@@ -40,28 +42,32 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
   const [honeypot, setHoneypot] = useState('');
   const mountedAt = useRef(Date.now());
   const { toast } = useToast();
+  // Visitor text rides the ui_text pack (base layer + @<locale> overlays);
+  // the operator's own success/submit wording wins on the site's language.
+  const t = useUiText();
+  const { lang, siteLang } = useUiTextLanguage();
 
   const validateField = (field: FormField, value: string | boolean): string | null => {
     if (field.required) {
       if (field.type === 'checkbox' && value !== true) {
-        return 'This field is required';
+        return t('form.required', 'This field is required');
       }
       if (typeof value === 'string' && !value.trim()) {
-        return 'This field is required';
+        return t('form.required', 'This field is required');
       }
     }
 
     if (field.type === 'email' && typeof value === 'string' && value) {
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       if (!emailRegex.test(value)) {
-        return 'Please enter a valid email address';
+        return t('form.invalidEmail', 'Please enter a valid email address');
       }
     }
 
     if (field.type === 'phone' && typeof value === 'string' && value) {
       const phoneRegex = /^[\d\s\-+()]{7,20}$/;
       if (!phoneRegex.test(value)) {
-        return 'Please enter a valid phone number';
+        return t('form.invalidPhone', 'Please enter a valid phone number');
       }
     }
 
@@ -259,8 +265,8 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
     } catch (error) {
       logger.error('Form submission error:', error);
       toast({
-        title: 'Error',
-        description: 'Failed to submit form. Please try again.',
+        title: t('form.errorTitle', 'Something went wrong'),
+        description: t('form.errorBody', 'The message could not be sent. Please try again.'),
         variant: 'destructive',
       });
     } finally {
@@ -340,7 +346,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
               onValueChange={(v) => handleFieldChange(field.id, v)}
             >
               <SelectTrigger id={field.id} className={cn(error && 'border-destructive')}>
-                <SelectValue placeholder={field.placeholder || 'Select…'} />
+                <SelectValue placeholder={operatorText(field.placeholder, t('form.select', 'Select…'), lang, siteLang)} />
               </SelectTrigger>
               <SelectContent>
                 {(field.options || []).map((opt) => (
@@ -445,14 +451,14 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
             <CardContent>
               <CheckCircle className="h-16 w-16 text-success mx-auto mb-4" />
               <p className="text-lg text-foreground whitespace-pre-line">
-                {data.successMessage || 'Thank you! Your message has been sent.'}
+                {operatorText(data.successMessage, t('form.success', 'Thank you! Your message has been sent.'), lang, siteLang)}
               </p>
               <Button
                 variant="outline"
                 className="mt-6"
                 onClick={() => setIsSubmitted(false)}
               >
-                Send Another Message
+                {t('form.sendAnother', 'Send another message')}
               </Button>
             </CardContent>
           </Card>
@@ -487,10 +493,10 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
         {isSubmitting ? (
           <>
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            Sending...
+            {t('form.sending', 'Sending…')}
           </>
         ) : (
-          data.submitButtonText || 'Send Message'
+          operatorText(data.submitButtonText, t('form.submit', 'Send message'), lang, siteLang)
         )}
       </Button>
     </form>

--- a/src/data/ui-text-catalog.json
+++ b/src/data/ui-text-catalog.json
@@ -426,6 +426,56 @@
       "fallback": "Quick Links"
     },
     {
+      "key": "form.errorBody",
+      "group": "form",
+      "fallback": "The message could not be sent. Please try again."
+    },
+    {
+      "key": "form.errorTitle",
+      "group": "form",
+      "fallback": "Something went wrong"
+    },
+    {
+      "key": "form.invalidEmail",
+      "group": "form",
+      "fallback": "Please enter a valid email address"
+    },
+    {
+      "key": "form.invalidPhone",
+      "group": "form",
+      "fallback": "Please enter a valid phone number"
+    },
+    {
+      "key": "form.required",
+      "group": "form",
+      "fallback": "This field is required"
+    },
+    {
+      "key": "form.select",
+      "group": "form",
+      "fallback": "Select…"
+    },
+    {
+      "key": "form.sendAnother",
+      "group": "form",
+      "fallback": "Send another message"
+    },
+    {
+      "key": "form.sending",
+      "group": "form",
+      "fallback": "Sending…"
+    },
+    {
+      "key": "form.submit",
+      "group": "form",
+      "fallback": "Send message"
+    },
+    {
+      "key": "form.success",
+      "group": "form",
+      "fallback": "Thank you! Your message has been sent."
+    },
+    {
       "key": "hero.scrollDown",
       "group": "hero",
       "fallback": "Scroll down"

--- a/src/lib/__tests__/fixtures/hardcoded-visitor-text-baseline.json
+++ b/src/lib/__tests__/fixtures/hardcoded-visitor-text-baseline.json
@@ -13,7 +13,6 @@
   "src/components/public/blocks/ConsultantMatcherBlock.tsx": 4,
   "src/components/public/blocks/FeaturedCarouselBlock.tsx": 3,
   "src/components/public/blocks/FeaturedProductBlock.tsx": 2,
-  "src/components/public/blocks/FormBlock.tsx": 3,
   "src/components/public/blocks/HandbookBlock.tsx": 2,
   "src/components/public/blocks/MapBlock.tsx": 3,
   "src/components/public/blocks/NewsletterBlock.tsx": 2,


### PR DESCRIPTION
"Send Another Message" stod på engelska på en svensk sida på optic. Det
var ingen översättning som saknades: strängen var hårdkodad i blocket,
liksom nio till (obligatoriskt, ogiltig e-post/telefon, skickar, skicka,
tack-texten, felrutan, rullistans "Select…"). Alla läser nu ui_text via
t('form.*') med engelskan som kodfallback; operatörens egna
successMessage/submitButtonText/placeholder går genom operatorText så de
vinner på sajtens språk men aldrig på en sida i ett annat. Katalogen
regenererad (134 nycklar). FormBlock struken ur ratchet-baslinjen: 3 → 0.
Optic har fått form.* på svenska i baslagret och engelska i @en.
