### PR TITLE
fix(ui-text): kodens default är inget operatörsord — "Blog" slog packets "Blogg" på Resta

### DIFF
--- a/src/components/chat/ChatConversation.tsx
+++ b/src/components/chat/ChatConversation.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useChat } from '@/hooks/useChat';
-import { useChatSettings } from '@/hooks/useSiteSettings';
+import { useChatSettings, defaultChatSettings } from '@/hooks/useSiteSettings';
 import { UnifiedChat } from './UnifiedChat';
 import { LiveAgentIndicator } from './LiveAgentIndicator';
 import { ChatLeadCapture } from './ChatLeadCapture';
@@ -100,7 +100,7 @@ export function ChatConversation({
     t('chat.suggestion2', 'Tell me about your services'),
     t('chat.suggestion3', 'How do I book an appointment?'),
     t('chat.suggestion4', 'How do I get in touch?'),
-  ], lang, siteLang);
+  ], lang, siteLang, defaultChatSettings.suggestedPrompts);
   // Limit prompts if needed
   const suggestedPrompts = maxPrompts
     ? localizedPrompts.slice(0, maxPrompts)
@@ -139,14 +139,14 @@ export function ChatConversation({
           onStartNew: clearMessages,
         }}
         visitorSettings={{
-          title: hideInternalTitle ? '' : (checkinId ? 'Profile Check-in' : operatorText(settings?.title, t('chat.assistantTitle', 'AI Assistant'), lang, siteLang)),
+          title: hideInternalTitle ? '' : (checkinId ? 'Profile Check-in' : operatorText(settings?.title, t('chat.assistantTitle', 'AI Assistant'), lang, siteLang, defaultChatSettings.title)),
           welcomeMessage: checkinId
             ? 'Hi! Tell me about your latest project and I\'ll update your profile. You can also use voice input 🎙️'
-            : operatorText(settings?.welcomeMessage, t('chat.welcome', 'Hi! How can I help you today?'), lang, siteLang),
+            : operatorText(settings?.welcomeMessage, t('chat.welcome', 'Hi! How can I help you today?'), lang, siteLang, defaultChatSettings.welcomeMessage),
           suggestedPrompts: checkinId
             ? ['Tell me about my latest project', 'I want to update my availability', 'What information do you need?']
             : suggestedPrompts,
-          placeholder: checkinId ? 'Tell me about your latest project...' : operatorText(settings?.placeholder, t('chat.placeholder', 'Type your message...'), lang, siteLang),
+          placeholder: checkinId ? 'Tell me about your latest project...' : operatorText(settings?.placeholder, t('chat.placeholder', 'Type your message...'), lang, siteLang, defaultChatSettings.placeholder),
           enabled: true,
           feedbackEnabled: checkinId ? false : (settings?.feedbackEnabled ?? true),
           showIcons: settings?.showChatIcons ?? true,

--- a/src/components/public/ChatWidget.tsx
+++ b/src/components/public/ChatWidget.tsx
@@ -4,7 +4,7 @@ import { operatorText } from '@/lib/operator-text';
 import { MessageCircle, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ChatConversation } from '@/components/chat/ChatConversation';
-import { useChatSettings } from '@/hooks/useSiteSettings';
+import { useChatSettings, defaultChatSettings } from '@/hooks/useSiteSettings';
 import { useIsModuleEnabled } from '@/hooks/useModules';
 import { useBranding } from '@/providers/BrandingProvider';
 import { useCookieConsent } from '@/components/public/CookieBanner';
@@ -118,7 +118,7 @@ export function ChatWidget() {
   const style = settings.widgetStyle || 'floating';
 
   const isPill = style === 'pill';
-  const buttonLabel = operatorText(settings.widgetButtonText, t('chat.buttonLabel', 'Chat'), lang, siteLang);
+  const buttonLabel = operatorText(settings.widgetButtonText, t('chat.buttonLabel', 'Chat'), lang, siteLang, defaultChatSettings.widgetButtonText);
 
   return (
     <div className={cn(
@@ -136,7 +136,7 @@ export function ChatWidget() {
           ref={panelRef}
           id={panelId}
           role="dialog"
-          aria-label={operatorText(settings.title, t('chat.assistantTitle', 'AI Assistant'), lang, siteLang)}
+          aria-label={operatorText(settings.title, t('chat.assistantTitle', 'AI Assistant'), lang, siteLang, defaultChatSettings.title)}
           className={cn(
             'absolute bottom-16 mb-2',
             size.width, size.height,
@@ -151,7 +151,7 @@ export function ChatWidget() {
           <div className="flex items-center justify-between px-4 py-3 border-b bg-primary/5 shrink-0">
             <div className="flex items-center gap-2 min-w-0">
               <MessageCircle className="h-4 w-4 text-primary shrink-0" aria-hidden="true" />
-              <p className="font-medium font-serif truncate">{operatorText(settings.title, t('chat.assistantTitle', 'AI Assistant'), lang, siteLang)}</p>
+              <p className="font-medium font-serif truncate">{operatorText(settings.title, t('chat.assistantTitle', 'AI Assistant'), lang, siteLang, defaultChatSettings.title)}</p>
             </div>
             <Button
               variant="ghost"

--- a/src/components/public/CookieBanner.tsx
+++ b/src/components/public/CookieBanner.tsx
@@ -66,20 +66,21 @@ export function CookieBanner() {
   // koden bär engelskan längst ned.
   const t = useUiText();
   const { lang, siteLang } = useUiTextLanguage();
+  // Raden läses rå (ingen merge med defaults), så ingen koddefault kan nå `own`.
   const own = settings.text ?? {};
 
   // t() anropas med LITERALER, inte genom en hjälpare — katalog-generatorn
   // läser anropsplatserna, så en nyckel bakom en variabel blir osynlig i
   // besökartext-editorn. Det gick jag på en gång redan med bloggänken.
   const text: BannerText = {
-    title: operatorText(own.title, t('cookie.title', 'We use cookies'), lang, siteLang),
-    description: operatorText(own.description, t('cookie.description', 'We use cookies for essential site functions, anonymous analytics, and — when you allow it — to help our sales team understand your interests. You choose what to allow.'), lang, siteLang),
-    customize: operatorText(own.customize, t('cookie.customize', 'Customize'), lang, siteLang),
-    acceptAll: operatorText(own.acceptAll, t('cookie.acceptAll', 'Accept all'), lang, siteLang),
-    essentialOnly: operatorText(own.essentialOnly, t('cookie.essentialOnly', 'Essential only'), lang, siteLang),
-    preferencesTitle: operatorText(own.preferencesTitle, t('cookie.preferencesTitle', 'Cookie preferences'), lang, siteLang),
-    back: operatorText(own.back, t('cookie.back', 'Back'), lang, siteLang),
-    saveSelection: operatorText(own.saveSelection, t('cookie.saveSelection', 'Save selection'), lang, siteLang),
+    title: operatorText(own.title, t('cookie.title', 'We use cookies'), lang, siteLang, null),
+    description: operatorText(own.description, t('cookie.description', 'We use cookies for essential site functions, anonymous analytics, and — when you allow it — to help our sales team understand your interests. You choose what to allow.'), lang, siteLang, null),
+    customize: operatorText(own.customize, t('cookie.customize', 'Customize'), lang, siteLang, null),
+    acceptAll: operatorText(own.acceptAll, t('cookie.acceptAll', 'Accept all'), lang, siteLang, null),
+    essentialOnly: operatorText(own.essentialOnly, t('cookie.essentialOnly', 'Essential only'), lang, siteLang, null),
+    preferencesTitle: operatorText(own.preferencesTitle, t('cookie.preferencesTitle', 'Cookie preferences'), lang, siteLang, null),
+    back: operatorText(own.back, t('cookie.back', 'Back'), lang, siteLang, null),
+    saveSelection: operatorText(own.saveSelection, t('cookie.saveSelection', 'Save selection'), lang, siteLang, null),
   };
 
   useEffect(() => {

--- a/src/components/public/PublicFooter.tsx
+++ b/src/components/public/PublicFooter.tsx
@@ -332,7 +332,8 @@ export function PublicFooter() {
                   to={link.url}
                   className="hover:text-primary-foreground transition-colors"
                 >
-                  {operatorText(link.label, legalPack[link.id] ?? link.label, lang, siteLang)}
+                  {operatorText(link.label, legalPack[link.id] ?? link.label, lang, siteLang,
+                    defaultFooterData.legalLinks.find((l) => l.id === link.id)?.label ?? null)}
                 </Link>
               ))}
             </div>

--- a/src/components/public/PublicNavigation.tsx
+++ b/src/components/public/PublicNavigation.tsx
@@ -16,7 +16,7 @@ import { pagePath } from '@/lib/language-path';
 import { operatorText } from '@/lib/operator-text';
 import { SandboxBanner } from '@/components/SandboxBanner';
 import { useHeaderBlock, defaultHeaderData } from '@/hooks/useGlobalBlocks';
-import { useBlogSettings, useStoreSettings, useCustomerPortalSettings, useSiteLanguages } from '@/hooks/useSiteSettings';
+import { useBlogSettings, useStoreSettings, useCustomerPortalSettings, useSiteLanguages, defaultBlogSettings } from '@/hooks/useSiteSettings';
 import { useIsModuleEnabled } from '@/hooks/useModules';
 import type { HeaderNavItem } from '@/types/cms';
 
@@ -178,11 +178,14 @@ export function PublicNavigation({ translations, currentLocale, onDarkSurface }:
   // platta baslagret i ui_text-packet. På en sida i ett annat språk får det
   // därför inte vara fallbacken, annars står "Blogg" kvar i en engelsk meny.
   // Där svarar packets overlay, och annars kodens engelska.
+  // Utan blog-rad fyller hooken i kodens 'Blog' — det är produktens engelska,
+  // inte operatörens val, och får inte slå packets "Blogg" (Resta, 2026-09-10).
   const blogLabel = operatorText(
     blogSettings?.archiveTitle,
     t('nav.blog', 'Blog'),
     currentLocale,
     siteDefaultLanguage,
+    defaultBlogSettings.archiveTitle,
   );
 
   // ── Navigationen följer besökarens språk ───────────────────────────────

--- a/src/components/public/blocks/ChatLauncherBlock.tsx
+++ b/src/components/public/blocks/ChatLauncherBlock.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowRight, Sparkles } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { useChatSettings } from '@/hooks/useSiteSettings';
+import { useChatSettings, defaultChatSettings } from '@/hooks/useSiteSettings';
 import { useIsModuleEnabled } from '@/hooks/useModules';
 import { cn } from '@/lib/utils';
 
@@ -46,7 +46,7 @@ export function ChatLauncherBlock({ data }: ChatLauncherBlockProps) {
     t('chat.suggestion2', 'Tell me about your services'),
     t('chat.suggestion3', 'How do I book an appointment?'),
     t('chat.suggestion4', 'How do I get in touch?'),
-  ], lang, siteLang).slice(0, quickActionCount);
+  ], lang, siteLang, defaultChatSettings.suggestedPrompts).slice(0, quickActionCount);
 
   const chatModuleEnabled = useIsModuleEnabled('chat');
   const isEnabled = chatModuleEnabled && chatSettings?.landingPageEnabled;

--- a/src/components/public/blocks/FormBlock.tsx
+++ b/src/components/public/blocks/FormBlock.tsx
@@ -352,7 +352,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
               onValueChange={(v) => handleFieldChange(field.id, v)}
             >
               <SelectTrigger id={field.id} className={cn(error && 'border-destructive')}>
-                <SelectValue placeholder={operatorText(field.placeholder, t('form.select', 'Select…'), lang, siteLang)} />
+                <SelectValue placeholder={operatorText(field.placeholder, t('form.select', 'Select…'), lang, siteLang, null)} />
               </SelectTrigger>
               <SelectContent>
                 {(field.options || []).map((opt) => (
@@ -457,7 +457,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
             <CardContent>
               <CheckCircle className="h-16 w-16 text-success mx-auto mb-4" />
               <p className="text-lg text-foreground whitespace-pre-line">
-                {operatorText(data.successMessage, t('form.success', 'Thank you! Your message has been sent.'), lang, siteLang)}
+                {operatorText(data.successMessage, t('form.success', 'Thank you! Your message has been sent.'), lang, siteLang, null)}
               </p>
               <Button
                 variant="outline"
@@ -502,7 +502,7 @@ export function FormBlock({ data, blockId, pageId }: FormBlockProps) {
             {t('form.sending', 'Sending…')}
           </>
         ) : (
-          operatorText(data.submitButtonText, t('form.submit', 'Send message'), lang, siteLang)
+          operatorText(data.submitButtonText, t('form.submit', 'Send message'), lang, siteLang, null)
         )}
       </Button>
     </form>

--- a/src/hooks/useSiteSettings.tsx
+++ b/src/hooks/useSiteSettings.tsx
@@ -208,7 +208,7 @@ export interface MaintenanceSettings {
   expectedEndTime?: string;
 }
 
-const defaultMaintenanceSettings: MaintenanceSettings = {
+export const defaultMaintenanceSettings: MaintenanceSettings = {
   enabled: false,
   title: 'Site under maintenance',
   message: 'We are currently performing scheduled maintenance. The site will be back online shortly.',
@@ -712,7 +712,7 @@ export interface BlogSettings {
   rssDescription: string;
 }
 
-const defaultBlogSettings: BlogSettings = {
+export const defaultBlogSettings: BlogSettings = {
   enabled: true,
   postsPerPage: 10,
   showAuthorBio: true,

--- a/src/lib/__tests__/operator-text-adoption.guardrails.test.ts
+++ b/src/lib/__tests__/operator-text-adoption.guardrails.test.ts
@@ -18,17 +18,39 @@ const read = (p: string) => readFileSync(resolve(ROOT, 'src', p), 'utf8');
  * så adoptionen ratchetas här i stället för att vara frivillig. Listan är
  * ytorna där en operatörsägd sträng möter en besökare; växer den, växer listan.
  */
-const CONSUMERS: Array<{ file: string; fields: string[] }> = [
-  { file: 'components/public/CookieBanner.tsx', fields: ['own.title', 'own.acceptAll', 'own.essentialOnly'] },
+const CONSUMERS: Array<{ file: string; fields: string[]; raw?: true }> = [
+  // Cookie-bannern läser raden RÅ (useCookieConsentSettings, ingen merge med
+  // defaults), så ingen koddefault kan nå `own` — där är `null` det ärliga svaret.
+  { file: 'components/public/CookieBanner.tsx', fields: ['own.title', 'own.acceptAll', 'own.essentialOnly'], raw: true },
   { file: 'components/public/PublicNavigation.tsx', fields: ['blogSettings?.archiveTitle'] },
   { file: 'components/public/PublicFooter.tsx', fields: ['link.label'] },
   { file: 'pages/PublicPage.tsx', fields: ['maintenanceSettings.title', 'maintenanceSettings.message'] },
   { file: 'components/chat/ChatConversation.tsx', fields: ['settings?.title', 'settings?.welcomeMessage', 'settings?.placeholder'] },
   { file: 'components/public/ChatWidget.tsx', fields: ['settings.widgetButtonText', 'settings.title'] },
+  { file: 'pages/BlogArchivePage.tsx', fields: ['blogSettings?.archiveTitle'] },
+  { file: 'pages/BlogTagPage.tsx', fields: ['blogSettings?.archiveTitle'] },
+  { file: 'pages/BlogCategoryPage.tsx', fields: ['blogSettings?.archiveTitle'] },
 ];
 
+/**
+ * Regeln måste också veta vad KODEN fyllde i. Hooken svarar
+ * `{ ...default, ...lagrat }`, så ett fält som operatören aldrig rört når
+ * komponenten som om hen valt det — och kodens 'Blog' slog packets "Blogg" på
+ * Resta Gård. Ett anrop över ett hook-fält skickar därför sin default med.
+ */
+function callText(src: string, field: string): string | null {
+  const start = src.search(new RegExp(`operatorText\\(\\s*${field.replace(/[.?*+^$[\]\\(){}|]/g, '\\$&')}\\s*,`));
+  if (start < 0) return null;
+  let depth = 0;
+  for (let i = start; i < src.length; i++) {
+    if (src[i] === '(') depth++;
+    else if (src[i] === ')' && --depth === 0) return src.slice(start, i + 1);
+  }
+  return null;
+}
+
 describe('operatorText används där en operatörssträng möter en besökare', () => {
-  for (const { file, fields } of CONSUMERS) {
+  for (const { file, fields, raw } of CONSUMERS) {
     const src = read(file);
 
     it(`${file} importerar regeln`, () => {
@@ -45,6 +67,16 @@ describe('operatorText används där en operatörssträng möter en besökare', 
         expect(
           passes.test(src),
           `${field} passerar regeln — annars visas operatörens språk på sidor i ett annat språk`,
+        ).toBe(true);
+      });
+      it(`${file}: ${field} skickar sin koddefault med`, () => {
+        const call = callText(src, field);
+        expect(call, 'anropet hittades inte').not.toBeNull();
+        // Hookens default (default…Settings / default…Data) — ett bart hook-fält
+        // utan default är exakt formen som visade "Blog" på en svensk sajt.
+        expect(
+          raw ? /,\s*null\s*\)$/.test(call!) : /default\w+(Settings|Data)\b/.test(call!),
+          `${field}: skicka hookens default som femte argument, annars räknas kodens engelska som operatörens ord`,
         ).toBe(true);
       });
 

--- a/src/lib/__tests__/operator-text.guardrails.test.ts
+++ b/src/lib/__tests__/operator-text.guardrails.test.ts
@@ -11,42 +11,69 @@ import { operatorText, operatorPrompts } from '../operator-text';
  */
 describe('bloggänkens etikett', () => {
   it('operatörens ord vinner på sajtens eget språk', () => {
-    expect(operatorText('Blogg', 'Blog', 'sv', 'sv')).toBe('Blogg');
-    expect(operatorText('Blogg', 'Blog', 'sv-SE', 'sv')).toBe('Blogg');
+    expect(operatorText('Blogg', 'Blog', 'sv', 'sv', null)).toBe('Blogg');
+    expect(operatorText('Blogg', 'Blog', 'sv-SE', 'sv', null)).toBe('Blogg');
   });
 
   it('en sida utan eget språk räknas som sajtens', () => {
-    expect(operatorText('Blogg', 'Blog', null, 'sv')).toBe('Blogg');
+    expect(operatorText('Blogg', 'Blog', null, 'sv', null)).toBe('Blogg');
   });
 
   it('på ett ANNAT språk gäller packet — aldrig operatörens ord', () => {
     // Kärnan. Utan det här står "Blogg" kvar i en engelsk meny.
-    expect(operatorText('Blogg', 'Blog', 'en', 'sv')).toBe('Blog');
-    expect(operatorText('Blogg', 'Nyheter', 'de', 'sv')).toBe('Nyheter');
+    expect(operatorText('Blogg', 'Blog', 'en', 'sv', null)).toBe('Blog');
+    expect(operatorText('Blogg', 'Nyheter', 'de', 'sv', null)).toBe('Nyheter');
   });
 
   it('utan operatörsord faller det tillbaka på packet', () => {
-    expect(operatorText(null, 'Blog', 'sv', 'sv')).toBe('Blog');
-    expect(operatorText('   ', 'Blog', 'sv', 'sv')).toBe('Blog');
+    expect(operatorText(null, 'Blog', 'sv', 'sv', null)).toBe('Blog');
+    expect(operatorText('   ', 'Blog', 'sv', 'sv', null)).toBe('Blog');
   });
 });
 
 describe('operatorPrompts — listvarianten', () => {
   const pack = ['P1', 'P2'];
   it('sajtens eget språk: operatörens lista vinner, tomma rader bort', () => {
-    expect(operatorPrompts(['Egen', '', null], pack, 'sv', 'sv')).toEqual(['Egen']);
+    expect(operatorPrompts(['Egen', '', null], pack, 'sv', 'sv', null)).toEqual(['Egen']);
   });
   it('annat språk: packet vinner även när operatören har egna', () => {
-    expect(operatorPrompts(['Egen'], pack, 'en', 'sv')).toEqual(pack);
+    expect(operatorPrompts(['Egen'], pack, 'en', 'sv', null)).toEqual(pack);
   });
   it('ingen sidkontext räknas som sajtens språk', () => {
-    expect(operatorPrompts(['Egen'], pack, null, 'sv')).toEqual(['Egen']);
+    expect(operatorPrompts(['Egen'], pack, null, 'sv', null)).toEqual(['Egen']);
   });
   it('tom operatörslista faller till packet', () => {
-    expect(operatorPrompts([], pack, 'sv', 'sv')).toEqual(pack);
-    expect(operatorPrompts(undefined, pack, 'sv', 'sv')).toEqual(pack);
+    expect(operatorPrompts([], pack, 'sv', 'sv', null)).toEqual(pack);
+    expect(operatorPrompts(undefined, pack, 'sv', 'sv', null)).toEqual(pack);
   });
   it('tomma packrader blir inga knappar', () => {
-    expect(operatorPrompts([], ['P1', ''], 'en', 'sv')).toEqual(['P1']);
+    expect(operatorPrompts([], ['P1', ''], 'en', 'sv', null)).toEqual(['P1']);
+  });
+});
+
+/**
+ * Kodens default är inget operatörsord.
+ *
+ * Hooken svarar `{ ...defaultBlogSettings, ...lagrat }`, så utan blog-rad
+ * kommer 'Blog' fram som om operatören valt det — och slog packets "Blogg" på
+ * Resta Gård (2026-09-10). Ett värde lika med defaulten räknas som frånvarande.
+ */
+describe('kodens default räknas som frånvarande', () => {
+  it('samma ord som defaulten faller till packet', () => {
+    expect(operatorText('Blog', 'Blogg', 'sv', 'sv', 'Blog')).toBe('Blogg');
+    expect(operatorText(' Blog ', 'Blogg', null, 'sv', 'Blog')).toBe('Blogg');
+  });
+  it('ett eget ord vinner fortfarande', () => {
+    expect(operatorText('Nyheter', 'Blogg', 'sv', 'sv', 'Blog')).toBe('Nyheter');
+  });
+  it('null = ingen koddefault kan nå värdet', () => {
+    expect(operatorText('Blog', 'Blogg', 'sv', 'sv', null)).toBe('Blog');
+  });
+  it('listan: defaultens förslag faller till packet, egna vinner', () => {
+    const dflt = ['What can you help me with?', 'Tell me about your services'];
+    const pack = ['Vad kan du hjälpa till med?', 'Berätta om era tjänster'];
+    expect(operatorPrompts([...dflt], pack, 'sv', 'sv', dflt)).toEqual(pack);
+    expect(operatorPrompts(['Egen fråga'], pack, 'sv', 'sv', dflt)).toEqual(['Egen fråga']);
+    expect(operatorPrompts([...dflt], pack, 'sv', 'sv', null)).toEqual(dflt);
   });
 });

--- a/src/lib/operator-text.ts
+++ b/src/lib/operator-text.ts
@@ -19,17 +19,30 @@ import { baseSubtag } from './pick-locale';
  *
  * On a page in the site's own language the operator's word beats the pack: they
  * chose it deliberately, and a generic entry should not override that.
+ *
+ * `codeDefault` is the value the settings hook fills in when the operator has
+ * saved nothing — `{ ...defaultBlogSettings, ...stored }` makes the two
+ * indistinguishable by the time they reach a component. That default is the
+ * product's English, not a choice: on Resta Gård no `blog` row existed, the
+ * hook handed the menu `archiveTitle: 'Blog'`, and because it arrived as the
+ * operator's own word it beat the Swedish pack that translate_ui_text had
+ * filled ("Blogg"). Nobody had chosen "Blog"; the code had. So a value equal
+ * to the default counts as absent, and the pack — which carries the same
+ * English at the bottom — answers. Pass `null` where no code default can
+ * reach `own` (block content, a raw row read without a merge).
  */
 export function operatorText(
   own: string | null | undefined,
   packText: string,
   currentLocale: string | null | undefined,
   siteLanguage: string,
+  codeDefault: string | null,
 ): string {
   const inSiteLanguage = !currentLocale
     || baseSubtag(currentLocale) === baseSubtag(siteLanguage);
   if (!inSiteLanguage) return packText;
   const chosen = String(own ?? '').trim();
+  if (codeDefault != null && chosen === String(codeDefault).trim()) return packText;
   return chosen || packText;
 }
 
@@ -38,17 +51,27 @@ export function operatorText(
  * site's own language, the pack's prompts on every other. One rule, three
  * chat surfaces (widget, block, launcher) — the launcher reading settings
  * directly is how Swedish quick actions reached an English page.
+ *
+ * `codeDefault` as above: a list identical to the hook's default is the
+ * product's English, not the operator's prompts, and yields to the pack.
  */
 export function operatorPrompts(
   own: ReadonlyArray<string | null | undefined> | null | undefined,
   packPrompts: string[],
   currentLocale: string | null | undefined,
   siteLanguage: string,
+  codeDefault: ReadonlyArray<string> | null,
 ): string[] {
   const cleanPack = packPrompts.filter((p) => p.trim() !== '');
   const inSiteLanguage = !currentLocale
     || baseSubtag(currentLocale) === baseSubtag(siteLanguage);
   if (!inSiteLanguage) return cleanPack;
-  const cleanOwn = (own ?? []).filter((p): p is string => !!p?.trim());
+  const cleanOwn = (own ?? []).filter((p): p is string => !!p?.trim()).map((p) => p.trim());
+  if (codeDefault) {
+    const cleanDefault = codeDefault.map((p) => p.trim()).filter(Boolean);
+    const sameAsDefault = cleanOwn.length === cleanDefault.length
+      && cleanOwn.every((p, i) => p === cleanDefault[i]);
+    if (sameAsDefault) return cleanPack;
+  }
   return cleanOwn.length ? cleanOwn : cleanPack;
 }

--- a/src/pages/BlogArchivePage.tsx
+++ b/src/pages/BlogArchivePage.tsx
@@ -1,5 +1,6 @@
 import { useSearchParams } from "react-router-dom";
-import { useUiText } from '@/lib/ui-text';
+import { useUiText, useUiTextLanguage } from '@/lib/ui-text';
+import { operatorText } from '@/lib/operator-text';
 import { Rss } from "lucide-react";
 import { Helmet } from "react-helmet-async";
 import { PublicNavigation } from "@/components/public/PublicNavigation";
@@ -9,11 +10,12 @@ import { BlogSidebar } from "@/components/public/BlogSidebar";
 import { BlogPagination } from "@/components/public/BlogPagination";
 import { Button } from "@/components/ui/button";
 import { useBlogPosts } from "@/hooks/useBlogPosts";
-import { useBlogSettings, useSeoSettings } from "@/hooks/useSiteSettings";
+import { useBlogSettings, useSeoSettings, defaultBlogSettings } from "@/hooks/useSiteSettings";
 import { usePageViewTracker } from "@/hooks/usePageViewTracker";
 
 export default function BlogArchivePage() {
   const t = useUiText();
+  const { lang, siteLang } = useUiTextLanguage();
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") || "1", 10);
   
@@ -56,8 +58,13 @@ export default function BlogArchivePage() {
      ?? behåller defaulten när inget satts, '' döljer synliga rubriken helt —
      arkivet har inget hero-block, så titeln är enda sättet den syns.
      <title>-taggen behåller alltid ett namn för SEO:ns skull. */
-  const archiveTitle = blogSettings?.archiveTitle ?? 'Blog';
-  const seoName = archiveTitle || 'Blog';
+  const archiveHidden = blogSettings?.archiveTitle === '';
+  // Samma regel som menyns bloggänk: operatörens ord på sajtens eget språk,
+  // packet på de andra — och hookens 'Blog' är kodens, inte operatörens.
+  const archiveTitle = archiveHidden ? '' : operatorText(
+    blogSettings?.archiveTitle, t('nav.blog', 'Blog'), lang, siteLang, defaultBlogSettings.archiveTitle,
+  );
+  const seoName = archiveTitle || t('nav.blog', 'Blog');
   const pageTitle = currentPage > 1
     ? `${seoName} - Page ${currentPage}`
     : seoName;

--- a/src/pages/BlogCategoryPage.tsx
+++ b/src/pages/BlogCategoryPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { useUiText } from '@/lib/ui-text';
+import { useUiText, useUiTextLanguage } from '@/lib/ui-text';
+import { operatorText } from '@/lib/operator-text';
 import { useParams, useSearchParams, Link } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import { Helmet } from "react-helmet-async";
@@ -10,11 +11,12 @@ import { BlogSidebar } from "@/components/public/BlogSidebar";
 import { BlogPagination } from "@/components/public/BlogPagination";
 import { useBlogPosts } from "@/hooks/useBlogPosts";
 import { useBlogCategory } from "@/hooks/useBlogCategories";
-import { useBlogSettings, useSeoSettings } from "@/hooks/useSiteSettings";
+import { useBlogSettings, useSeoSettings, defaultBlogSettings } from "@/hooks/useSiteSettings";
 import NotFound from "./NotFound";
 
 export default function BlogCategoryPage() {
   const t = useUiText();
+  const { lang, siteLang } = useUiTextLanguage();
   const { slug } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") || "1", 10);
@@ -61,7 +63,7 @@ export default function BlogCategoryPage() {
   return (
     <>
       <Helmet>
-        <title>{pageTitle} | {blogSettings?.archiveTitle || "Blog"} | {seoSettings?.siteTitle || "CMS"}</title>
+        <title>{pageTitle} | {operatorText(blogSettings?.archiveTitle, t('nav.blog', 'Blog'), lang, siteLang, defaultBlogSettings.archiveTitle)} | {seoSettings?.siteTitle || "CMS"}</title>
         {category.description && <meta name="description" content={category.description} />}
       </Helmet>
       

--- a/src/pages/BlogTagPage.tsx
+++ b/src/pages/BlogTagPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { useUiText } from '@/lib/ui-text';
+import { useUiText, useUiTextLanguage } from '@/lib/ui-text';
+import { operatorText } from '@/lib/operator-text';
 import { useParams, useSearchParams, Link } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import { Helmet } from "react-helmet-async";
@@ -10,11 +11,12 @@ import { BlogSidebar } from "@/components/public/BlogSidebar";
 import { BlogPagination } from "@/components/public/BlogPagination";
 import { useBlogPosts } from "@/hooks/useBlogPosts";
 import { useBlogTag } from "@/hooks/useBlogTags";
-import { useBlogSettings, useSeoSettings } from "@/hooks/useSiteSettings";
+import { useBlogSettings, useSeoSettings, defaultBlogSettings } from "@/hooks/useSiteSettings";
 import NotFound from "./NotFound";
 
 export default function BlogTagPage() {
   const t = useUiText();
+  const { lang, siteLang } = useUiTextLanguage();
   const { slug } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") || "1", 10);
@@ -61,7 +63,7 @@ export default function BlogTagPage() {
   return (
     <>
       <Helmet>
-        <title>{pageTitle} | {blogSettings?.archiveTitle || "Blog"} | {seoSettings?.siteTitle || "CMS"}</title>
+        <title>{pageTitle} | {operatorText(blogSettings?.archiveTitle, t('nav.blog', 'Blog'), lang, siteLang, defaultBlogSettings.archiveTitle)} | {seoSettings?.siteTitle || "CMS"}</title>
       </Helmet>
       
       <PublicNavigation />

--- a/src/pages/PublicPage.tsx
+++ b/src/pages/PublicPage.tsx
@@ -3,7 +3,7 @@ import { useUiText, useSetUiTextLang } from '@/lib/ui-text';
 import { pagePath } from '@/lib/language-path';
 import { buildHreflangAlternates } from '@/lib/hreflang';
 import { operatorText } from '@/lib/operator-text';
-import { useSiteLanguages } from '@/hooks/useSiteSettings';
+import { useSiteLanguages, defaultMaintenanceSettings } from '@/hooks/useSiteSettings';
 import { logger } from '@/lib/logger';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
@@ -446,6 +446,7 @@ export default function PublicPage() {
             maintenanceSettings.title,
             t('maintenance.title', 'Website is under maintenance'),
             declaredLang, siteDefaultLanguage,
+            defaultMaintenanceSettings.title,
           )}
           noIndex
         />
@@ -458,6 +459,7 @@ export default function PublicPage() {
               maintenanceSettings.title,
               t('maintenance.title', 'Website is under maintenance'),
               declaredLang, siteDefaultLanguage,
+              defaultMaintenanceSettings.title,
             )}
           </h1>
           <p className="text-muted-foreground mb-4">
@@ -465,6 +467,7 @@ export default function PublicPage() {
               maintenanceSettings.message,
               t('maintenance.message', 'We are performing scheduled maintenance. The website will be available again shortly.'),
               declaredLang, siteDefaultLanguage,
+              defaultMaintenanceSettings.message,
             )}
           </p>
           {maintenanceSettings.expectedEndTime && (


### PR DESCRIPTION
## Fyndet
Resta Gårds header visade **Blog** fast `ui_text` har "Blogg" i både baslagret och `@sv`. Orsak: ingen `blog`-rad i site_settings → hooken fyller i `defaultBlogSettings.archiveTitle = 'Blog'` → når `operatorText` som operatörens ord → slår packet på sajtens eget språk. Kodens engelska såg ut som ett val.

## Fixen
- `operatorText`/`operatorPrompts` får ett femte **obligatoriskt** argument: hookens koddefault. Lika med defaulten = frånvarande → packet svarar. `null` där ingen default kan nå värdet (cookie-bannern läser rå rad; blockinnehåll).
- Bloggens arkiv-, tagg- och kategorisidor gick inte genom regeln alls (`archiveTitle ?? 'Blog'`) — nu gör de det; `''` förblir AV-ratten.
- Adoptionsvakten kräver att varje hook-fält skickar sin default (`raw: true` = den ärliga null:en) och listar bloggsidorna.

## Verifierat
Lokalt mot Restas publika nyckel: header "Blogg", `/blog` h1 "Blogg". tsc, 82 vakttester, lint-ratchet gröna. Katalogen oförändrad (inga nya nycklar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)