### PR TITLE
fix(flowbox): brus viks undan ur kön, svensk text avkodas rätt, skickade svar behåller sin text

### DIFF
--- a/src/lib/__tests__/inbox-items.test.ts
+++ b/src/lib/__tests__/inbox-items.test.ts
@@ -65,6 +65,15 @@ describe('Inbox — one queue, organised by who has it', () => {
     expect(staged.reason).toContain('approve or reject');
   });
 
+  it('email: bulk and system mail is noise — logged, not answered, folded away from the queue', () => {
+    const [row] = emailItems(
+      [{ thread_key: 'n1', subject: '[repo] CI failed', last_message_at: '2026-09-02T10:00:00Z', message_count: 1 }],
+      [{ thread_id: 'n1', direction: 'inbound', sender: 'notifications@github.com', recipient: null, body_text: 'Run failed', created_at: '2026-09-02T10:00:00Z', metadata: { classification: 'noise' } }],
+    );
+    expect(row.noise).toBe(true);
+    expect(row.reason).toContain('not answered');
+  });
+
   it('chat: FlowPilot has it unless a person was asked for, escalated, or already on it', () => {
     const base = { title: null, priority: null, assigned_agent_id: null, customer_email: null, customer_name: 'Eva', escalation_reason: null, channel: 'web', updated_at: '2026-09-02T10:00:00Z' };
     const s = (conversation_status: string) => chatItems([{ id: 'c', conversation_status, ...base }])[0];

--- a/src/lib/inbox-items.ts
+++ b/src/lib/inbox-items.ts
@@ -59,6 +59,13 @@ export interface InboxItem {
   hasDraft?: boolean;
   /** Form: the submitted fields, shown where the submission is handled. */
   fields?: Record<string, unknown> | null;
+  /**
+   * Bulk, marketing and system mail (the ingest's own classification: List-
+   * Unsubscribe, no-reply senders, auto-submitted). Real, logged, never
+   * answered by FlowPilot — and hidden from the queue unless asked for, the
+   * way Gmail folds newsletters. An info@ box is half of this.
+   */
+  noise?: boolean;
 }
 
 /** One thing FlowPilot did on this item, in the order it happened. */
@@ -150,7 +157,7 @@ export interface EmailMessageRow {
   body_text: string | null;
   created_at: string;
   status?: string | null;
-  metadata?: { needs_person?: boolean | null; approval_request_id?: string | null } | null;
+  metadata?: { needs_person?: boolean | null; approval_request_id?: string | null; classification?: string | null } | null;
 }
 
 export function emailItems(threads: EmailThreadRow[], messages: EmailMessageRow[]): InboxItem[] {
@@ -176,6 +183,7 @@ export function emailItems(threads: EmailThreadRow[], messages: EmailMessageRow[
     const last = latest.get(t.thread_key);
     const inboundLast = last?.direction === 'inbound';
     const who = inboundLast ? (last?.sender ?? '') : (last?.recipient ?? '');
+    const noise = inboundLast && last?.metadata?.classification === 'noise';
     const entity = t.related_entity_type && t.related_entity_id
       ? { type: t.related_entity_type, id: t.related_entity_id }
       : null;
@@ -189,7 +197,9 @@ export function emailItems(threads: EmailThreadRow[], messages: EmailMessageRow[
       channel: 'email',
       state: last ? (inboundLast ? 'human' : 'customer') : 'done',
       reason: last
-        ? (inboundLast
+        ? (noise
+          ? 'bulk or system mail — not answered'
+          : inboundLast
           ? (wantsPerson
             ? `FlowPilot could not answer this one${onLead} — holding draft, needs you`
             : staged
@@ -206,6 +216,7 @@ export function emailItems(threads: EmailThreadRow[], messages: EmailMessageRow[
       matchIds: [t.thread_key, ...(entity ? [entity.id] : [])],
       sourceId: t.thread_key,
       hasDraft,
+      noise,
     };
   });
 }

--- a/src/pages/admin/FlowBoxPage.tsx
+++ b/src/pages/admin/FlowBoxPage.tsx
@@ -113,6 +113,7 @@ function QueueTab({ live, openKey }: { live: boolean; openKey?: string | null })
   const { data: items = [], isLoading } = useInboxItems();
   const [channel, setChannel] = useState<InboxChannel | 'all'>('all');
   const [showDone, setShowDone] = useState(false);
+  const [showNoise, setShowNoise] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   // ?open=chat:<id> (a redirect from the old Live Support address, or a
   // notification) lands with that row's reply already open.
@@ -120,7 +121,8 @@ function QueueTab({ live, openKey }: { live: boolean; openKey?: string | null })
   const toggle = (set: React.Dispatch<React.SetStateAction<Set<string>>>, key: string) =>
     set((s) => { const n = new Set(s); if (n.has(key)) n.delete(key); else n.add(key); return n; });
 
-  const filtered = useMemo(() => items.filter((i) => channel === 'all' || i.channel === channel), [items, channel]);
+  const filtered = useMemo(() => items.filter((i) => (channel === 'all' || i.channel === channel) && (showNoise || !i.noise)), [items, channel, showNoise]);
+  const noiseCount = useMemo(() => items.filter((i) => i.noise && i.state !== 'done').length, [items]);
   const grouped = useMemo(() => {
     const g: Record<InboxState, InboxItem[]> = { human: [], agent: [], customer: [], done: [] };
     for (const i of filtered) g[i.state].push(i);
@@ -128,7 +130,7 @@ function QueueTab({ live, openKey }: { live: boolean; openKey?: string | null })
   }, [filtered]);
   const channelCounts = useMemo(() => {
     const c: Record<string, number> = {};
-    for (const i of items) if (i.state !== 'done') c[i.channel] = (c[i.channel] ?? 0) + 1;
+    for (const i of items) if (i.state !== 'done' && !i.noise) c[i.channel] = (c[i.channel] ?? 0) + 1;
     return c;
   }, [items]);
 
@@ -147,9 +149,17 @@ function QueueTab({ live, openKey }: { live: boolean; openKey?: string | null })
             </Button>
           );
         })}
-        <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
-          <Switch checked={showDone} onCheckedChange={setShowDone} aria-label="Show done" />
-          Show done
+        <div className="ml-auto flex items-center gap-4 text-xs text-muted-foreground">
+          {/* Bulk and system mail: real, logged, never answered — folded away
+              the way Gmail folds newsletters. The count says what is folded. */}
+          <label className="inline-flex items-center gap-2">
+            <Switch checked={showNoise} onCheckedChange={setShowNoise} aria-label="Show bulk and system mail" />
+            Show noise{noiseCount ? ` (${noiseCount})` : ''}
+          </label>
+          <label className="inline-flex items-center gap-2">
+            <Switch checked={showDone} onCheckedChange={setShowDone} aria-label="Show done" />
+            Show done
+          </label>
         </div>
       </div>
 

--- a/supabase/functions/_shared/email/ingest-gmail.ts
+++ b/supabase/functions/_shared/email/ingest-gmail.ts
@@ -39,7 +39,13 @@ export interface IngestResult {
 
 function decodeBase64Url(data: string): string {
   try {
-    return atob(String(data).replace(/-/g, '+').replace(/_/g, '/'));
+    // atob yields a byte string; reading it as text turns every UTF-8
+    // multibyte character into Latin-1 debris ("nÃ¤ra" for "nära" — every
+    // Swedish mail on Resta, 2026-09-03). Decode the bytes as UTF-8.
+    const bin = atob(String(data).replace(/-/g, '+').replace(/_/g, '/'));
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return new TextDecoder('utf-8').decode(bytes);
   } catch {
     return '';
   }

--- a/supabase/functions/composio-proxy/index.ts
+++ b/supabase/functions/composio-proxy/index.ts
@@ -390,7 +390,10 @@ Deno.serve(async (req) => {
         subject,
         // An HTML send is stored as HTML, so the thread view renders it as
         // such instead of showing the tags as text.
-        body_text: is_html ? null : emailBody,
+        // A text body always: the queue's preview and the responder's thread
+        // history read body_text, and an HTML-only row made a sent reply vanish
+        // from both.
+        body_text: is_html ? htmlToText(String(emailBody)) : emailBody,
         body_html: is_html ? emailBody : null,
         // The reply joins its thread: Gmail's thread id (echoed back by the
         // send when we did not know it) plus the header it answers.
@@ -897,3 +900,14 @@ Deno.serve(async (req) => {
     });
   }
 });
+
+/** Plain text out of a rendered HTML mail — block closers become line breaks, tags go, entities unescape. */
+function htmlToText(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<(br|\/p|\/div|\/li|\/h[1-6]|\/tr)\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+    .replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2295,7 +2295,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:0c1ea16407fda408d6e2007cb0fd29d9566d889f84f984c4e308989e1644901d",
+      "shared_hash": "sha256:71e74f6966b5b5ddba164134626fc9485a1c20ea6ee12c318fbfa0bcb83cb7e8",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
@@ -2309,7 +2309,7 @@
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
         "comms-send": "sha256:39dc9fde197bf59a92ae372f96263fe368238b212ad5674b299736ec1052d6b6",
-        "composio-proxy": "sha256:ecaaf2b4121bd1ad4a2d5d753b6cf3d7b3c746602b94a5f3c2d058d8b0ac91b3",
+        "composio-proxy": "sha256:0f84780d7016fe3318cb97543be8d56cf08c5fb0b5a3ac9390eadcab474135bd",
         "composio-webhook": "sha256:27f17b7198bfbab422931ef1c872da083299e095792e43b98b4154ec79c858ca",
         "consultant-match": "sha256:19f388f6c2b0abcdadaef40912fc00ea6c49982f2e2c05f2252b486548326160",
         "content-api": "sha256:64c03bcaa94f7e17575c9e36611830c049cdcf372747ed2af264eb03c70bce42",


### PR DESCRIPTION
## Vad
- **ingest-gmail**: base64url → bytes → `TextDecoder('utf-8')` (var atob-sträng som text ⇒ "nÃ¤ra").
- **composio-proxy gmail_send**: `body_text` alltid satt (HTML → text via `htmlToText`), så köns preview och svararens trådhistorik ser skickade svar.
- **FlowBox**: `InboxItem.noise` från inbound-radens `metadata.classification === 'noise'`; kön döljer dem bakom **Show noise (N)**; kanalräknare exkluderar; reason "bulk or system mail — not answered". Loggen orörd.

## Verifiering
tsc grön; kötester + vakter gröna (23, nytt brusfall); deno: composio-proxy oförändrat antal förekommande fel (2), ingest-gmail inga nya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)