### PR TITLE
fix(ui-text): besökartext som inte kan byta språk — fem ytor till på rälsen

### DIFF
--- a/src/components/public/CookieBanner.tsx
+++ b/src/components/public/CookieBanner.tsx
@@ -83,6 +83,28 @@ export function CookieBanner() {
     saveSelection: operatorText(own.saveSelection, t('cookie.saveSelection', 'Save selection'), lang, siteLang, null),
   };
 
+  /* Kategorierna är operatörsägda sedan starten och var de ENDA strängarna i
+     filen som inte gick genom regeln — tio rader under de åtta som gör det.
+     Raden läses rå, men `defaults` fyller i när den saknas helt, så kodens
+     engelska måste räknas som frånvarande (samma klass som #513). */
+  const cat = (
+    own: string, packText: string, codeDefault: string,
+  ) => operatorText(own, packText, lang, siteLang, codeDefault);
+  const categoryText = {
+    essential: {
+      label: cat(settings.categories.essential.label, t('cookie.cat.essential', 'Essential'), defaults.categories.essential.label),
+      description: cat(settings.categories.essential.description, t('cookie.cat.essentialDesc', 'Required for the site to work.'), defaults.categories.essential.description),
+    },
+    analytics: {
+      label: cat(settings.categories.analytics.label, t('cookie.cat.analytics', 'Analytics'), defaults.categories.analytics.label),
+      description: cat(settings.categories.analytics.description, t('cookie.cat.analyticsDesc', 'Anonymous measurement of page visits.'), defaults.categories.analytics.description),
+    },
+    marketing: {
+      label: cat(settings.categories.marketing.label, t('cookie.cat.marketing', 'Marketing'), defaults.categories.marketing.label),
+      description: cat(settings.categories.marketing.description, t('cookie.cat.marketingDesc', 'Personalization and signals for the sales team.'), defaults.categories.marketing.description),
+    },
+  };
+
   useEffect(() => {
     if (getConsent()) return; // already decided
     const t = setTimeout(() => setIsVisible(true), 500);
@@ -148,23 +170,23 @@ export function CookieBanner() {
 
             <CategoryRow
               id="essential"
-              label={settings.categories.essential.label}
-              description={settings.categories.essential.description}
+              label={categoryText.essential.label}
+              description={categoryText.essential.description}
               checked={true}
               disabled
               onChange={() => {}}
             />
             <CategoryRow
               id="analytics"
-              label={settings.categories.analytics.label}
-              description={settings.categories.analytics.description}
+              label={categoryText.analytics.label}
+              description={categoryText.analytics.description}
               checked={analytics}
               onChange={setAnalytics}
             />
             <CategoryRow
               id="marketing"
-              label={settings.categories.marketing.label}
-              description={settings.categories.marketing.description}
+              label={categoryText.marketing.label}
+              description={categoryText.marketing.description}
               checked={marketing}
               onChange={setMarketing}
             />

--- a/src/components/public/PublicFooter.tsx
+++ b/src/components/public/PublicFooter.tsx
@@ -5,6 +5,7 @@ import { Phone, Mail, MapPin, Clock, Facebook, Instagram, Linkedin, Twitter, You
 import { useUiText, useUiTextLanguage } from '@/lib/ui-text';
 import { operatorText } from '@/lib/operator-text';
 import { useFooterBlock, defaultFooterData } from '@/hooks/useGlobalBlocks';
+import { defaultBrandingSettings } from '@/hooks/useSiteSettings';
 import { useBranding } from '@/providers/BrandingProvider';
 import { useTheme } from 'next-themes';
 import { FooterSectionId, FooterVariant } from '@/types/cms';
@@ -55,14 +56,32 @@ export function PublicFooter() {
     privacy: t('footer.legal.privacy', 'Privacy Policy'),
     accessibility: t('footer.legal.accessibility', 'Accessibility'),
     cookies: t('footer.legal.cookies', 'Cookie Policy'),
+    // Produkten skickar dessa tre i footerns varianter (se footerVariantPresets),
+    // så de har ett stabilt namn att översätta under. Utan nyckel föll packet
+    // tillbaka på operatörens egen etikett och regeln blev en no-op.
+    terms: t('footer.legal.terms', 'Terms'),
+    security: t('footer.legal.security', 'Security'),
+    sla: t('footer.legal.sla', 'Service Level Agreement'),
   };
 
   const quickLinksHeading = t('footer.quickLinks', 'Quick Links');
   const contactHeading = t('footer.contact', 'Contact');
   const hoursHeading = t('footer.hours', 'Opening Hours');
+  /* Öppettiderna själva lämnas som de står: de är oftast siffror ("08–17"),
+     som är språklösa. Att dölja dem på ett annat språk vore sämre än att en
+     operatör som skrivit "Stängt" får sitt ord kvar. Det är ETIKETTERNA runt
+     dem som var fel — hårdkodad engelska på varje svensk sajt. */
   const phoneLink = settings?.phone?.replace(/[^+\d]/g, '') || '';
   const brandName = branding?.organizationName || 'Organization';
-  const brandTagline = branding?.brandTagline || '';
+  /* Taggraden är en hel mening under loggan, ett enda värde, skriven på
+     sajtens eget språk. Produkten har ingen egen engelska att gissa — och en
+     nyckel utan fallback vore en tom nyckel, vilket katalogvakten med rätta
+     vägrar. Därför tomt packet: på ett annat språk visas ingen rad alls,
+     hellre än en svensk mening under en engelsk sida. Att ÖVERSÄTTA den kräver
+     branding per språk, vilket är ett eget beslut. */
+  const brandTagline = operatorText(
+    branding?.brandTagline, '', lang, siteLang, defaultBrandingSettings.brandTagline,
+  );
   const brandInitial = brandName.charAt(0);
 
   // Copyright-raden stod hårdkodad på engelska under varje sida på varje
@@ -204,10 +223,10 @@ export function PublicFooter() {
             <div className="flex flex-col gap-2 text-sm text-primary-foreground/80">
               <div className="flex items-center gap-3">
                 <Clock className="h-4 w-4 flex-shrink-0" />
-                <span>Monday–Friday</span>
+                <span>{t('footer.hours.weekdays', 'Monday–Friday')}</span>
               </div>
               <p className="ml-7">{settings?.weekdayHours || '–'}</p>
-              <p className="ml-7 mt-2">Saturday–Sunday: {settings?.weekendHours || '–'}</p>
+              <p className="ml-7 mt-2">{t('footer.hours.weekend', 'Saturday–Sunday')}: {settings?.weekendHours || '–'}</p>
             </div>
           </div>
         );

--- a/src/components/public/blocks/ChatLauncherBlock.tsx
+++ b/src/components/public/blocks/ChatLauncherBlock.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useUiText, useUiTextLanguage } from '@/lib/ui-text';
-import { operatorPrompts } from '@/lib/operator-text';
+import { operatorPrompts, operatorText } from '@/lib/operator-text';
 import { useNavigate } from 'react-router-dom';
 import { ArrowRight, Sparkles } from 'lucide-react';
 import { Input } from '@/components/ui/input';
@@ -31,15 +31,28 @@ export function ChatLauncherBlock({ data }: ChatLauncherBlockProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const {
-    title = chatSettings?.title || 'What can I help you with?',
+    title: ownTitle,
     subtitle,
-    placeholder = chatSettings?.placeholder || 'Message AI Assistant...',
+    placeholder: ownPlaceholder,
     showQuickActions = true,
     quickActionCount = 4,
     variant = 'card',
   } = data;
 
   const { lang, siteLang } = useUiTextLanguage();
+
+  // Blockets egen text vinner; annars chattinställningen genom regeln, aldrig
+  // `|| 'English'` — den formen är just vad adoptionsvakten vägrar, och den satt
+  // kvar här tolv rader från operatorPrompts som redan var rättad.
+  const title = ownTitle || operatorText(
+    chatSettings?.title, t('chat.launcherTitle', 'What can I help you with?'),
+    lang, siteLang, defaultChatSettings.title,
+  );
+  const placeholder = ownPlaceholder || operatorText(
+    chatSettings?.placeholder, t('chat.launcherPlaceholder', 'Message the assistant…'),
+    lang, siteLang, defaultChatSettings.placeholder,
+  );
+
   // Samma regel som chatten: operatörens frågor på sajtens språk, packets på andra.
   const quickActions = operatorPrompts(chatSettings?.suggestedPrompts, [
     t('chat.suggestion1', 'What can you help me with?'),

--- a/src/components/public/blocks/TermsBlock.tsx
+++ b/src/components/public/blocks/TermsBlock.tsx
@@ -21,6 +21,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { supabase } from '@/integrations/supabase/client';
+import { useUiText } from '@/lib/ui-text';
+import { useVisitorDateFormat } from '@/lib/visitor-date';
 
 export interface TermsBlockData {
   title?: string;
@@ -44,6 +46,14 @@ interface TermsBlockProps {
 export function TermsBlock({ data }: TermsBlockProps) {
   const { title, subtitle, showPrint = true } = data;
   const [openId, setOpenId] = useState<string | null>(null);
+  const t = useUiText();
+  /* Datumen låg på 'sv-SE' i koden — varje instans, varje språk. Namnbärande
+     datum följer BESÖKARENS språk (docs/architecture/language.md §0). */
+  const { formatDate } = useVisitorDateFormat();
+  const printedMeta = (updatedAt: string) =>
+    t('terms.printedMeta', 'last updated {updated}, printed {printed} from the published version')
+      .replace('{updated}', formatDate(updatedAt))
+      .replace('{printed}', formatDate(new Date()));
 
   const { data: terms = [], isLoading } = useQuery({
     queryKey: ['public-terms'],
@@ -54,12 +64,12 @@ export function TermsBlock({ data }: TermsBlockProps) {
     },
   });
 
-  const printTerm = (t: PublicTerm) => {
-    const el = document.querySelector(`[data-term-body="${t.id}"]`);
+  const printTerm = (term: PublicTerm) => {
+    const el = document.querySelector(`[data-term-body="${term.id}"]`);
     const w = window.open('', '_blank', 'noopener,width=800,height=1000');
     if (!w || !el) return;
     w.document.write(`<!doctype html><html><head><meta charset="utf-8">
-      <title>${t.name}</title>
+      <title>${term.name}</title>
       <style>
         body { font-family: Georgia, 'Times New Roman', serif; max-width: 44rem; margin: 2rem auto; padding: 0 1.5rem; color: #111; line-height: 1.55; }
         .meta { font-family: system-ui, sans-serif; font-size: .75rem; color: #555; margin-top: 2.5rem; border-top: 1px solid #ccc; padding-top: .75rem; }
@@ -69,7 +79,7 @@ export function TermsBlock({ data }: TermsBlockProps) {
         blockquote { border-left: 3px solid #999; margin-left: 0; padding-left: 1rem; color: #444; }
       </style></head><body>
       ${el.innerHTML}
-      <div class="meta">${t.name} — senast uppdaterad ${new Date(t.updated_at).toLocaleDateString('sv-SE')} — utskriven ${new Date().toLocaleString('sv-SE')} från den publicerade versionen.</div>
+      <div class="meta">${term.name} — ${printedMeta(term.updated_at)}</div>
       </body></html>`);
     w.document.close();
     w.onload = () => w.print();
@@ -92,45 +102,45 @@ export function TermsBlock({ data }: TermsBlockProps) {
         </div>
       )}
       {!isLoading && terms.length === 0 && (
-        <p className="text-sm text-muted-foreground">Inga villkor är publicerade ännu.</p>
+        <p className="text-sm text-muted-foreground">{t('terms.empty', 'No terms have been published yet.')}</p>
       )}
 
-      {terms.map((t) => {
-        const open = openId === t.id;
+      {terms.map((term) => {
+        const open = openId === term.id;
         return (
-          <Card key={t.id}>
+          <Card key={term.id}>
             <CardHeader
               className="cursor-pointer select-none py-4"
-              onClick={() => setOpenId(open ? null : t.id)}
+              onClick={() => setOpenId(open ? null : term.id)}
             >
               <div className="flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2 min-w-0">
                   <FileText className="h-4 w-4 shrink-0 text-primary" />
-                  <span className="font-medium truncate">{t.name}</span>
+                  <span className="font-medium truncate">{term.name}</span>
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
                   <span className="text-xs text-muted-foreground hidden sm:inline">
-                    Uppdaterad {new Date(t.updated_at).toLocaleDateString('sv-SE')}
+                    {t('terms.updated', 'Updated')} {formatDate(term.updated_at)}
                   </span>
                   <ChevronDown className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`} />
                 </div>
               </div>
-              {t.description && !open && (
-                <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{t.description}</p>
+              {term.description && !open && (
+                <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{term.description}</p>
               )}
             </CardHeader>
             {open && (
               <CardContent className="border-t pt-6">
                 {showPrint && (
                   <div className="flex justify-end mb-4">
-                    <Button variant="outline" size="sm" className="gap-1.5" onClick={() => printTerm(t)}>
+                    <Button variant="outline" size="sm" className="gap-1.5" onClick={() => printTerm(term)}>
                       <Download className="h-4 w-4" />
-                      Spara som PDF
+                      {t('terms.savePdf', 'Save as PDF')}
                     </Button>
                   </div>
                 )}
-                <article data-term-body={t.id} className="prose prose-sm dark:prose-invert max-w-none">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{t.body_markdown}</ReactMarkdown>
+                <article data-term-body={term.id} className="prose prose-sm dark:prose-invert max-w-none">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{term.body_markdown}</ReactMarkdown>
                 </article>
               </CardContent>
             )}

--- a/src/data/ui-text-catalog.json
+++ b/src/data/ui-text-catalog.json
@@ -116,6 +116,11 @@
       "fallback": "Your Details"
     },
     {
+      "key": "breadcrumb.home",
+      "group": "breadcrumb",
+      "fallback": "Home"
+    },
+    {
       "key": "chat.assistantTitle",
       "group": "chat",
       "fallback": "AI Assistant"
@@ -169,6 +174,16 @@
       "key": "chat.feedback.thanks",
       "group": "chat",
       "fallback": "Thanks!"
+    },
+    {
+      "key": "chat.launcherPlaceholder",
+      "group": "chat",
+      "fallback": "Message the assistant…"
+    },
+    {
+      "key": "chat.launcherTitle",
+      "group": "chat",
+      "fallback": "What can I help you with?"
     },
     {
       "key": "chat.leadCapture.error",
@@ -351,6 +366,36 @@
       "fallback": "Back"
     },
     {
+      "key": "cookie.cat.analytics",
+      "group": "cookie",
+      "fallback": "Analytics"
+    },
+    {
+      "key": "cookie.cat.analyticsDesc",
+      "group": "cookie",
+      "fallback": "Anonymous measurement of page visits."
+    },
+    {
+      "key": "cookie.cat.essential",
+      "group": "cookie",
+      "fallback": "Essential"
+    },
+    {
+      "key": "cookie.cat.essentialDesc",
+      "group": "cookie",
+      "fallback": "Required for the site to work."
+    },
+    {
+      "key": "cookie.cat.marketing",
+      "group": "cookie",
+      "fallback": "Marketing"
+    },
+    {
+      "key": "cookie.cat.marketingDesc",
+      "group": "cookie",
+      "fallback": "Personalization and signals for the sales team."
+    },
+    {
       "key": "cookie.consentLabel",
       "group": "cookie",
       "fallback": "Cookie consent"
@@ -416,6 +461,16 @@
       "fallback": "Opening Hours"
     },
     {
+      "key": "footer.hours.weekdays",
+      "group": "footer",
+      "fallback": "Monday–Friday"
+    },
+    {
+      "key": "footer.hours.weekend",
+      "group": "footer",
+      "fallback": "Saturday–Sunday"
+    },
+    {
       "key": "footer.legal.accessibility",
       "group": "footer",
       "fallback": "Accessibility"
@@ -429,6 +484,21 @@
       "key": "footer.legal.privacy",
       "group": "footer",
       "fallback": "Privacy Policy"
+    },
+    {
+      "key": "footer.legal.security",
+      "group": "footer",
+      "fallback": "Security"
+    },
+    {
+      "key": "footer.legal.sla",
+      "group": "footer",
+      "fallback": "Service Level Agreement"
+    },
+    {
+      "key": "footer.legal.terms",
+      "group": "footer",
+      "fallback": "Terms"
     },
     {
       "key": "footer.quickLinks",
@@ -689,6 +759,26 @@
       "key": "sign.yourName",
       "group": "sign",
       "fallback": "Your name"
+    },
+    {
+      "key": "terms.empty",
+      "group": "terms",
+      "fallback": "No terms have been published yet."
+    },
+    {
+      "key": "terms.printedMeta",
+      "group": "terms",
+      "fallback": "last updated {updated}, printed {printed} from the published version"
+    },
+    {
+      "key": "terms.savePdf",
+      "group": "terms",
+      "fallback": "Save as PDF"
+    },
+    {
+      "key": "terms.updated",
+      "group": "terms",
+      "fallback": "Updated"
     }
   ]
 }

--- a/src/hooks/useSiteSettings.tsx
+++ b/src/hooks/useSiteSettings.tsx
@@ -119,7 +119,7 @@ export interface BrandingSettings {
   defaultTheme?: 'light' | 'dark' | 'system';
 }
 
-const defaultBrandingSettings: BrandingSettings = {
+export const defaultBrandingSettings: BrandingSettings = {
   logo: '',
   logoDark: '',
   favicon: '',

--- a/src/lib/__tests__/fixtures/hardcoded-visitor-text-baseline.json
+++ b/src/lib/__tests__/fixtures/hardcoded-visitor-text-baseline.json
@@ -9,7 +9,6 @@
   "src/components/public/blocks/BookingBlock.tsx": 5,
   "src/components/public/blocks/CartBlock.tsx": 3,
   "src/components/public/blocks/CategoryNavBlock.tsx": 1,
-  "src/components/public/blocks/ChatLauncherBlock.tsx": 2,
   "src/components/public/blocks/ConsultantMatcherBlock.tsx": 4,
   "src/components/public/blocks/FeaturedCarouselBlock.tsx": 3,
   "src/components/public/blocks/FeaturedProductBlock.tsx": 2,

--- a/src/lib/__tests__/operator-text-adoption.guardrails.test.ts
+++ b/src/lib/__tests__/operator-text-adoption.guardrails.test.ts
@@ -22,11 +22,14 @@ const CONSUMERS: Array<{ file: string; fields: string[]; raw?: true }> = [
   // Cookie-bannern läser raden RÅ (useCookieConsentSettings, ingen merge med
   // defaults), så ingen koddefault kan nå `own` — där är `null` det ärliga svaret.
   { file: 'components/public/CookieBanner.tsx', fields: ['own.title', 'own.acceptAll', 'own.essentialOnly'], raw: true },
+  // Footern: taggraden och öppettiderna är operatörsägd prosa på VARJE sida.
+  { file: 'components/public/PublicFooter.tsx', fields: ['branding?.brandTagline'] },
   { file: 'components/public/PublicNavigation.tsx', fields: ['blogSettings?.archiveTitle'] },
   { file: 'components/public/PublicFooter.tsx', fields: ['link.label'] },
   { file: 'pages/PublicPage.tsx', fields: ['maintenanceSettings.title', 'maintenanceSettings.message'] },
   { file: 'components/chat/ChatConversation.tsx', fields: ['settings?.title', 'settings?.welcomeMessage', 'settings?.placeholder'] },
   { file: 'components/public/ChatWidget.tsx', fields: ['settings.widgetButtonText', 'settings.title'] },
+  { file: 'components/public/blocks/ChatLauncherBlock.tsx', fields: ['chatSettings?.title', 'chatSettings?.placeholder'] },
   { file: 'pages/BlogArchivePage.tsx', fields: ['blogSettings?.archiveTitle'] },
   { file: 'pages/BlogTagPage.tsx', fields: ['blogSettings?.archiveTitle'] },
   { file: 'pages/BlogCategoryPage.tsx', fields: ['blogSettings?.archiveTitle'] },

--- a/src/lib/__tests__/public-chrome.guardrails.test.ts
+++ b/src/lib/__tests__/public-chrome.guardrails.test.ts
@@ -63,6 +63,21 @@ describe('cookie banner copy is data, not code', () => {
     expect(src).toContain('operatorText(own.title');
     expect(src).toContain('operatorText(own.acceptAll');
   });
+
+  /**
+   * Kategorierna låg tio rader under de åtta text-fälten och gick INTE genom
+   * regeln — de äldsta operatörsägda strängarna i filen, och de sista kvar.
+   */
+  it('cookie-bannerns kategorier går genom regeln', () => {
+    const src = readFileSync(resolve(__dirname, '../../components/public/CookieBanner.tsx'), 'utf8');
+    for (const cat of ['essential', 'analytics', 'marketing']) {
+      expect(
+        src.includes(`categoryText.${cat}.label`) && src.includes(`categoryText.${cat}.description`),
+        `${cat} skickas rått till CategoryRow — operatörens språk visas då på alla språk`,
+      ).toBe(true);
+      expect(src).not.toContain(`settings.categories.${cat}.label}`);
+    }
+  });
 });
 
 describe('hero background video is decor, not a player', () => {

--- a/src/pages/PublicPage.tsx
+++ b/src/pages/PublicPage.tsx
@@ -564,8 +564,10 @@ export default function PublicPage() {
   });
   
   // Build breadcrumbs for structured data
+  // Strukturerad data är det Google skriver ut under träffen. Ordet stod på
+  // svenska i koden, på varje instans och varje språk.
   const breadcrumbs = [
-    { name: 'Hem', url: baseUrl }
+    { name: t('breadcrumb.home', 'Home'), url: baseUrl }
   ];
   if (pageSlug !== homepageSlug) {
     breadcrumbs.push({ name: pageData.title, url: canonicalUrl });


### PR DESCRIPTION
Uppföljning på #513. Ett svep efter samma form: en sträng som möter en besökare men bara har **ett** värde, eller som är hårdkodad på ett språk.

## Rättat
| Yta | Vad var fel |
|---|---|
| `ChatLauncherBlock` | `chatSettings?.title \|\| 'What can I help you with?'` — exakt formen adoptionsvakten finns för, tolv rader från `operatorPrompts` som redan var rättad. Filen stod inte i vaktens lista. |
| Cookie-bannerns kategorier | Etikett + beskrivning ×3 gick rått till `CategoryRow`, tio rader under de åtta fält som ligger på rälsen. |
| Footerns juridiska länkar | Nyckel fanns för privacy/accessibility/cookies, men produkten skickar även **terms/security/sla**. Utan nyckel blev regeln en no-op. |
| Taggraden under loggan | En hel mening, ett enda värde. Visas nu bara på sajtens eget språk. |
| Öppettidernas etiketter | "Monday–Friday" hårdkodat engelska på varje svensk sajt. |
| Brödsmulans JSON-LD | Sa `"Hem"` på varje instans och varje språk. |
| `TermsBlock` | Hårdkodad **svenska** på varje instans, plus tre `toLocaleDateString('sv-SE')`. Datumen går nu genom besökardatum-rälsen. |

## Vakter
Adoptionslistan får chattlanseraren och footerns taggrad. `public-chrome` får en egen kontroll att kategorierna inte skickas rått. Besökartext-baslinjen krymper med chattlanserarens två strängar.

## Medvetet utanför
Footerns snabblänkar lokaliseras inte alls (renderar båda språkens sidor på en tvåspråkig sajt), mega-menyns beskrivningar har inget språklager, och produkter/kategorier/blogg saknar språkdimension. Tre datamodellbeslut, inte rättelser.

## Verifierat
tsc, ratchet 3544, hela vitest-batteriet: samma fem env-beroende fel som ren main (live-DB utan lokala nycklar), inga nya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)