### PR TITLE
feat(flowbox): besvarat och tyst är klart — tråden kan stängas, kunden öppnar den igen

### DIFF
--- a/src/hooks/useInboxItems.ts
+++ b/src/hooks/useInboxItems.ts
@@ -23,7 +23,7 @@ export function useInboxItems() {
     queryFn: async (): Promise<InboxItem[]> => {
       const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000).toISOString();
       const [threads, messages, chats, tickets, forms, calls, activity] = await Promise.all([
-        supabase.from('email_threads' as never).select('thread_key, subject, last_message_at, message_count, related_entity_type, related_entity_id').gte('last_message_at', since).order('last_message_at', { ascending: false }).limit(LIMIT),
+        supabase.from('email_threads' as never).select('thread_key, subject, last_message_at, message_count, related_entity_type, related_entity_id, closed_at').gte('last_message_at', since).order('last_message_at', { ascending: false }).limit(LIMIT),
         supabase.from('outbound_communications' as never).select('thread_id, direction, sender, recipient, body_text, created_at, status, metadata').eq('channel', 'email').not('thread_id', 'is', null).gte('created_at', since).order('created_at', { ascending: false }).limit(LIMIT * 3),
         supabase.from('chat_conversations' as never).select('id, title, conversation_status, priority, assigned_agent_id, customer_email, customer_name, escalation_reason, channel, updated_at').eq('scope', 'visitor').gte('updated_at', since).order('updated_at', { ascending: false }).limit(LIMIT),
         supabase.from('tickets' as never).select('id, ticket_number, subject, status, priority, assigned_to, contact_name, contact_email, source, updated_at').gte('updated_at', since).order('updated_at', { ascending: false }).limit(LIMIT),

--- a/src/lib/__tests__/inbox-items.test.ts
+++ b/src/lib/__tests__/inbox-items.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { emailItems, chatItems, ticketItems, formItems, voiceItems, sortQueue, attachSteps, guessEmail } from '../inbox-items';
+import { emailItems, chatItems, ticketItems, formItems, voiceItems, sortQueue, attachSteps, guessEmail, QUIET_DAYS } from '../inbox-items';
 
 describe('Inbox — one queue, organised by who has it', () => {
   it('email: the latest message decides whose turn it is', () => {
@@ -63,6 +63,24 @@ describe('Inbox — one queue, organised by who has it', () => {
     );
     expect(staged.state).toBe('human');
     expect(staged.reason).toContain('approve or reject');
+  });
+
+  it('email: answered and quiet for three days is done; marked done is done; the customer’s mail reopens', () => {
+    const threads = [{ thread_key: 'q', subject: 'Offert', last_message_at: '2026-09-01T10:00:00Z', message_count: 2 }];
+    const answered = [
+      { thread_id: 'q', direction: 'inbound', sender: 'anna@x.se', recipient: null, body_text: 'Kan ni?', created_at: '2026-09-01T09:00:00Z' },
+      { thread_id: 'q', direction: 'outbound', sender: null, recipient: 'anna@x.se', body_text: 'Ja', created_at: '2026-09-01T10:00:00Z' },
+    ];
+    expect(emailItems(threads, answered, new Date('2026-09-02T10:00:00Z'))[0].state).toBe('customer');
+    const late = emailItems(threads, answered, new Date(`2026-09-0${1 + QUIET_DAYS}T10:00:01Z`))[0];
+    expect(late.state).toBe('done');
+    expect(late.reason).toContain('quiet');
+    const closed = emailItems([{ ...threads[0], closed_at: '2026-09-01T11:00:00Z' }], answered, new Date('2026-09-01T12:00:00Z'))[0];
+    expect(closed.state).toBe('done');
+    expect(closed.reason).toContain('marked done');
+    // The trigger clears closed_at on the customer's next mail; the row is theirs again.
+    const reopened = emailItems([{ ...threads[0], closed_at: null }], [...answered, { thread_id: 'q', direction: 'inbound', sender: 'anna@x.se', recipient: null, body_text: 'En sak till', created_at: '2026-09-01T13:00:00Z' }], new Date('2026-09-01T14:00:00Z'))[0];
+    expect(reopened.state).toBe('human');
   });
 
   it('email: bulk and system mail is noise — logged, not answered, folded away from the queue', () => {

--- a/src/lib/inbox-items.ts
+++ b/src/lib/inbox-items.ts
@@ -148,6 +148,8 @@ export interface EmailThreadRow {
   message_count: number | null;
   related_entity_type?: string | null;
   related_entity_id?: string | null;
+  /** A person marked the thread done; the customer's next mail clears it (trigger). */
+  closed_at?: string | null;
 }
 export interface EmailMessageRow {
   thread_id: string | null;
@@ -160,7 +162,16 @@ export interface EmailMessageRow {
   metadata?: { needs_person?: boolean | null; approval_request_id?: string | null; classification?: string | null } | null;
 }
 
-export function emailItems(threads: EmailThreadRow[], messages: EmailMessageRow[]): InboxItem[] {
+/**
+ * An answered thread that stays quiet this long is done. An inbox does not
+ * close cases: what we answered and nobody came back to has ended, and the
+ * customer's next mail reopens it by itself. Three days is a mail rhythm —
+ * long enough for a weekend, short enough that "Waiting on the customer" is
+ * this week's list, not everything ever answered.
+ */
+export const QUIET_DAYS = 3;
+
+export function emailItems(threads: EmailThreadRow[], messages: EmailMessageRow[], now: Date = new Date()): InboxItem[] {
   // Latest message per thread decides whose turn it is. A FlowPilot draft is
   // a proposal, not a turn: it never counts as "we answered", it only marks
   // the row as having an answer waiting. Spent drafts (used, discarded) are
@@ -189,15 +200,22 @@ export function emailItems(threads: EmailThreadRow[], messages: EmailMessageRow[
       : null;
     const onLead = entity ? ` on ${entity.type === 'lead' ? 'a lead' : entity.type}` : '';
     const hasDraft = inboundLast && drafts.has(t.thread_key);
+    const closed = !!t.closed_at;
+    const quietDays = last && !inboundLast ? Math.floor((now.getTime() - new Date(last.created_at).getTime()) / 86_400_000) : 0;
+    const quiet = !inboundLast && !!last && quietDays >= QUIET_DAYS;
     const kind = hasDraft ? drafts.get(t.thread_key) : undefined;
     const wantsPerson = kind === 'needs_person';
     const staged = kind === 'staged';
     return {
       key: `email:${t.thread_key}`,
       channel: 'email',
-      state: last ? (inboundLast ? 'human' : 'customer') : 'done',
+      state: !last || closed || quiet ? 'done' : (inboundLast ? 'human' : 'customer'),
       reason: last
-        ? (noise
+        ? (closed
+          ? 'marked done — their next mail reopens it'
+          : quiet
+          ? `answered · quiet for ${quietDays} days`
+          : noise
           ? 'bulk or system mail — not answered'
           : inboundLast
           ? (wantsPerson

--- a/src/pages/admin/FlowBoxPage.tsx
+++ b/src/pages/admin/FlowBoxPage.tsx
@@ -1,4 +1,7 @@
 import { useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { supabase } from '@/integrations/supabase/client';
 import { Link, useSearchParams } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
 import { Bot, Headphones, Inbox, Loader2, Mail, MessageSquare, Phone, FileText, Ticket, UserRound, Hourglass, CheckCircle2, Route, ScrollText, Reply } from 'lucide-react';
@@ -12,7 +15,7 @@ import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useInboxItems } from '@/hooks/useInboxItems';
 import { useSupportPresence } from '@/hooks/useSupportPresence';
-import { STATE_ORDER, type InboxChannel, type InboxItem, type InboxState } from '@/lib/inbox-items';
+import { STATE_ORDER, QUIET_DAYS, type InboxChannel, type InboxItem, type InboxState } from '@/lib/inbox-items';
 import { RoutingLenses } from '@/components/admin/flowbox/RoutingLenses';
 import { MessageLogTab } from '@/components/admin/flowbox/MessageLogTab';
 import { ChatReply } from '@/components/admin/flowbox/ChatReply';
@@ -103,7 +106,7 @@ const CHANNEL_META: Record<InboxChannel, { label: string; icon: React.ComponentT
 const STATE_META: Record<InboxState, { label: string; hint: string; icon: React.ComponentType<{ className?: string }>; tone: string }> = {
   human: { label: 'Needs a person', hint: 'Escalated, asked for, or not allowed to finish — your hand-off list.', icon: UserRound, tone: 'text-destructive' },
   agent: { label: 'With FlowPilot', hint: 'Being handled by the operator. Nothing hidden — open any row to read every step.', icon: Bot, tone: 'text-primary' },
-  customer: { label: 'Waiting on the customer', hint: 'Answered; the ball is with them.', icon: Hourglass, tone: 'text-muted-foreground' },
+  customer: { label: 'Waiting on the customer', hint: `Answered; the ball is with them. Quiet for ${QUIET_DAYS} days → Done; their next mail brings it back.`, icon: Hourglass, tone: 'text-muted-foreground' },
   done: { label: 'Done', hint: 'Closed or handled in the last 30 days.', icon: CheckCircle2, tone: 'text-muted-foreground' },
 };
 
@@ -148,6 +151,16 @@ function QueueTab({ live, openKey }: { live: boolean; openKey?: string | null })
   // ?open=chat:<id> (a redirect from the old Live Support address, or a
   // notification) lands with that row's reply already open.
   const [replying, setReplying] = useState<Set<string>>(() => new Set(openKey ? [openKey] : []));
+  const qc = useQueryClient();
+  // Done on an email thread: a stamp on the thread, cleared by the customer's
+  // next mail (trigger). Not a status machine — an inbox's "archive".
+  const markThreadDone = async (threadKey: string) => {
+    const { data: auth } = await supabase.auth.getUser();
+    const { error } = await supabase.from('email_threads' as never).update({ closed_at: new Date().toISOString(), closed_by: auth?.user?.id ?? null } as never).eq('thread_key', threadKey);
+    if (error) { toast.error(error.message); return; }
+    toast.success('Marked done — find it under Show done; their next mail brings it back');
+    qc.invalidateQueries({ queryKey: ['inbox-items'] });
+  };
   const toggle = (set: React.Dispatch<React.SetStateAction<Set<string>>>, key: string) =>
     set((s) => { const n = new Set(s); if (n.has(key)) n.delete(key); else n.add(key); return n; });
 
@@ -294,6 +307,16 @@ function QueueTab({ live, openKey }: { live: boolean; openKey?: string | null })
                                 {i.hasDraft ? <Bot className="h-3 w-3 text-primary" /> : <Reply className="h-3 w-3" />}
                                 {replying.has(i.key) ? 'Close' : i.hasDraft ? 'Review FlowPilot’s draft' : i.channel === 'form' ? 'Handle here' : 'Reply here'}
                               </button>
+                              {i.channel === 'email' && (
+                                <button
+                                  type="button"
+                                  onClick={() => markThreadDone(i.sourceId!)}
+                                  className="ml-3 inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+                                  title="Nothing more to do here — their next mail brings it back"
+                                >
+                                  <CheckCircle2 className="h-3 w-3" /> Mark done
+                                </button>
+                              )}
                               {replying.has(i.key) && (
                                 <div className="mt-2">
                                   {i.channel === 'form' ? (

--- a/supabase/migrations/20260906120000_traden-kan-stangas-och-oppnas-igen.sql
+++ b/supabase/migrations/20260906120000_traden-kan-stangas-och-oppnas-igen.sql
@@ -1,0 +1,48 @@
+-- Tråden kan stängas — och öppnas igen av kundens nästa mejl.
+--
+-- "Waiting on the customer" i FlowBox växte till en lista över allt vi
+-- någonsin besvarat (17 rader på Resta första kvällen). En inkorg stänger
+-- inte ärenden; det som är besvarat och tyst ska tystna. Två saker:
+--   closed_at på tråden — en person kan markera den klar; ett INKOMMANDE
+--   mejl nollar den (kunden öppnar den igen, aldrig vi).
+--   Utkast räknas inte som meddelanden: touch_email_thread hoppar över
+--   status='draft', så FlowPilots förslag inte flyttar last_message_at.
+-- Policyn följer matrisen (email) i stället för en handskriven rollista
+-- (den parallella ratten, rollsvepet).
+
+ALTER TABLE public.email_threads
+  ADD COLUMN IF NOT EXISTS closed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS closed_by uuid;
+
+CREATE OR REPLACE FUNCTION public.touch_email_thread() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_key text;
+BEGIN
+  IF NEW.channel <> 'email' THEN RETURN NEW; END IF;
+  v_key := normalize_thread_key(NEW.subject, NEW.thread_id);
+  IF v_key IS NULL OR v_key = '' THEN RETURN NEW; END IF;
+  NEW.thread_id := v_key;
+  -- A draft is a proposal on the thread, not a message in it.
+  IF NEW.status = 'draft' THEN
+    INSERT INTO public.email_threads (thread_key, subject, last_message_at, message_count, related_entity_type, related_entity_id)
+      VALUES (v_key, NEW.subject, coalesce(NEW.sent_at, now()), 0, NEW.related_entity_type, NEW.related_entity_id)
+      ON CONFLICT (thread_key) DO NOTHING;
+    RETURN NEW;
+  END IF;
+  INSERT INTO public.email_threads (thread_key, subject, last_message_at, message_count, related_entity_type, related_entity_id)
+    VALUES (v_key, NEW.subject, coalesce(NEW.sent_at, now()), 1, NEW.related_entity_type, NEW.related_entity_id)
+    ON CONFLICT (thread_key) DO UPDATE SET
+      last_message_at = greatest(email_threads.last_message_at, coalesce(NEW.sent_at, now())),
+      message_count = email_threads.message_count + 1,
+      -- The customer reopens a closed thread by writing; we never do.
+      closed_at = CASE WHEN NEW.direction = 'inbound' THEN NULL ELSE email_threads.closed_at END,
+      closed_by = CASE WHEN NEW.direction = 'inbound' THEN NULL ELSE email_threads.closed_by END,
+      updated_at = now();
+  RETURN NEW;
+END $$;
+
+DROP POLICY IF EXISTS "email_threads staff" ON public.email_threads;
+CREATE POLICY "email_threads staff" ON public.email_threads
+  FOR ALL TO authenticated
+  USING (public.can_access_module(auth.uid(), 'email'))
+  WITH CHECK (public.can_access_module(auth.uid(), 'email'));

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260906110000",
-      "migrations_count": 570,
+      "migration_head": "20260906120000",
+      "migrations_count": 571,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2285,6 +2285,10 @@
         {
           "version": "20260906110000",
           "name": "indexet-rapporterar-sina-fel"
+        },
+        {
+          "version": "20260906120000",
+          "name": "traden-kan-stangas-och-oppnas-igen"
         }
       ]
     },


### PR DESCRIPTION
"Waiting on the customer" växte till allt vi någonsin besvarat (17 rader
första kvällen på Resta). En inkorg stänger inga ärenden; det som är
besvarat och tyst ska tystna. Tre regler, en per plats:

Tyst i tre dagar efter vårt svar → Done, med "answered · quiet for N
days" på raden. Tre dagar är en mejlrytm: en helg ryms, listan är veckans.
"Mark done" på raden → closed_at på tråden; en inkorgs arkiv, ingen
statusmaskin. Kundens nästa mejl nollar stämpeln i triggern — kunden
öppnar igen, aldrig vi. Utkast räknas inte längre som meddelanden i
tråden (touch_email_thread hoppar över status draft).

Trådpolicyn följer matrisen (email) i stället för en handskriven rollista.
Migrationen repeterad på nordbrygg.
