### PR TITLE
fix(email): Gmail via Composio tar en mottagare i recipient_email — resten i extra_recipients

### DIFF
--- a/supabase/functions/composio-proxy/index.ts
+++ b/supabase/functions/composio-proxy/index.ts
@@ -350,8 +350,15 @@ Deno.serve(async (req) => {
         return json({ error: 'Gmail not connected. Connect Gmail first.' }, 400);
       }
 
+      // email-send joins its recipient list with ", " — and Gmail's action takes
+      // ONE address in recipient_email, the rest in extra_recipients. Passed
+      // joined, Composio answers "Invalid email format passed: a, b" and the
+      // daily briefing to two addresses failed every morning on Resta
+      // (2026-08-29 → 09-03) while single-recipient mail went through.
+      const toList = String(to).split(/[,;]/).map((x) => x.trim()).filter(Boolean);
       const input: Record<string, unknown> = {
-        recipient_email: to,
+        recipient_email: toList[0] ?? to,
+        ...(toList.length > 1 ? { extra_recipients: toList.slice(1) } : {}),
         subject,
         body: emailBody,
         // Composio rejects an HTML body outright unless is_html is set, with an

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2309,7 +2309,7 @@
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
         "comms-send": "sha256:39dc9fde197bf59a92ae372f96263fe368238b212ad5674b299736ec1052d6b6",
-        "composio-proxy": "sha256:dfe9792b9628e727f8a90f7450287e68ea4fe29e780fe852a106e79af102664d",
+        "composio-proxy": "sha256:ecaaf2b4121bd1ad4a2d5d753b6cf3d7b3c746602b94a5f3c2d058d8b0ac91b3",
         "composio-webhook": "sha256:27f17b7198bfbab422931ef1c872da083299e095792e43b98b4154ec79c858ca",
         "consultant-match": "sha256:19f388f6c2b0abcdadaef40912fc00ea6c49982f2e2c05f2252b486548326160",
         "content-api": "sha256:64c03bcaa94f7e17575c9e36611830c049cdcf372747ed2af264eb03c70bce42",


### PR DESCRIPTION
Daglig briefing till två adresser föll varje morgon på Resta sedan 29 aug
med "Invalid email format passed: a, b": email-send skickar listan som
en kommaseparerad sträng och proxyn lade hela strängen i recipient_email.
Nu delas den: första adressen där, resten i extra_recipients. Enskilda
mottagare oförändrade.
