### PR TITLE
fix(mcp-server): ett tillfälligt databasfel i nyckeluppslaget är inte en ogiltig nyckel

### DIFF
--- a/supabase/functions/mcp-server/index.ts
+++ b/supabase/functions/mcp-server/index.ts
@@ -49,7 +49,7 @@ function serviceClient() {
 
 async function authenticateApiKey(
   authHeader: string | null,
-): Promise<{ valid: boolean; keyId?: string; scopes?: string[]; createdBy?: string | null }> {
+): Promise<{ valid: boolean; transient?: boolean; keyId?: string; scopes?: string[]; createdBy?: string | null }> {
   if (!authHeader?.startsWith("Bearer ")) {
     console.error("Auth: missing or malformed header");
     return { valid: false };
@@ -62,14 +62,29 @@ async function authenticateApiKey(
   // exposure surface for credentials.
   const sb = serviceClient();
 
-  const { data, error } = await sb
-    .from("api_keys")
-    .select("id, scopes, expires_at, created_by")
-    .eq("key_hash", hash)
-    .single();
-
+  // A key lookup can fail for two unrelated reasons, and until 2026-09-08 both
+  // came back as "Invalid or expired API key": the hash matched nothing
+  // (PGRST116, a genuinely wrong or revoked key) — or PostgREST/the pooler hit
+  // a transient error under load. An external operator firing six calls in
+  // parallel got one such hiccup mid-run and concluded its key had been
+  // revoked (Hermes on nordbrygg, during the MJP demo). A transient failure
+  // gets ONE quiet retry here and, if it persists, is reported as what it is
+  // (503, retry) — never as a verdict on the key.
+  const lookup = () =>
+    sb.from("api_keys").select("id, scopes, expires_at, created_by").eq("key_hash", hash).single();
+  let { data, error } = await lookup();
+  const isNoRows = (e: { code?: string } | null) => e?.code === "PGRST116";
+  if (error && !isNoRows(error)) {
+    console.error("Auth: key lookup failed transiently, retrying once:", error.message);
+    await new Promise((r) => setTimeout(r, 300));
+    ({ data, error } = await lookup());
+  }
+  if (error && !isNoRows(error)) {
+    console.error("Auth: key lookup failed twice — reporting transient, not invalid:", error.message);
+    return { valid: false, transient: true };
+  }
   if (error || !data) {
-    console.error("Auth: no matching key found, error=", error?.message);
+    console.error("Auth: no matching key found");
     return { valid: false };
   }
 
@@ -1264,6 +1279,14 @@ app.use("/*", async (c, next) => {
   const xApiKey = c.req.header("x-api-key");
   const authHeader = xApiKey ? `Bearer ${xApiKey}` : c.req.header("Authorization");
   const auth = await authenticateApiKey(authHeader);
+  if (!auth.valid && auth.transient) {
+    c.header("Retry-After", "2");
+    return c.json({
+      error: "Key lookup temporarily failed",
+      retry: true,
+      hint: "The instance's database did not answer the API-key lookup in time. Your key was NOT rejected — retry the same call in a moment.",
+    }, 503);
+  }
   if (!auth.valid) {
     // Keys are per-instance: every deployment hashes its own. Sending a
     // perfectly good key to the wrong instance produced the same bare

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2391,7 +2391,7 @@
         "invite-employee": "sha256:354d9ecbcc20ff402597a0e4c10875807c1a140ace0c5c06505ff8fc9fe13eb5",
         "knowledge-indexer": "sha256:9719ea8dfda56ca4fa126907806adef794ae492f44ab6ba9e97884637cb7ba36",
         "llms-txt": "sha256:0a8a132d383590b810617ff9cdcd4893980208233d0c26b65d6c17a80af4f452",
-        "mcp-server": "sha256:611d0782ffb321a9f66729ccfb6396342852e3c9d3389c3084dcd81ec55be559",
+        "mcp-server": "sha256:b313f3696582d705944038f408163d33e621dd609f2faeb5478d8377b17fc692",
         "media-optimize": "sha256:ddaa5868b1f154561a900e133ab64c6ffd0ebef9751098b2a42c03684c34d496",
         "migrate-page": "sha256:163d9a8a447050186eb9226430a8edb675b7c918f87ce437a859a483d285e7fe",
         "newsletter": "sha256:3700d8ab630710a2a7c25ebaafe79a89022570776f7c8baaa9cddd0c648b728c",


### PR DESCRIPTION
Hermes på nordbrygg (MJP-demon 2026-09-08) fick 'Invalid or expired API key'
mitt i en körning med sex parallella anrop och drog slutsatsen att nyckeln
återkallats. Nyckeln var giltig hela tiden: authenticateApiKey svarade
valid:false på ALLA fel från api_keys-uppslaget, även pooler-/PostgREST-hickor.
Nu: PGRST116 (ingen rad) = ogiltig (401 som förut); andra fel får en tyst
retry och rapporteras annars som 503 + Retry-After med texten 'din nyckel
avvisades INTE — försök igen'. En agent ska aldrig få en dom över nyckeln
för att databasen var långsam.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
