### PR TITLE
fix(header): "Show logo" styr även initial-badgen — ett ordmärke utan logo är ett val

### DIFF
--- a/src/components/admin/blocks/HeaderBlockEditor.tsx
+++ b/src/components/admin/blocks/HeaderBlockEditor.tsx
@@ -483,7 +483,7 @@ export function HeaderBlockEditor({ data, onChange }: HeaderBlockEditorProps) {
             <div className="flex items-center justify-between">
               <div>
                 <Label>Show logo</Label>
-                <p className="text-sm text-muted-foreground">Show logo in header</p>
+                <p className="text-sm text-muted-foreground">Show the mark next to the name. With no logo uploaded the mark is the initial letter; turn this off for a name-only header.</p>
               </div>
               <Switch
                 checked={data.showLogo !== false}

--- a/src/components/public/PublicNavigation.tsx
+++ b/src/components/public/PublicNavigation.tsx
@@ -568,14 +568,20 @@ export function PublicNavigation({ translations, currentLocale, onDarkSurface }:
                 );
               }
               
-              // No logo but show name is enabled, or fallback
+              // No logo: the initial badge stands in for the mark, and "Show
+              // logo" decides whether the mark is shown at all — a wordmark-only
+              // header is a choice, not an accident of having no file yet
+              // (liteit, 2026-09-06: no logo that survives a transparent
+              // header, and no way to show just the name).
               return (
                 <>
-                  <div className={cn('rounded-lg bg-primary flex items-center justify-center', iconSizes[logoSize])}>
-                    <span className="text-primary-foreground font-serif font-bold">
-                      {orgName.charAt(0)}
-                    </span>
-                  </div>
+                  {showLogo && (
+                    <div className={cn('rounded-lg bg-primary flex items-center justify-center', iconSizes[logoSize])}>
+                      <span className="text-primary-foreground font-serif font-bold">
+                        {orgName.charAt(0)}
+                      </span>
+                    </div>
+                  )}
                   <span className="font-serif font-bold text-xl">{orgName}</span>
                 </>
               );

--- a/src/lib/__tests__/inbox-items.test.ts
+++ b/src/lib/__tests__/inbox-items.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+// The queue's "quiet for three days" rule reads a clock; the fixtures are
+// dated, so the tests must be too — or they age past the rule (2026-09-06).
+const NOW = new Date('2026-09-02T12:00:00Z');
 import { emailItems, chatItems, ticketItems, formItems, voiceItems, sortQueue, attachSteps, guessEmail, QUIET_DAYS } from '../inbox-items';
 
 describe('Inbox — one queue, organised by who has it', () => {
@@ -13,6 +16,7 @@ describe('Inbox — one queue, organised by who has it', () => {
         { thread_id: 't1', direction: 'outbound', sender: null, recipient: 'anna@x.se', body_text: 'Hej', created_at: '2026-09-01T10:00:00Z' },
         { thread_id: 't2', direction: 'outbound', sender: null, recipient: 'bo@y.se', body_text: 'Svar', created_at: '2026-09-02T09:00:00Z' },
       ],
+    NOW,
     );
     expect(items.find((i) => i.key === 'email:t1')?.state).toBe('human');
     expect(items.find((i) => i.key === 'email:t1')?.who).toBe('anna@x.se');
@@ -26,6 +30,7 @@ describe('Inbox — one queue, organised by who has it', () => {
         { thread_id: 't1', direction: 'inbound', sender: 'anna@x.se', recipient: null, body_text: 'Kan ni?', created_at: '2026-09-02T10:00:00Z' },
         { thread_id: 't1', direction: 'outbound', sender: null, recipient: 'anna@x.se', body_text: 'Hej Anna…', created_at: '2026-09-02T10:00:30Z', status: 'draft' },
       ],
+    NOW,
     );
     expect(row.state).toBe('human');
     expect(row.who).toBe('anna@x.se');
@@ -40,6 +45,7 @@ describe('Inbox — one queue, organised by who has it', () => {
         { thread_id: 't1', direction: 'outbound', sender: null, recipient: 'anna@x.se', body_text: 'Hej Anna…', created_at: '2026-09-02T10:00:30Z', status: 'used' },
         { thread_id: 't1', direction: 'outbound', sender: null, recipient: 'anna@x.se', body_text: 'Hej Anna, ja.', created_at: '2026-09-02T10:05:00Z', status: 'sent' },
       ],
+    NOW,
     );
     expect(after.state).toBe('customer');
     expect(after.hasDraft).toBe(false);
@@ -50,6 +56,7 @@ describe('Inbox — one queue, organised by who has it', () => {
         { thread_id: 't1', direction: 'inbound', sender: 'anna@x.se', recipient: null, body_text: 'Kan ni?', created_at: '2026-09-02T10:00:00Z' },
         { thread_id: 't1', direction: 'outbound', sender: null, recipient: 'anna@x.se', body_text: 'Hej Anna…', created_at: '2026-09-02T10:00:30Z', status: 'draft', metadata: { needs_person: true } },
       ],
+    NOW,
     );
     expect(holding.state).toBe('human');
     expect(holding.reason).toContain('needs you');
@@ -60,6 +67,7 @@ describe('Inbox — one queue, organised by who has it', () => {
         { thread_id: 't1', direction: 'inbound', sender: 'anna@x.se', recipient: null, body_text: 'Kan ni?', created_at: '2026-09-02T10:00:00Z' },
         { thread_id: 't1', direction: 'outbound', sender: null, recipient: 'anna@x.se', body_text: 'Hej Anna…', created_at: '2026-09-02T10:00:30Z', status: 'draft', metadata: { approval_request_id: 'req-1' } },
       ],
+    NOW,
     );
     expect(staged.state).toBe('human');
     expect(staged.reason).toContain('approve or reject');
@@ -87,6 +95,7 @@ describe('Inbox — one queue, organised by who has it', () => {
     const [row] = emailItems(
       [{ thread_key: 'n1', subject: '[repo] CI failed', last_message_at: '2026-09-02T10:00:00Z', message_count: 1 }],
       [{ thread_id: 'n1', direction: 'inbound', sender: 'notifications@github.com', recipient: null, body_text: 'Run failed', created_at: '2026-09-02T10:00:00Z', metadata: { classification: 'noise' } }],
+    NOW,
     );
     expect(row.noise).toBe(true);
     expect(row.reason).toContain('not answered');


### PR DESCRIPTION
Utan logo ritade headern alltid initial-badgen + namnet, och "Show logo" gjorde ingenting. Nu följer badgen `showLogo`; namnet visas alltid. Editorn förklarar brytaren när ingen logo finns. (liteit vill visa bara "LiteIT" i en transparent header.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)