### PR TITLE
fix(email): ett utkast per mejl — unikt index där koden bara läste

### DIFF
--- a/supabase/functions/_shared/handlers/draft-email-reply.ts
+++ b/supabase/functions/_shared/handlers/draft-email-reply.ts
@@ -192,6 +192,9 @@ export async function handleDraftEmailReply(
     }
 
     const { data: inserted, error: insErr } = await fileDraft(supabase, { threadId, mailbox, fromAddr, replySubject, body, messageId, evt: str, related, needsPerson, extra: {} });
+    // Two runs for one event (the dispatcher can fire twice) both pass the
+    // read above; the unique index lets only one write. The loser says so.
+    if (insErr && /duplicate key|23505/.test(insErr.message)) return { success: true, skipped: 'already drafted (concurrent run)', thread_id: threadId };
     if (insErr) return { success: false, error: `could not file the draft: ${insErr.message}`, thread_id: threadId };
     return {
       success: true,

--- a/supabase/migrations/20260906130000_ett-utkast-per-mejl.sql
+++ b/supabase/migrations/20260906130000_ett-utkast-per-mejl.sql
@@ -1,0 +1,10 @@
+-- Ett utkast per inkommande mejl — sagt i databasen, inte bara i koden.
+--
+-- Simuleringen på Resta (25 mejl, 2026-09-04) gav dubbla utkast på flera
+-- trådar: två körningar av draft_email_reply tre sekunder isär, båda förbi
+-- kodens "finns redan?"-läsning innan någon hunnit skriva. Ett partiellt
+-- unikt index gör den andra insättningen omöjlig; handlern svarar
+-- "already drafted" på 23505.
+CREATE UNIQUE INDEX IF NOT EXISTS outbound_communications_one_draft_per_message
+  ON public.outbound_communications (thread_id, (metadata->>'draft_of'))
+  WHERE status = 'draft' AND metadata->>'draft_of' IS NOT NULL;

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260906110000",
-      "migrations_count": 570,
+      "migration_head": "20260906130000",
+      "migrations_count": 571,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2285,6 +2285,10 @@
         {
           "version": "20260906110000",
           "name": "indexet-rapporterar-sina-fel"
+        },
+        {
+          "version": "20260906130000",
+          "name": "ett-utkast-per-mejl"
         }
       ]
     },
@@ -2295,7 +2299,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:71e74f6966b5b5ddba164134626fc9485a1c20ea6ee12c318fbfa0bcb83cb7e8",
+      "shared_hash": "sha256:6d4f65cc75582fe95d91eb9edd5db72be509bfe879fd13ed2cec22a2765d35ce",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",


### PR DESCRIPTION
Simuleringen på Resta (25 mejl) gav dubbla utkast på flera trådar: två
körningar av draft_email_reply tre sekunder isär, båda förbi kodens
"finns redan?"-läsning innan någon hunnit skriva. Partiellt unikt index
på (thread_id, metadata->>draft_of) för status draft; handlern svarar
"already drafted" på 23505. Repeterad på nordbrygg.
