### PR TITLE
fix(email): brevlådans kort beskriver brevlådan som den är — en dörr in i FlowBox, inte ett kallmejlsundantag

### DIFF
--- a/src/components/admin/EmailRouterSettings.tsx
+++ b/src/components/admin/EmailRouterSettings.tsx
@@ -249,9 +249,8 @@ export function EmailRouterSettings() {
             <Inbox className="h-4 w-4" /> Inbound mailboxes
           </CardTitle>
           <CardDescription>
-            Register the addresses FlowWink should watch for replies. Primary path: cold
-            outbound email → reply lands on the contact/lead card and in Communications.
-            Ticket routing is optional and gated by the Tickets module.
+            The addresses FlowWink reads. Each one is a door into FlowBox: mail arrives with FlowPilot's reply
+            waiting, is attached to the sender's contact or lead, and can become a ticket when nobody is known.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/components/admin/email/InboundMailboxesSection.tsx
+++ b/src/components/admin/email/InboundMailboxesSection.tsx
@@ -292,9 +292,11 @@ export function InboundMailboxesSection({ emphasis = "crm", isGmailConnected }: 
       <div className="text-xs text-muted-foreground">
         {emphasis === "crm" ? (
           <>
-            Primary use case: a cold outbound email is sent to a lead — the reply lands on the
-            contact/lead card and in <Link to="/admin/flowbox?tab=log" className="underline">FlowBox → Message log</Link>.
-            Optionally, unmatched replies can create a ticket if the Tickets module is enabled.
+            Every message to a mailbox here lands in <Link to="/admin/flowbox" className="underline">FlowBox</Link> with
+            FlowPilot's reply waiting — the same responder as the website chat. <em>Route replies to</em> decides
+            where it also lands: on the sender's contact/lead card, or as a ticket when the sender is unknown
+            (Tickets module). <em>Who answers</em> decides whether FlowPilot's reply waits as a draft, goes out when
+            it is grounded, or is not written at all.
           </>
         ) : (
           <>


### PR DESCRIPTION
Texten sa "cold outbound email → reply lands on the contact card and in
Communications". Communications finns inte längre, och sedan #456 är
brevlådan företagets inkorg: allt landar i FlowBox med FlowPilots svar
väntande. Route replies to och Who answers förklaras som de två rattar
de är.
