### PR TITLE
fix(retrieval): indexet rapporterar sina fel — och räknar sig självt

### DIFF
--- a/src/components/admin/system/ObservabilityTab.tsx
+++ b/src/components/admin/system/ObservabilityTab.tsx
@@ -535,7 +535,7 @@ function KnowledgeIndexCard() {
       toast({
         title: fullReindex ? 'Full reindex queued' : 'Indexer swept',
         description: fullReindex
-          ? `${res.queued ?? 0} item(s) re-queued · ${res.indexed_chunks ?? 0} chunk(s) rewritten this pass — the 5-minute sweeper drains the rest`
+          ? `${res.queued ?? 0} item(s) queued — the sweep runs every 5 minutes and drains them in bounded slices; press Sweep now to start at once`
           : `${res.indexed_chunks ?? 0} chunk(s) indexed · ${res.processed ?? 0} item(s) processed`,
       });
     } catch (e) {
@@ -605,7 +605,16 @@ function KnowledgeIndexCard() {
             )}
             {(data?.missingEmbedding ?? 0) > 0 && (
               <p className="text-xs text-amber-600 dark:text-amber-500">
-                {data?.missingEmbedding} chunk(s) without an embedding — check the AI provider key.
+                {data?.missingEmbedding} chunk(s) without an embedding
+                {data?.gaveUp ? ` — ${data.gaveUp} parked after 5 failed attempts` : ' — the sweep embeds 80 per run'}
+                {data?.lastEmbeddingError
+                  ? <>. Last provider error{data.lastEmbeddingErrorAt ? ` (${timeAgo(data.lastEmbeddingErrorAt)})` : ''}: <span className="font-mono">{data.lastEmbeddingError.slice(0, 200)}</span></>
+                  : '.'}
+              </p>
+            )}
+            {data?.bounded && (
+              <p className="text-xs text-muted-foreground">
+                Counts come from a client read capped at 1,000 rows — this instance lacks the stats function; run the pending migration for whole numbers.
               </p>
             )}
             {/* A file waiting to become text has no chunks, so every count below

--- a/src/hooks/useKnowledgeIndex.ts
+++ b/src/hooks/useKnowledgeIndex.ts
@@ -36,6 +36,13 @@ export interface KnowledgeIndexHealth {
   totalChunks: number;
   /** Chunks still missing an embedding — they cannot be retrieved yet. */
   missingEmbedding: number;
+  /** Of those, chunks the embedder gave up on (5 failed attempts) — see lastEmbeddingError. */
+  gaveUp: number;
+  /** What the provider last said when an embedding failed, verbatim. */
+  lastEmbeddingError: string | null;
+  lastEmbeddingErrorAt: string | null;
+  /** True when the numbers came from a bounded client read (older instance without the stats RPC). */
+  bounded: boolean;
   /** Items waiting for the next sweep. A steady non-zero value means the sweeper is not running. */
   queueDepth: number;
   lastIndexedAt: string | null;
@@ -54,10 +61,33 @@ export function useKnowledgeIndexHealth() {
   return useQuery({
     queryKey: ['knowledge-index-health'],
     queryFn: async (): Promise<KnowledgeIndexHealth> => {
+      const docsRead = supabase.from('documents').select('extraction_status').not('file_url', 'is', null);
+      // Counts belong in the database. The old client read of every chunk was
+      // capped at 1000 rows by PostgREST without a word — "1000 chunk(s)" on
+      // labs1100 was the cap, not the index — and it pulled every vector over
+      // the wire to test it for null. The RPC counts everything, whole.
+      const { data: stats, error: statsErr } = await supabase.rpc('knowledge_index_stats' as never);
+      if (!statsErr && stats && typeof stats === 'object') {
+        const s = stats as Record<string, unknown>;
+        const docs = await docsRead;
+        return {
+          bySource: (s.by_source ?? {}) as Record<string, number>,
+          totalChunks: Number(s.total ?? 0),
+          missingEmbedding: Number(s.missing_embedding ?? 0),
+          gaveUp: Number(s.gave_up ?? 0),
+          lastEmbeddingError: typeof s.last_embedding_error === 'string' ? s.last_embedding_error : null,
+          lastEmbeddingErrorAt: typeof s.last_embedding_error_at === 'string' ? s.last_embedding_error_at : null,
+          bounded: false,
+          queueDepth: Number(s.queue_depth ?? 0),
+          lastIndexedAt: typeof s.last_indexed_at === 'string' ? s.last_indexed_at : null,
+          documentsAwaitingText: awaitingText(docs.data ?? []),
+        };
+      }
+      if (statsErr) logger.warn('knowledge_index_stats unavailable, falling back to a bounded client read:', statsErr.message);
       const [chunks, queue, docs] = await Promise.all([
-        supabase.from('knowledge_chunks').select('source_table, embedding, updated_at'),
+        supabase.from('knowledge_chunks').select('source_table, embedding, updated_at').limit(1000),
         supabase.from('knowledge_index_queue').select('source_table'),
-        supabase.from('documents').select('extraction_status').not('file_url', 'is', null),
+        docsRead,
       ]);
       if (chunks.error) throw chunks.error;
 
@@ -75,23 +105,31 @@ export function useKnowledgeIndexHealth() {
         bySource,
         totalChunks: rows.length,
         missingEmbedding,
+        gaveUp: 0,
+        lastEmbeddingError: null,
+        lastEmbeddingErrorAt: null,
+        bounded: true,
         // A missing queue table (un-migrated instance) reads as 0, not as an error:
         // the card must still render the chunk counts it CAN see.
         queueDepth: queue.error ? 0 : (queue.data?.length ?? 0),
         lastIndexedAt,
-        documentsAwaitingText: (docs.data ?? []).reduce(
-          (acc, d: { extraction_status: string | null }) => {
-            if (d.extraction_status && d.extraction_status in acc) {
-              acc[d.extraction_status as keyof typeof acc] += 1;
-            }
-            return acc;
-          },
-          { pending: 0, processing: 0, unsupported: 0, failed: 0 },
-        ),
+        documentsAwaitingText: awaitingText(docs.data ?? []),
       };
     },
     staleTime: 30_000,
   });
+}
+
+function awaitingText(rows: Array<{ extraction_status: string | null }>) {
+  return rows.reduce(
+    (acc, d) => {
+      if (d.extraction_status && d.extraction_status in acc) {
+        acc[d.extraction_status as keyof typeof acc] += 1;
+      }
+      return acc;
+    },
+    { pending: 0, processing: 0, unsupported: 0, failed: 0 },
+  );
 }
 
 /**

--- a/src/lib/admin-only-rpcs.ts
+++ b/src/lib/admin-only-rpcs.ts
@@ -77,4 +77,10 @@ export const ADMIN_ONLY_RPCS: Readonly<Record<string, string>> = {
   // 20260821090000) — men mall-DELETE är destruktivt och förblir admin, samma
   // klass som deals DELETE.
   delete_email_template: 'Destruktiv grind — mallradering är admin-only med avsikt.',
+  // ── Plattformsdiagnostik ───────────────────────────────────────────
+  // Läses bara av System → Observability (adminOnly-gruppen). Räknar över
+  // ALLA indexkällor på en gång (pages, kb, wiki, docs, handbook, documents) —
+  // det finns ingen modul att grinda på; en modulbeviljad roll skulle se
+  // andra modulers antal. Admin är rätt dimension.
+  knowledge_index_stats: 'Systemdiagnostik över alla källor — Observability är adminOnly, ingen modulyta.',
 };

--- a/supabase/functions/_shared/retrieval/embedder.ts
+++ b/supabase/functions/_shared/retrieval/embedder.ts
@@ -51,16 +51,27 @@ export interface EmbedSweepResult {
  * (model switch marks everything stale). Bounded per sweep — the 5-minute
  * cron catches up over successive runs.
  */
+/** After this many failed attempts a chunk is parked; a reindex resets the count. */
+export const MAX_EMBED_ATTEMPTS = 5;
+
 export async function embedPendingChunks(service: any, limit = 80): Promise<EmbedSweepResult> {
   const provider = await loadEmbeddingProvider(service);
   if (!provider) return { provider: null, embedded: 0, failed: 0, pending: 0 };
 
   const modelTag = `${provider.provider}:${provider.model}`;
 
+  // Fewest attempts first, oldest first: a chunk the provider rejects every
+  // time drifts to the back after its failures instead of sitting at the
+  // front and stopping the sweep at "3 consecutive failures" forever (the
+  // labs1100 wedge, 2026-09-03). Five strikes and it is parked — visible in
+  // the stats with its error — until a reindex resets the count.
   const { data: pending, error } = await service
     .from('knowledge_chunks')
-    .select('id, content')
+    .select('id, content, embedding_attempts')
     .or(`embedding.is.null,embedding_model.neq.${modelTag}`)
+    .lt('embedding_attempts', MAX_EMBED_ATTEMPTS)
+    .order('embedding_attempts', { ascending: true })
+    .order('updated_at', { ascending: true })
     .limit(limit);
   if (error) throw new Error(`embed sweep read failed: ${error.message}`);
 
@@ -72,7 +83,7 @@ export async function embedPendingChunks(service: any, limit = 80): Promise<Embe
       const { embedding } = await embedText(chunk.content, provider);
       const { error: upErr } = await service
         .from('knowledge_chunks')
-        .update({ embedding, embedding_model: modelTag })
+        .update({ embedding, embedding_model: modelTag, embedding_attempts: 0, embedding_error: null, embedding_attempted_at: new Date().toISOString() })
         .eq('id', chunk.id);
       if (upErr) throw new Error(upErr.message);
       embedded += 1;
@@ -80,7 +91,16 @@ export async function embedPendingChunks(service: any, limit = 80): Promise<Embe
     } catch (e) {
       failed += 1;
       consecutiveFailures += 1;
-      console.error(`embed failed for chunk ${chunk.id}:`, e);
+      const message = (e instanceof Error ? e.message : String(e)).slice(0, 400);
+      console.error(`embed failed for chunk ${chunk.id}:`, message);
+      // Write the failure on the chunk: the count, the time, the text. The
+      // Observability card reads it back, so "check the AI provider key" is
+      // replaced by what the provider actually said.
+      const { error: markErr } = await service
+        .from('knowledge_chunks')
+        .update({ embedding_attempts: (chunk.embedding_attempts ?? 0) + 1, embedding_error: message, embedding_attempted_at: new Date().toISOString() })
+        .eq('id', chunk.id);
+      if (markErr) console.error(`could not record the embed failure on ${chunk.id}:`, markErr.message);
       // A dead/quota-exhausted provider fails every call — don't hammer it
       // with the whole batch; the next cron sweep retries.
       if (consecutiveFailures >= 3) {

--- a/supabase/functions/knowledge-indexer/index.ts
+++ b/supabase/functions/knowledge-indexer/index.ts
@@ -51,6 +51,14 @@ serve(async (req) => {
         );
       }
       queued = await queueFullReindex(service, source);
+      // Queue only. Re-chunking every source and embedding in the same request
+      // is what blew the worker's CPU budget on a 1000-chunk instance and came
+      // back to the button as "indexer run failed" while the work half-happened.
+      // The cron sweep drains the queue in bounded slices; say so.
+      return new Response(
+        JSON.stringify({ status: 'queued', queued, note: 'Queued for the sweep. It runs every 5 minutes and drains in bounded slices; press Sweep now to start at once.' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
     }
 
     // A document has to be READ before it can be indexed. Uploads land as

--- a/supabase/migrations/20260906110000_indexet-rapporterar-sina-fel.sql
+++ b/supabase/migrations/20260906110000_indexet-rapporterar-sina-fel.sql
@@ -1,0 +1,49 @@
+-- Indexet rapporterar sina fel — och räknar sig självt.
+--
+-- Två saker labs1100 visade 2026-09-03: "591 chunk(s) without an embedding —
+-- check the AI provider key" när nyckeln var frisk, och "1000 chunk(s)" som
+-- var PostgREST:s tysta 1000-radskap, inte antalet. Svepet valde samma
+-- oordnade 80 rader varje gång, en chunk som alltid felar bröt svepet efter
+-- tre fel, och ingen såg felet. Nu bär varje chunk sina försök och sitt
+-- senaste fel, och statistiken räknas här, hel.
+
+ALTER TABLE public.knowledge_chunks
+  ADD COLUMN IF NOT EXISTS embedding_attempts integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS embedding_error text,
+  ADD COLUMN IF NOT EXISTS embedding_attempted_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_chunks_embed_pending
+  ON public.knowledge_chunks (embedding_attempts, updated_at)
+  WHERE embedding IS NULL;
+
+CREATE OR REPLACE FUNCTION public.knowledge_index_stats()
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v jsonb;
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR has_role(auth.uid(), 'admin')) THEN
+    RAISE EXCEPTION 'Only staff can read knowledge index stats';
+  END IF;
+  SELECT jsonb_build_object(
+    'total', (SELECT count(*) FROM public.knowledge_chunks),
+    'by_source', COALESCE((SELECT jsonb_object_agg(source_table, n) FROM (
+        SELECT source_table, count(*) AS n FROM public.knowledge_chunks GROUP BY source_table) s), '{}'::jsonb),
+    'missing_embedding', (SELECT count(*) FROM public.knowledge_chunks WHERE embedding IS NULL),
+    'gave_up', (SELECT count(*) FROM public.knowledge_chunks WHERE embedding IS NULL AND embedding_attempts >= 5),
+    'last_embedding_error', (SELECT embedding_error FROM public.knowledge_chunks
+        WHERE embedding_error IS NOT NULL ORDER BY embedding_attempted_at DESC NULLS LAST LIMIT 1),
+    'last_embedding_error_at', (SELECT embedding_attempted_at FROM public.knowledge_chunks
+        WHERE embedding_error IS NOT NULL ORDER BY embedding_attempted_at DESC NULLS LAST LIMIT 1),
+    'last_indexed_at', (SELECT max(updated_at) FROM public.knowledge_chunks),
+    'queue_depth', (SELECT count(*) FROM public.knowledge_index_queue)
+  ) INTO v;
+  RETURN v;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.knowledge_index_stats() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.knowledge_index_stats() TO authenticated, service_role;
+
+-- Ett omtag ska få bli av: nollställ försöken på allt som saknar vektor, så
+-- att chunkar som gav upp under den gamla regimen provas igen med felet synligt.
+UPDATE public.knowledge_chunks SET embedding_attempts = 0 WHERE embedding IS NULL AND embedding_attempts <> 0;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260906100000",
-      "migrations_count": 569,
+      "migration_head": "20260906110000",
+      "migrations_count": 570,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2281,6 +2281,10 @@
         {
           "version": "20260906100000",
           "name": "brevladan-far-en-svarare"
+        },
+        {
+          "version": "20260906110000",
+          "name": "indexet-rapporterar-sina-fel"
         }
       ]
     },
@@ -2291,7 +2295,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:1b6a93e8d714dc03c31e5f279403a0cfcb182fb169ce57a38d12dc7e8c1ba04d",
+      "shared_hash": "sha256:0c1ea16407fda408d6e2007cb0fd29d9566d889f84f984c4e308989e1644901d",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
@@ -2337,7 +2341,7 @@
         "integrations-account": "sha256:97349b1f66e6a4e628de49bd36473af4f5c19726174c30e3b47ff4c594d68e29",
         "invite-colleague": "sha256:cad6246a2988ca3c780cb3497707a4d818e311f3b1bf704957b3754b9d86b5b3",
         "invite-employee": "sha256:354d9ecbcc20ff402597a0e4c10875807c1a140ace0c5c06505ff8fc9fe13eb5",
-        "knowledge-indexer": "sha256:51f19b1f01bb746d7dc51e4ffa7eee51053c9c99a9f27812090d2f6b4f100070",
+        "knowledge-indexer": "sha256:9719ea8dfda56ca4fa126907806adef794ae492f44ab6ba9e97884637cb7ba36",
         "llms-txt": "sha256:0a8a132d383590b810617ff9cdcd4893980208233d0c26b65d6c17a80af4f452",
         "mcp-server": "sha256:611d0782ffb321a9f66729ccfb6396342852e3c9d3389c3084dcd81ec55be559",
         "media-optimize": "sha256:ddaa5868b1f154561a900e133ab64c6ffd0ebef9751098b2a42c03684c34d496",


### PR DESCRIPTION
## Vad
- **Migration**: `knowledge_chunks.embedding_attempts/embedding_error/embedding_attempted_at` + partiellt index; RPC `knowledge_index_stats()` (admin/service_role) som räknar total, per källa, saknade, parkerade, senaste fel, kö — helt, i SQL. Nollställer försök på allt utan vektor. Repeterad på nordbrygg.
- **embedder**: urval `embedding_attempts asc, updated_at asc`, `< 5`; fel skrivs på chunken (400 tecken); lyckat nollställer. En giftig chunk kan inte längre wedga svepet.
- **knowledge-indexer**: `full_reindex` köar och returnerar (`status: queued`); svepet tömmer.
- **Observability**: siffror från RPC:n (fallback: begränsad läsning, markerad); raden visar parkerade + providerns senaste fel i klartext i stället för "check the AI provider key"; toast för Reindex all säger att det köats.

## Verifiering
tsc grön, deno check grönt, vakter gröna (49), manifest regenererat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)