### PR TITLE
fix(projects): beroendeväljaren läser alla projekts uppgifter — hooken den importerade var avstängd utan projekt-id

### DIFF
--- a/src/components/admin/projects/TaskEditDialog.tsx
+++ b/src/components/admin/projects/TaskEditDialog.tsx
@@ -10,9 +10,9 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Bot, CheckCircle2, HelpCircle, Loader2, MessageSquare, Plus, Send, X } from "lucide-react";
 import { toast } from "sonner";
 import { useAuth } from "@/hooks/useAuth";
-import { useProjects } from "@/hooks/useProjects";
 import {
-  useProjectTasks,
+  useAllProjectTasks,
+  useProjects,
   useUpdateProjectTask,
   type ProjectTask,
 } from "@/hooks/useProjects";
@@ -46,7 +46,7 @@ export function TaskEditDialog({
   // Every active project's tasks, not only this one's: a dependency may
   // cross projects (the ledger close in Ekonomi gates the data room in
   // Finansiering). Titles from other projects carry the project name.
-  const { data: allTasks } = useProjectTasks();
+  const { data: allTasks } = useAllProjectTasks();
   const { data: projects } = useProjects();
   const { data: deps } = useTaskDependencies(task.id, projectId);
   const depMut = useManageDependency();

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -68,6 +68,28 @@ export function useProjectTasks(projectId?: string) {
   });
 }
 
+/**
+ * Every task across every project the user can see. The dependency picker
+ * needs this since edges may cross projects (2026-09-08); the per-project
+ * hook above is `enabled: !!projectId` and returns NOTHING when called
+ * without an id — which is exactly what the picker did for a day (badge
+ * showed an id prefix, candidate list empty, every dependency read as
+ * "done"). Keep the two apart by name so the gate cannot be tripped again.
+ */
+export function useAllProjectTasks() {
+  return useQuery({
+    queryKey: ["project_tasks", "all"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("project_tasks")
+        .select("*")
+        .order("sort_order");
+      if (error) throw error;
+      return data as ProjectTask[];
+    },
+  });
+}
+
 export function useCreateProject() {
   const qc = useQueryClient();
   return useMutation({
@@ -93,7 +115,7 @@ export function useCreateProjectTask() {
       return data;
     },
     onSuccess: (_, variables) => {
-      qc.invalidateQueries({ queryKey: ["project_tasks", variables.project_id] });
+      qc.invalidateQueries({ queryKey: ["project_tasks"] });
       qc.invalidateQueries({ queryKey: ["project_task_stats"] });
       toast.success("Task added");
     },
@@ -110,7 +132,7 @@ export function useUpdateProjectTask() {
       return project_id;
     },
     onSuccess: (projectId) => {
-      qc.invalidateQueries({ queryKey: ["project_tasks", projectId] });
+      qc.invalidateQueries({ queryKey: ["project_tasks"] });
       qc.invalidateQueries({ queryKey: ["project_task_stats"] });
     },
     onError: (e: Error) => toast.error(e.message),
@@ -161,7 +183,7 @@ export function useDeleteProjectTask() {
       return project_id;
     },
     onSuccess: (projectId) => {
-      qc.invalidateQueries({ queryKey: ["project_tasks", projectId] });
+      qc.invalidateQueries({ queryKey: ["project_tasks"] });
       qc.invalidateQueries({ queryKey: ["project_task_stats"] });
       toast.success("Task deleted");
     },


### PR DESCRIPTION
#500 lät beroenden korsa projekt och bytte väljarens källa till 'alla
uppgifter' via useProjectTasks() utan id. Men TaskEditDialog importerar
useProjectTasks från hooks/useProjects.ts, som är enabled: !!projectId — utan
id returnerar den ingenting. Peter på optic fick en badge med id-prefix i
stället för titel, tom kandidatlista och varje beroende visat som 'done'
(2026-09-09). Nu en egen hook, useAllProjectTasks, med eget namn så grinden
inte kan trampas på igen; mutationer invaliderar prefixet project_tasks så
även alla-listan uppdateras.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
