### PR TITLE
feat(flowbox): samtalen hålls ihop — svarsstationen in i Calls, Voice blir uppsättning och logg

### DIFF
--- a/src/pages/admin/FlowBoxPage.tsx
+++ b/src/pages/admin/FlowBoxPage.tsx
@@ -21,6 +21,9 @@ import { FormHandle } from '@/components/admin/flowbox/FormHandle';
 import { TicketReply } from '@/components/admin/flowbox/TicketReply';
 import { CallbacksPanel } from '@/components/admin/live-support/CallbacksPanel';
 import { VoicemailPanel } from '@/components/admin/live-support/VoicemailPanel';
+import { ActiveCallsPanel } from '@/components/admin/live-support/ActiveCallsPanel';
+import { useVoiceSettings } from '@/hooks/useVoice';
+import { getVoiceProvider } from '@/lib/voice-providers';
 import { cn } from '@/lib/utils';
 
 /**
@@ -80,12 +83,7 @@ export default function FlowBoxPage() {
           {/* Callbacks and voicemail — the two things Live Support did that the
               queue row cannot: schedule/complete a callback, play a message.
               Same panels, moved; the page they lived on is retired. */}
-          <TabsContent value="calls">
-            <div className="grid gap-4 lg:grid-cols-2">
-              <CallbacksPanel />
-              <VoicemailPanel />
-            </div>
-          </TabsContent>
+          <TabsContent value="calls"><CallsTab /></TabsContent>
           <TabsContent value="routing"><RoutingLenses /></TabsContent>
           <TabsContent value="log"><MessageLogTab /></TabsContent>
         </Tabs>
@@ -108,6 +106,38 @@ const STATE_META: Record<InboxState, { label: string; hint: string; icon: React.
   customer: { label: 'Waiting on the customer', hint: 'Answered; the ball is with them.', icon: Hourglass, tone: 'text-muted-foreground' },
   done: { label: 'Done', hint: 'Closed or handled in the last 30 days.', icon: CheckCircle2, tone: 'text-muted-foreground' },
 };
+
+/**
+ * Calls, worked here. Three panels that lived on the retired Live Support
+ * page: the answer station (who is ringing right now — send an SMS, book a
+ * callback, mark handled; "Answer here" when the browser softphone is on),
+ * the callbacks to make, and the voicemail to hear. The line above them
+ * says where a call actually goes on this instance — the softphone in this
+ * browser or an agent's mobile — and where that is set (Voice → Agent
+ * routing), so the desk never wonders why nothing rang.
+ */
+function CallsTab() {
+  const { data: voice } = useVoiceSettings();
+  const provider = voice?.provider ? getVoiceProvider(voice.provider) : null;
+  const webrtc = !!provider?.metadata.capabilities.webrtc;
+  const softphone = webrtc && voice?.softphoneEnabled !== false;
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-muted-foreground">
+        {!voice?.provider
+          ? <>No voice provider is set up — calls are not reaching FlowWink. Set one up in <Link to="/admin/voice?tab=settings" className="underline">Voice → Settings</Link>.</>
+          : softphone
+            ? <>Incoming calls ring the softphone in this browser for agents with a voice line, and forward to their mobile after {voice.ringTimeoutSeconds ?? 20} s. Lines and forwarding are set in <Link to="/admin/voice?tab=softphone" className="underline">Voice → Agent routing</Link>.</>
+            : <>Incoming calls forward to the agents' mobiles{webrtc ? '' : ` (${provider?.metadata.name ?? voice.provider} has no browser client)`}. {webrtc ? <>To answer here instead, turn on the browser softphone in <Link to="/admin/voice?tab=settings" className="underline">Voice → Settings</Link> and give each agent a line under <Link to="/admin/voice?tab=softphone" className="underline">Agent routing</Link>.</> : null}</>}
+      </p>
+      <ActiveCallsPanel />
+      <div className="grid gap-4 lg:grid-cols-2">
+        <CallbacksPanel />
+        <VoicemailPanel />
+      </div>
+    </div>
+  );
+}
 
 function QueueTab({ live, openKey }: { live: boolean; openKey?: string | null }) {
   const { data: items = [], isLoading } = useInboxItems();

--- a/src/pages/admin/VoicePage.tsx
+++ b/src/pages/admin/VoicePage.tsx
@@ -1,9 +1,9 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Helmet } from 'react-helmet-async';
 import { format } from 'date-fns';
 import { Phone, PhoneIncoming, PhoneMissed, PhoneOutgoing, Voicemail, PhoneCall, Settings as SettingsIcon, Headphones, CheckCircle2, AlertCircle } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams, useNavigate } from 'react-router-dom';
 import { useIsGeminiConfigured } from '@/hooks/useIntegrationStatus';
 
 import { AdminLayout } from '@/components/admin/AdminLayout';
@@ -603,7 +603,17 @@ function ProviderCapabilitiesCard() {
 }
 
 export default function VoicePage() {
-  const [tab, setTab] = useState<'all' | 'missed' | 'voicemail' | 'callbacks' | 'softphone' | 'settings'>('all');
+  // ?tab=settings / ?tab=softphone deep-link from FlowBox; the three retired
+  // tabs' old addresses (missed, voicemail, callbacks) land on the queue.
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const requestedTab = params.get('tab');
+  useEffect(() => {
+    if (requestedTab && ['missed', 'voicemail', 'callbacks'].includes(requestedTab)) navigate('/admin/flowbox?tab=calls', { replace: true });
+  }, [requestedTab, navigate]);
+  const [tab, setTab] = useState<'all' | 'missed' | 'voicemail' | 'callbacks' | 'softphone' | 'settings'>(
+    requestedTab === 'settings' || requestedTab === 'softphone' ? requestedTab : 'all',
+  );
   const [selected, setSelected] = useState<VoiceCallRow | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -643,19 +653,21 @@ export default function VoicePage() {
         <Tabs value={tab} onValueChange={(v) => setTab(v as typeof tab)}>
           <TabsList>
             <TabsTrigger value="all">All <Badge variant="secondary" className="ml-2">{counts.all}</Badge></TabsTrigger>
-            <TabsTrigger value="missed"><PhoneMissed className="h-3 w-3 mr-1" />Missed <Badge variant="secondary" className="ml-2">{counts.missed}</Badge></TabsTrigger>
-            <TabsTrigger value="voicemail"><Voicemail className="h-3 w-3 mr-1" />Voicemail <Badge variant="secondary" className="ml-2">{counts.voicemail}</Badge></TabsTrigger>
-            <TabsTrigger value="callbacks"><PhoneCall className="h-3 w-3 mr-1" />Callbacks <Badge variant="secondary" className="ml-2">{counts.callbacks}</Badge></TabsTrigger>
             <TabsTrigger value="softphone"><Phone className="h-3 w-3 mr-1" />Agent routing</TabsTrigger>
             <TabsTrigger value="settings"><SettingsIcon className="h-3 w-3 mr-1" />Settings</TabsTrigger>
           </TabsList>
 
+          {/* The work — ringing calls, callbacks, voicemail — is done in FlowBox →
+              Calls, one queue with everything else that flows in. This page
+              keeps the log, the lines and the provider. Old links to the three
+              retired tabs land on the queue. */}
+          <p className="text-xs text-muted-foreground mt-3">
+            Missed calls ({counts.missed}), voicemail ({counts.voicemail}) and callbacks ({counts.callbacks}) are worked in{' '}
+            <Link to="/admin/flowbox?tab=calls" className="underline">FlowBox → Calls</Link>. This page is the call log, the agents' lines and the provider.
+          </p>
           <TabsContent value="all" className="mt-4">
             {isLoading ? <Card><CardContent className="py-12 text-center text-sm text-muted-foreground">Loading…</CardContent></Card> : <CallsTable calls={filtered} onAction={onAction} />}
           </TabsContent>
-          <TabsContent value="missed" className="mt-4"><CallsTable calls={filtered} onAction={onAction} /></TabsContent>
-          <TabsContent value="voicemail" className="mt-4"><CallsTable calls={filtered} onAction={onAction} /></TabsContent>
-          <TabsContent value="callbacks" className="mt-4"><CallsTable calls={filtered} onAction={onAction} /></TabsContent>
 
           <TabsContent value="softphone" className="mt-4">
             <AgentVoiceConfigCard />


### PR DESCRIPTION
När Live Support pensionerades följde callbacks och röstbrevlådan med,
men inte svarsstationen: panelen som visar vem som ringer just nu, hur
länge det ringt, och låter desken skicka ett SMS, boka en återuppringning
eller markera samtalet hanterat — och som får "Answer here" när
softphonen är på. Den låg orenderad kvar. Nu överst i FlowBox → Calls.

Ovanför står var ett samtal faktiskt tar vägen på den här instansen:
softphonen i webbläsaren (46elks/Twilio med WebRTC, ratten "Browser
softphone for agents" på, linje per agent) eller agentens mobil — med
länk till var det ställs in. Ingen ska undra varför inget ringde.

Voice-sidan tappar flikarna Missed, Voicemail och Callbacks; de var samma
rader som FlowBox → Calls. Kvar: loggen, agenternas linjer, leverantören.
Gamla adresser till de tre flikarna landar på kön; ?tab=settings och
?tab=softphone djuplänkar från FlowBox.
