### PR TITLE
fix(email): en tom ström säger varför — och svaret följer avsändarens språk

### DIFF
--- a/src/lib/__tests__/email-responder.test.ts
+++ b/src/lib/__tests__/email-responder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseSse, splitNeedsPerson, NEEDS_PERSON_MARKER } from '../../../supabase/functions/_shared/email/responder-client';
+import { parseSse, parseSseDetailed, splitNeedsPerson, NEEDS_PERSON_MARKER } from '../../../supabase/functions/_shared/email/responder-client';
 
 describe('email rides the chat responder', () => {
   it('reads the responder’s SSE into plain text, ignoring keepalives and [DONE]', () => {
@@ -12,6 +12,16 @@ describe('email rides the chat responder', () => {
       '',
     ].join('\n');
     expect(parseSse(raw)).toBe('Hej Anna, tack för ditt mejl.');
+  });
+
+  it('an empty stream says why: the error frame, or how the model finished', () => {
+    const err = parseSseDetailed('data: {"error":{"message":"rate limited"}}\n\ndata: [DONE]\n');
+    expect(err.text).toBe('');
+    expect(err.errorFrame).toContain('rate limited');
+    const tools = parseSseDetailed('data: {"choices":[{"delta":{"tool_calls":[{"id":"x"}]}}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n');
+    expect(tools.text).toBe('');
+    expect(tools.finish).toBe('tool_calls');
+    expect(tools.toolCallFrames).toBe(1);
   });
 
   it('the marker means a person: split off, body kept, never sent by the caller', () => {

--- a/supabase/functions/_shared/email/responder-client.ts
+++ b/supabase/functions/_shared/email/responder-client.ts
@@ -56,7 +56,14 @@ export async function askResponder(call: ResponderCall): Promise<ResponderAnswer
     return { text: '', skipped: false, error: `responder ${res.status}: ${msg}` };
   }
   if (contentType.includes('text/event-stream')) {
-    return { text: parseSse(raw), skipped: false };
+    const parsed = parseSseDetailed(raw);
+    if (!parsed.text) {
+      // An empty stream is a fact to report, not a shrug: the frame that
+      // carried an error, or how the model finished (tool_calls at the last
+      // step, a length cut) — so the activity row says WHY nothing came.
+      return { text: '', skipped: false, error: `empty stream — ${parsed.errorFrame ? `error frame: ${parsed.errorFrame}` : `finish=${parsed.finish ?? 'none'}, frames=${parsed.frames}, tool_call_frames=${parsed.toolCallFrames}`}` };
+    }
+    return { text: parsed.text, skipped: false };
   }
   let json: any = {};
   try { json = JSON.parse(raw); } catch { /* not json */ }
@@ -68,19 +75,41 @@ export async function askResponder(call: ResponderCall): Promise<ResponderAnswer
 
 /** OpenAI-style SSE → the concatenated assistant text. Pure, so it can be tested. */
 export function parseSse(raw: string): string {
+  return parseSseDetailed(raw).text;
+}
+
+export interface SseSummary {
+  text: string;
+  finish: string | null;
+  frames: number;
+  toolCallFrames: number;
+  errorFrame: string | null;
+}
+
+/** The same parse, plus what the stream said about itself — for the empty case. */
+export function parseSseDetailed(raw: string): SseSummary {
   let acc = '';
+  let finish: string | null = null;
+  let frames = 0;
+  let toolCallFrames = 0;
+  let errorFrame: string | null = null;
   for (const line of raw.split('\n')) {
     const t = line.trim();
     if (!t.startsWith('data:')) continue;
     const payload = t.slice(5).trim();
     if (!payload || payload === '[DONE]') continue;
+    frames += 1;
     try {
       const obj = JSON.parse(payload);
-      const delta = obj?.choices?.[0]?.delta?.content ?? obj?.choices?.[0]?.message?.content ?? '';
+      if (obj?.error) errorFrame = typeof obj.error === 'string' ? obj.error : (obj.error?.message ?? JSON.stringify(obj.error)).slice(0, 300);
+      const choice = obj?.choices?.[0];
+      const delta = choice?.delta?.content ?? choice?.message?.content ?? '';
       if (typeof delta === 'string') acc += delta;
+      if (choice?.delta?.tool_calls) toolCallFrames += 1;
+      if (choice?.finish_reason) finish = String(choice.finish_reason);
     } catch { /* keepalives, non-JSON frames */ }
   }
-  return acc.trim();
+  return { text: acc.trim(), finish, frames, toolCallFrames, errorFrame };
 }
 
 /**

--- a/supabase/functions/chat-completion/index.ts
+++ b/supabase/functions/chat-completion/index.ts
@@ -189,6 +189,7 @@ function buildEmailRegister(ctx?: { subject?: string; from?: string; mailbox?: s
     '\n\n=== CHANNEL: EMAIL ===\n' +
     'You are answering an EMAIL, not a chat message. A person may read it before it goes out, or it may be sent as is.' +
     who + subj + '\n' +
+    'Write in the language the sender wrote in — an English mail gets an English reply — even if other instructions above name a site language.\n' +
     'Write the reply as an email: greet the sender by first name when the message shows one, otherwise a plain greeting; ' +
     'full sentences and short paragraphs; under 180 words; plain text only — no subject line, no markdown, no placeholders like [name]; ' +
     "end with a plain sign-off in the company's name, no personal name.\n" +

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260906140000",
-      "migrations_count": 572,
+      "migration_head": "20260906120000",
+      "migrations_count": 571,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2289,31 +2289,27 @@
         {
           "version": "20260906120000",
           "name": "traden-kan-stangas-och-oppnas-igen"
-        },
-        {
-          "version": "20260906140000",
-          "name": "indexets-ko-i-statistiken"
         }
       ]
     },
     "skills": {
-      "seed_hash": "sha256:f38676cb34b2f3cd08641a8d856433777fa704828691d6618e7d6c1d61e2fa56",
-      "skill_count": 557,
+      "seed_hash": "sha256:a1432db60af312d2bdd0965bec30f4292a8f682d6a3e246257ef7df59b661c08",
+      "skill_count": 555,
       "module_count": 68
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:2660b81c8c3530d885589e9362ed81ab7fc761cd82a02681b3683c06e0e97168",
+      "shared_hash": "sha256:23a160dec74bdcfe9ef18eb14baa37b40f0e516105de3dc009d938aa5f04c44c",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
-        "agent-execute": "sha256:4aeaaaec143af1cfa7efec2e8cf170261321612ea885fa8668740dba5f5ae2f0",
+        "agent-execute": "sha256:6d0eb27dcfe472ee49285a0114afac3c28a981fc5403774257063edbad0bfdf6",
         "agent-operate": "sha256:9edc79c928f9920a74d8cfbba484aeabe7b21fba0018ae2ec813031593a74798",
         "ai-task": "sha256:35ae34d3748467b51f716cfef3d80af31b08e92e801905277b8460765b017169",
         "automation-dispatcher": "sha256:3cb8681d7acce65624bd7957a432b143a2d959d769845dc71696b95c2ea2012b",
         "blog-rss": "sha256:dd57f6386804f1e0a4b8e0db3cdb83abc386c5790a677c7fdfe145067ae51be6",
         "browser-fetch": "sha256:762a956222c98ae99b4a361bec94c3d31fcbde6c0d96512755bd50caefa6d652",
-        "chat-completion": "sha256:dd93997e723b35de72359a8a2a3d0b01ebf745580074d8e9a8a47aa2d579de5b",
+        "chat-completion": "sha256:045f091bc5c1c449ad891933744f5c548a97ee04378fcd07fb51b5cff6f56205",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
         "comms-send": "sha256:39dc9fde197bf59a92ae372f96263fe368238b212ad5674b299736ec1052d6b6",
@@ -2362,7 +2358,7 @@
         "quote-pay": "sha256:f42a8accc1489304c32b0e3a2c5f30188faa898e48e9323698ed624ca9aea296",
         "quote-sign": "sha256:6f0e0aabc65a4d5375753109a8cc94992b3c56785bd341db925d446891e45d46",
         "run-autonomy-tests": "sha256:53426062cbb9c3c6963f6c807c77176ca89f56aea35b7bfab3e84e4dff087cd2",
-        "run-platform-tests": "sha256:ef21e62bd5c8c53cad18d2edf5599744a5e7b5a96fa242c6d9e5fdabdec4d8ff",
+        "run-platform-tests": "sha256:d2a1e9f20471d8876bac39021e82cbc7ae646be78d4a7623b2045299b11cbf55",
         "score-visitor-intent": "sha256:15e438b8dd9a8ba8a5348d23df7b28b071c66854dd667d86d33f81d4c185987a",
         "send-webhook": "sha256:f2b9573421d0923317593d19383a83bbd6b55f9f0d3205e467f8040edf5b5b48",
         "setup-database": "sha256:49f03dc85ea4d48cd53b7760b0a68f4e2a628a217207b0fe4590d931f594e56e",

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260906120000",
-      "migrations_count": 571,
+      "migration_head": "20260906140000",
+      "migrations_count": 572,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2289,21 +2289,25 @@
         {
           "version": "20260906120000",
           "name": "traden-kan-stangas-och-oppnas-igen"
+        },
+        {
+          "version": "20260906140000",
+          "name": "indexets-ko-i-statistiken"
         }
       ]
     },
     "skills": {
-      "seed_hash": "sha256:a1432db60af312d2bdd0965bec30f4292a8f682d6a3e246257ef7df59b661c08",
-      "skill_count": 555,
+      "seed_hash": "sha256:f38676cb34b2f3cd08641a8d856433777fa704828691d6618e7d6c1d61e2fa56",
+      "skill_count": 557,
       "module_count": 68
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:23a160dec74bdcfe9ef18eb14baa37b40f0e516105de3dc009d938aa5f04c44c",
+      "shared_hash": "sha256:8ea81a8d6caf1eadf138bbefd6f399be0a634fc2c9da83c35a73f429230fcc8c",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
-        "agent-execute": "sha256:6d0eb27dcfe472ee49285a0114afac3c28a981fc5403774257063edbad0bfdf6",
+        "agent-execute": "sha256:4aeaaaec143af1cfa7efec2e8cf170261321612ea885fa8668740dba5f5ae2f0",
         "agent-operate": "sha256:9edc79c928f9920a74d8cfbba484aeabe7b21fba0018ae2ec813031593a74798",
         "ai-task": "sha256:35ae34d3748467b51f716cfef3d80af31b08e92e801905277b8460765b017169",
         "automation-dispatcher": "sha256:3cb8681d7acce65624bd7957a432b143a2d959d769845dc71696b95c2ea2012b",
@@ -2358,7 +2362,7 @@
         "quote-pay": "sha256:f42a8accc1489304c32b0e3a2c5f30188faa898e48e9323698ed624ca9aea296",
         "quote-sign": "sha256:6f0e0aabc65a4d5375753109a8cc94992b3c56785bd341db925d446891e45d46",
         "run-autonomy-tests": "sha256:53426062cbb9c3c6963f6c807c77176ca89f56aea35b7bfab3e84e4dff087cd2",
-        "run-platform-tests": "sha256:d2a1e9f20471d8876bac39021e82cbc7ae646be78d4a7623b2045299b11cbf55",
+        "run-platform-tests": "sha256:ef21e62bd5c8c53cad18d2edf5599744a5e7b5a96fa242c6d9e5fdabdec4d8ff",
         "score-visitor-intent": "sha256:15e438b8dd9a8ba8a5348d23df7b28b071c66854dd667d86d33f81d4c185987a",
         "send-webhook": "sha256:f2b9573421d0923317593d19383a83bbd6b55f9f0d3205e467f8040edf5b5b48",
         "setup-database": "sha256:49f03dc85ea4d48cd53b7760b0a68f4e2a628a217207b0fe4590d931f594e56e",


### PR DESCRIPTION
Resta: 'Ledig tid för grisupplevelsen?' fick inget utkast, två gånger, med
bara 'the responder returned nothing'. Nu bär felet strömmens egen
berättelse: felramen om det fanns en, annars finish_reason, antal ramar
och verktygsramar — så aktivitetsraden i FlowBox säger varför.

Ett engelskt mejl fick svenskt svar: chattens sajtspråk vann över
avsändarens. Registret säger nu uttryckligen att avsändarens språk gäller.
