### PR TITLE
feat(projects): uppgifter i delad vy — lista till vänster, den öppna uppgiften till höger

### DIFF
--- a/src/components/admin/projects/TaskEditDialog.tsx
+++ b/src/components/admin/projects/TaskEditDialog.tsx
@@ -7,7 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Bot, CheckCircle2, HelpCircle, Loader2, MessageSquare, Plus, Send, X } from "lucide-react";
+import { ArrowUpRight, Bot, CheckCircle2, HelpCircle, Loader2, MessageSquare, Plus, Send, X } from "lucide-react";
 import { toast } from "sonner";
 import { useAuth } from "@/hooks/useAuth";
 import {
@@ -32,14 +32,25 @@ import { cn } from "@/lib/utils";
  * notes, steps, questions, decisions. FlowPilot's skill calls on the task
  * ride in from the activity log, so nothing an agent did is hidden.
  */
-export function TaskEditDialog({
+/**
+ * The task card's body — form on the left, thread on the right. Rendered by
+ * TaskEditDialog (a popup, from the board) and by the split pane in TasksView
+ * (Gmail-style: list left, the open task right). One component, two frames,
+ * so the two never drift apart.
+ */
+export function TaskDetail({
   task,
   projectId,
-  onOpenChange,
+  onClose,
+  variant = "dialog",
+  onOpenProject,
 }: {
   task: ProjectTask;
   projectId: string;
-  onOpenChange: (o: boolean) => void;
+  onClose: () => void;
+  /** "pane": Save keeps the task open; Close clears the selection. */
+  variant?: "dialog" | "pane";
+  onOpenProject?: (projectId: string) => void;
 }) {
   const { user, profile } = useAuth();
   const update = useUpdateProjectTask();
@@ -89,7 +100,7 @@ export function TaskEditDialog({
         estimated_hours: estHours ? Number(estHours) : null,
         checklist,
       } as any,
-      { onSuccess: () => onOpenChange(false) },
+      { onSuccess: () => { if (variant === "dialog") onClose(); else toast.success("Saved"); } },
     );
   };
 
@@ -133,20 +144,31 @@ export function TaskEditDialog({
     })),
   ].sort((x, y) => (x.at < y.at ? -1 : x.at > y.at ? 1 : 0));
 
+  const badges = (
+    <>
+      {blocking.length > 0 && <Badge variant="destructive" className="text-[10px]">blocked</Badge>}
+      {progress.total > 0 && <Badge variant="outline" className="text-[10px]">{progress.done}/{progress.total} done</Badge>}
+    </>
+  );
+
   return (
-    <Dialog open onOpenChange={onOpenChange}>
-      {/* Never wider than the window: the two-column grid used to size itself
-          from its inputs (min-content) and push the thread column past the
-          edge, leaving a horizontal scrollbar (optic, 2026-09-09). minmax(0,…)
-          lets the columns shrink; below md the thread drops under the form. */}
-      <DialogContent className="w-[calc(100vw-2rem)] max-w-4xl max-h-[90vh] overflow-y-auto overflow-x-hidden">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            Task
-            {blocking.length > 0 && <Badge variant="destructive" className="text-[10px]">blocked</Badge>}
-            {progress.total > 0 && <Badge variant="outline" className="text-[10px]">{progress.done}/{progress.total} done</Badge>}
-          </DialogTitle>
-        </DialogHeader>
+    <div className="space-y-4">
+        {variant === "pane" && (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-serif text-lg font-semibold">Task</span>
+            {badges}
+            {onOpenProject && (
+              <Button type="button" variant="link" size="sm" className="h-auto px-0 text-xs" onClick={() => onOpenProject(projectId)}>
+                Open project <ArrowUpRight className="ml-0.5 h-3 w-3" />
+              </Button>
+            )}
+          </div>
+        )}
+        {variant === "dialog" && (
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">Task {badges}</DialogTitle>
+          </DialogHeader>
+        )}
         <div className="grid gap-6 md:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
           <form onSubmit={save} className="min-w-0 space-y-4">
             <div>
@@ -230,7 +252,7 @@ export function TaskEditDialog({
             </div>
 
             <div className="flex justify-end gap-2 pt-2">
-              <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>Close</Button>
+              <Button type="button" variant="ghost" onClick={onClose}>Close</Button>
               <Button type="submit" disabled={update.isPending}>{update.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save"}</Button>
             </div>
           </form>
@@ -265,6 +287,28 @@ export function TaskEditDialog({
             </div>
           </div>
         </div>
+    </div>
+  );
+}
+
+/** The popup frame around TaskDetail — what the board opens on the pencil. */
+export function TaskEditDialog({
+  task,
+  projectId,
+  onOpenChange,
+}: {
+  task: ProjectTask;
+  projectId: string;
+  onOpenChange: (o: boolean) => void;
+}) {
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      {/* Never wider than the window: the two-column grid used to size itself
+          from its inputs (min-content) and push the thread column past the
+          edge, leaving a horizontal scrollbar (optic, 2026-09-09). minmax(0,…)
+          lets the columns shrink; below md the thread drops under the form. */}
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-4xl max-h-[90vh] overflow-y-auto overflow-x-hidden">
+        <TaskDetail task={task} projectId={projectId} onClose={() => onOpenChange(false)} variant="dialog" />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/admin/projects/TasksView.tsx
+++ b/src/components/admin/projects/TasksView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useOwnershipLens } from "@/hooks/useOwnershipLens";
@@ -6,8 +6,9 @@ import { LensToggle } from "@/components/admin/LensToggle";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { AlertTriangle, CalendarDays } from "lucide-react";
-import type { Project } from "@/hooks/useProjects";
+import { AlertTriangle, CalendarDays, PanelRightClose, PanelRightOpen } from "lucide-react";
+import { useAllProjectTasks, type Project } from "@/hooks/useProjects";
+import { TaskDetail, TaskEditDialog } from "@/components/admin/projects/TaskEditDialog";
 
 /**
  * Aktiviteter över ALLA projekt — projektledarens dagliga ingång.
@@ -28,6 +29,24 @@ type Row = {
 };
 
 const DONE = new Set(["done", "completed", "cancelled"]);
+const SPLIT_KEY = "flowwink.tasks.splitPane";
+
+/** Gmail-style split pane: list left, the open task right. Remembered per
+ *  browser; defaults on where there is room for two columns. */
+function useSplitPane() {
+  const [split, setSplit] = useState<boolean>(() => {
+    try {
+      const raw = localStorage.getItem(SPLIT_KEY);
+      if (raw === "1") return true;
+      if (raw === "0") return false;
+    } catch { /* private mode */ }
+    return typeof window !== "undefined" ? window.innerWidth >= 1024 : true;
+  });
+  useEffect(() => {
+    try { localStorage.setItem(SPLIT_KEY, split ? "1" : "0"); } catch { /* private mode */ }
+  }, [split]);
+  return [split, setSplit] as const;
+}
 
 export function TasksView({
   projects,
@@ -41,6 +60,13 @@ export function TasksView({
   // the same thing are two truths waiting to disagree.
   const { lens, uid, coveredUids } = useOwnershipLens();
   const [showDone, setShowDone] = useState(false);
+  const [split, setSplit] = useSplitPane();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [dialogId, setDialogId] = useState<string | null>(null);
+  // The full rows (brief, checklist, dates) for the open task — the list
+  // query above is deliberately thin.
+  const { data: fullTasks } = useAllProjectTasks();
+  const openTask = useMemo(() => (fullTasks ?? []).find((t) => t.id === (split ? selectedId : dialogId)) ?? null, [fullTasks, split, selectedId, dialogId]);
   const mineUids = useMemo(() => new Set([uid, ...coveredUids].filter(Boolean) as string[]), [uid, coveredUids]);
 
   const { data: tasks, isLoading } = useQuery({
@@ -101,6 +127,16 @@ export function TasksView({
             <AlertTriangle className="h-3 w-3" /> {overdueCount} overdue
           </Badge>
         )}
+        <Button
+          size="sm"
+          variant="ghost"
+          className="ml-auto gap-1.5"
+          onClick={() => setSplit((v) => !v)}
+          title={split ? "Open tasks in a popup instead" : "Show the open task beside the list"}
+        >
+          {split ? <PanelRightClose className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}
+          <span className="hidden sm:inline">{split ? "Split view" : "Popup"}</span>
+        </Button>
       </div>
 
       {isLoading ? (
@@ -110,15 +146,18 @@ export function TasksView({
           No tasks match — switch filters or create tasks inside a project.
         </p>
       ) : (
-        <div className="divide-y rounded-lg border">
+        <div className={cn("grid gap-4", split && "lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]")}>
+        <div className="divide-y rounded-lg border self-start">
           {rows.map((t) => {
             const p = byProject.get(t.project_id)!;
             const overdue = !!t.due_date && t.due_date < today && !DONE.has(t.status);
+            const active = split && selectedId === t.id;
             return (
               <button
                 key={t.id}
-                onClick={() => onOpenProject(t.project_id)}
-                className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-muted/50"
+                onClick={() => (split ? setSelectedId(t.id) : setDialogId(t.id))}
+                aria-current={active ? "true" : undefined}
+                className={cn("flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-muted/50", active && "bg-accent/60")}
               >
                 <span
                   className="h-2.5 w-2.5 shrink-0 rounded-full"
@@ -144,6 +183,28 @@ export function TasksView({
             );
           })}
         </div>
+        {split && (
+          <div className="min-w-0 rounded-lg border p-4 self-start lg:sticky lg:top-4">
+            {openTask ? (
+              <TaskDetail
+                key={openTask.id}
+                task={openTask}
+                projectId={openTask.project_id}
+                variant="pane"
+                onClose={() => setSelectedId(null)}
+                onOpenProject={onOpenProject}
+              />
+            ) : (
+              <p className="py-12 text-center text-sm text-muted-foreground">
+                Pick a task on the left — its brief, checklist, dependencies and thread open here.
+              </p>
+            )}
+          </div>
+        )}
+        </div>
+      )}
+      {!split && openTask && (
+        <TaskEditDialog task={openTask} projectId={openTask.project_id} onOpenChange={(o) => { if (!o) setDialogId(null); }} />
       )}
     </div>
   );


### PR DESCRIPTION
Magnus 2026-09-09: 'som e-post, listan till vänster och mailet till höger'
(Gmails split pane). Uppgiftskortets kropp (brief, datum, checklista,
beroenden, tråd) bryts ut till TaskDetail; TaskEditDialog blir ett tunt
popup-skal runt den så tavlan och listan aldrig glider isär. TasksView får
en toggle (PanelRight), minns valet i localStorage, default på från 1024 px.
I delad vy: klick väljer, Save behåller uppgiften öppen, Close tömmer valet,
'Open project' hoppar till tavlan. I popup-läge öppnar klick dialogen.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
