### PR TITLE
fix(flowpilot): ett mål en gång — unikt partiellt index på aktiva mål

### DIFF
--- a/src/lib/modules/flowpilot-module.ts
+++ b/src/lib/modules/flowpilot-module.ts
@@ -158,7 +158,10 @@ async function seedFlowPilotSoul(): Promise<void> {
     }
   }
 
-  // Seed starter objectives (skip duplicates by goal text)
+  // Seed starter objectives (skip duplicates by goal text). Two concurrent
+  // bootstraps both read an empty table; the unique partial index
+  // agent_objectives_one_active_goal (20260906190000) makes the second insert
+  // fail, and the warning below is the right outcome for it.
   const { data: existingObjectives } = await supabase
     .from('agent_objectives')
     .select('goal');

--- a/supabase/migrations/20260906190000_ett-mal-en-gang.sql
+++ b/supabase/migrations/20260906190000_ett-mal-en-gang.sql
@@ -1,0 +1,27 @@
+-- Ett mål en gång.
+--
+-- seedFlowPilotSoul() sår startmålen med "hoppa över om goal-texten finns".
+-- Två bootstraps som kör samtidigt (mallinstall + FlowPilot-bootstrap på en
+-- nyinstallation) läser båda en tom tabell och sår båda: nya liteit
+-- (2026-09-05) föddes med varje startmål två gånger, och heartbeaten arbetar
+-- då mot två identiska mål. En läs-sedan-skriv-kontroll i klienten kan inte
+-- lova unikhet; det kan bara databasen. Insert-felet i seedern är redan
+-- bara en varning, så det andra loppet förlorar tyst och rätt.
+--
+-- Dubbletter som redan finns städas först (den äldsta behålls — det är den
+-- som hunnit få progress), annars vägrar indexet.
+
+WITH d AS (
+  SELECT id, row_number() OVER (PARTITION BY goal ORDER BY created_at, id) AS rn
+    FROM public.agent_objectives
+   WHERE status = 'active'
+)
+DELETE FROM public.agent_objectives o
+ USING d
+ WHERE o.id = d.id AND d.rn > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS agent_objectives_one_active_goal
+  ON public.agent_objectives (goal)
+  WHERE status = 'active';
+COMMENT ON INDEX public.agent_objectives_one_active_goal IS
+  'One active objective per goal text — the seeder''s check-then-insert cannot promise this across two concurrent bootstraps; the index can.';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "layers": {
     "schema": {
-      "migration_head": "20260906180000",
-      "migrations_count": 576,
+      "migration_head": "20260906190000",
+      "migrations_count": 577,
       "migrations": [
         {
           "version": "00000000000000",
@@ -2309,6 +2309,10 @@
         {
           "version": "20260906180000",
           "name": "papperskorgen-blockerar-inte-sluggen"
+        },
+        {
+          "version": "20260906190000",
+          "name": "ett-mal-en-gang"
         }
       ]
     },


### PR DESCRIPTION
Nya liteit föddes med varje startmål två gånger (två samtidiga bootstraps). Klientens läs-sedan-skriv kan inte lova unikhet; indexet `agent_objectives_one_active_goal (goal) WHERE status='active'` kan. Migrationen städar befintliga dubbletter (äldsta behålls). Seederns insert-fel är redan bara en varning.

Repeterat på nordbrygg: dubblett avvisas, replay no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)