### PR TITLE
fix(ci): main-red alert kör bara i ursprungsrepot — forkarnas main är en spegel

### DIFF
--- a/.github/workflows/main-red-alert.yml
+++ b/.github/workflows/main-red-alert.yml
@@ -41,6 +41,10 @@ concurrency:
 jobs:
   evaluate:
     name: Evaluate main
+    # Only the source repo watches main. A fork's main is a mirror of it — the
+    # same CI result is already watched here — so on forks this job ran on
+    # every push and every 15 minutes for nothing (six forks × ~100 runs a day).
+    if: github.repository == 'magnusfroste/flowwink'
     runs-on: ubuntu-latest
     # Hard bound on the grace-window wait below. Comfortably above the default
     # 30-minute window plus margin; a larger grace_minutes is capped by this,


### PR DESCRIPTION
Jobbet triggas på varje CI-avslut på main och var 15:e minut. På sex forkar
blev det ~100 körningar om dagen per fork utan mening: forkens main är en
spegel av det här repot, vars resultat redan bevakas här. Repo-vakt på
jobbet; ingenting ändras för magnusfroste/flowwink.
