### PR TITLE
fix(pages): bara den första sidan blir startsida — general-raden skrivs inte över

### DIFF
--- a/supabase/functions/agent-execute/index.ts
+++ b/supabase/functions/agent-execute/index.ts
@@ -4213,14 +4213,22 @@ async function executePagesAction(
         }).select('id, title, slug, status').single();
         if (error) throw new Error(`Create page failed: ${error.message}`);
 
-        // If this is the first page, set it as homepage
+        // Only the FIRST page becomes the homepage. `<= 1` made the SECOND page
+        // the homepage too (new liteit, 2026-09-05: "om-oss" replaced "home"),
+        // and the upsert replaced the whole general row, dropping every other
+        // general setting with it. Now: zero pages before this one, and a merge.
         let setAsHomepage = false;
-        if ((existingPages ?? 0) <= 1) {
-          await supabase.from('site_settings').upsert(
-            { key: 'general', value: { homepageSlug: pageSlug } },
+        if ((existingPages ?? 0) === 0) {
+          const { data: generalRow, error: generalErr } = await supabase
+            .from('site_settings').select('value').eq('key', 'general').maybeSingle();
+          if (generalErr) console.warn('[manage_page] general read failed:', generalErr.message);
+          const general = (generalRow?.value && typeof generalRow.value === 'object') ? (generalRow.value as Record<string, unknown>) : {};
+          const { error: homeErr } = await supabase.from('site_settings').upsert(
+            { key: 'general', value: { ...general, homepageSlug: pageSlug } },
             { onConflict: 'key' }
           );
-          setAsHomepage = true;
+          if (homeErr) console.warn('[manage_page] homepage write failed:', homeErr.message);
+          else setAsHomepage = true;
         }
 
         return { page_id: data.id, slug: data.slug, title: data.title, status: 'draft', set_as_homepage: setAsHomepage };

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2327,7 +2327,7 @@
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
-        "agent-execute": "sha256:b19347328abebce21ef55c57b9cc955176714a6deadab92861e55e4ac0529a18",
+        "agent-execute": "sha256:9f8ee9785ddc43d923c4747111d27949de5ceeac1c728750422c716f9abae124",
         "agent-operate": "sha256:9edc79c928f9920a74d8cfbba484aeabe7b21fba0018ae2ec813031593a74798",
         "ai-task": "sha256:35ae34d3748467b51f716cfef3d80af31b08e92e801905277b8460765b017169",
         "automation-dispatcher": "sha256:8825afae36e18f64c1f8c59ea4cc320a8a418554d2d8638e45644713b3af21a9",


### PR DESCRIPTION
`manage_page create` satte startsidan när befintliga sidor var `<= 1`, alltså även för den andra sidan (nya liteit: "om-oss" ersatte "home"), och upserten ersatte hela `general`-raden. Nu `=== 0` och merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)