### PR TITLE
fix(email): sidfoten bär företagets publika adress, inte var FlowWink-sajten bor

### DIFF
--- a/supabase/functions/_shared/email-shell.ts
+++ b/supabase/functions/_shared/email-shell.ts
@@ -90,7 +90,7 @@ export async function loadEmailShell(
   const { data: rows } = await supabase
     .from("site_settings")
     .select("key, value")
-    .in("key", ["branding", "general"]);
+    .in("key", ["branding", "general", "company_profile"]);
 
   const byKey: Record<string, Record<string, unknown>> = {};
   for (const row of (rows ?? []) as Array<{ key: string; value: unknown }>) {
@@ -98,13 +98,19 @@ export async function loadEmailShell(
   }
   const branding = byKey.branding ?? {};
   const general = byKey.general ?? {};
+  const profile = byKey.company_profile ?? {};
+  // The footer names the company's public address. Business Identity's
+  // website is that address; general.siteUrl is where THIS FlowWink site
+  // lives, which on a fork or a not-yet-launched instance is a Vercel host —
+  // "flowwink-sigma.vercel.app" under every mail Resta sent (2026-09-04).
+  const publicUrl = ((profile.website as string) || (general.siteUrl as string) || "").trim();
 
   return {
     organizationName:
       (branding.organizationName as string) || (branding.adminName as string) || "",
     logoUrl: emailSafeLogo(branding),
     primaryHex: hslTripletToHex(branding.primaryColor as string) ?? DEFAULT_PRIMARY,
-    siteUrl: ((general.siteUrl as string) || "").replace(/\/+$/, ""),
+    siteUrl: (/^https?:\/\//i.test(publicUrl) ? publicUrl : publicUrl ? `https://${publicUrl}` : "").replace(/\/+$/, ""),
     tagline: (branding.brandTagline as string) || null,
   };
 }

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2303,7 +2303,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:8ea81a8d6caf1eadf138bbefd6f399be0a634fc2c9da83c35a73f429230fcc8c",
+      "shared_hash": "sha256:4eac06da029a05a48619a21f3cd7cb000eb7eb388b94315e1cded2478bb75c1e",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",


### PR DESCRIPTION
Varje mejl Resta skickade slutade med flowwink-sigma.vercel.app: skalet
läste general.siteUrl, som på en fork eller en olanserad instans är
Vercel-värden. Business Identity:s webbplats är företagets adress; den
vinner, siteUrl är reserv.
