### PR TITLE
ci: nattsyncen 01:23 UTC — GitHub sköt 02:30 fem timmar in i arbetsdagen två nätter i rad

### DIFF
--- a/.github/workflows/nightly-fork-sync.yml
+++ b/.github/workflows/nightly-fork-sync.yml
@@ -18,7 +18,13 @@ name: Nightly fork sync
 
 on:
   schedule:
-    - cron: '30 2 * * *'
+    # 01:23 UTC, deliberately off the :00/:30 marks. GitHub queues scheduled
+    # runs behind everyone else's; the first two nights on '30 2' fired at
+    # 07:21 and 07:27 UTC — five hours late, i.e. 09:20 CET, inside the
+    # working day the schedule exists to avoid. An off-peak, off-minute slot
+    # is the lever we have; if a run is still late past 05:00 UTC, dispatch it
+    # by hand before people start (gh workflow run nightly-fork-sync.yml).
+    - cron: '23 1 * * *'
   workflow_dispatch:
     inputs:
       fork:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,7 +523,7 @@ type check, correctness lint, the ESLint ratchet (findings may only shrink — `
 lint:ratchet`, baseline in src/lib/__tests__/fixtures/eslint-baseline.json), 3900
 unit/guardrail tests, skill linter, artifact freshness, build; a single business process
 does not earn a live step on every PR. The Docker image builds on release tags only.
-**Fork syncs run once a day, at night** (`nightly-fork-sync.yml`, 02:30 UTC): a sync is
+**Fork syncs run once a day, at night** (`nightly-fork-sync.yml`, 01:23 UTC): a sync is
 a production deploy, and deploying six times in an evening while an operator works
 is how "sometimes I get errors in the project view" happens (optic, 2026-09-04).
 Fleet-only workflows (docker image, release, main-red alert, MCP regression) carry

--- a/docs/operators/provisioning-and-updates.md
+++ b/docs/operators/provisioning-and-updates.md
@@ -76,7 +76,7 @@ because that determines how a change reaches it:
   the auto-deploy above points at ONE ref. Point it at prod, or extend it to a
   matrix, only deliberately.
 - **Fork syncs happen ONCE a day, at night.** `.github/workflows/nightly-fork-sync.yml`
-  runs `scripts/sync-forks.sh` at 02:30 UTC with per-fork tokens from the
+  runs `scripts/sync-forks.sh` at 01:23 UTC with per-fork tokens from the
   upstream repo's secrets (`FORK_TOKEN_<FORK>`) and repo variables
   (`FORK_REPO_<FORK>`; GitHub reserves the `GITHUB_` prefix). A sync is a production deploy on that instance, and
   every deploy invalidates the chunks a signed-in operator already has loaded:


### PR DESCRIPTION
Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
