### PR TITLE
fix(chat): ett verktyg som kastar avslutar inte svaret

### DIFF
--- a/supabase/functions/chat-completion/index.ts
+++ b/supabase/functions/chat-completion/index.ts
@@ -1181,13 +1181,26 @@ serve(async (req) => {
                   for (const tc of Object.values(tcMap)) {
                     let fnArgs: any;
                     try { fnArgs = JSON.parse(tc.args || '{}'); } catch { fnArgs = {}; }
-                    const result = await executeChatTool(
-                      supabase, supabaseUrl, serviceKey,
-                      tc.name, fnArgs,
-                      conversationId, customerEmail, customerName,
-                      authedCustomer?.email,
-                      companyCtx?.activeCompanyId, companyCtx?.activeRole,
-                    );
+                    // A tool that throws must not end the answer: the visitor (or
+                    // the mail rail) got a stream that stopped after the tool-call
+                    // frames and nothing else — "empty stream, finish=tool_calls" on
+                    // Resta's availability question. The error becomes the tool's
+                    // result and the model answers around it, as it does for any
+                    // other failed lookup.
+                    let result: string;
+                    try {
+                      result = await executeChatTool(
+                        supabase, supabaseUrl, serviceKey,
+                        tc.name, fnArgs,
+                        conversationId, customerEmail, customerName,
+                        authedCustomer?.email,
+                        companyCtx?.activeCompanyId, companyCtx?.activeRole,
+                      );
+                    } catch (toolErr) {
+                      const msg = toolErr instanceof Error ? toolErr.message : String(toolErr);
+                      console.error(`[chat] tool ${tc.name} threw:`, msg);
+                      result = `TOOL_ERROR: ${tc.name} failed — ${msg.slice(0, 300)}. Answer without it; if the question depends on it, say a colleague will check.`;
+                    }
                     msgs.push({ role: 'tool', tool_call_id: tc.id, content: result });
                   }
 

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2313,7 +2313,7 @@
         "automation-dispatcher": "sha256:3cb8681d7acce65624bd7957a432b143a2d959d769845dc71696b95c2ea2012b",
         "blog-rss": "sha256:dd57f6386804f1e0a4b8e0db3cdb83abc386c5790a677c7fdfe145067ae51be6",
         "browser-fetch": "sha256:762a956222c98ae99b4a361bec94c3d31fcbde6c0d96512755bd50caefa6d652",
-        "chat-completion": "sha256:045f091bc5c1c449ad891933744f5c548a97ee04378fcd07fb51b5cff6f56205",
+        "chat-completion": "sha256:bb774ef4d5a78e1fdf0c1dc43cb29f0c03f07e74cf3b109e8bf7608343c41778",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
         "comms-send": "sha256:39dc9fde197bf59a92ae372f96263fe368238b212ad5674b299736ec1052d6b6",


### PR DESCRIPTION
Resta, 'Ledig tid för grisupplevelsen?': strömmen slutade efter
verktygsramarna — finish=tool_calls, 14 verktygsramar, ingen text — och
mejlrälsen fick inget. Ett verktyg kastade inuti loopen, catch-blocket
avbröt hela strömmen. Nu blir felet verktygets resultat och modellen
svarar runt det, som för vilket misslyckat uppslag som helst.
