### PR TITLE
fix(public): kakrutan täckte mobilmenyn — halva menyn gick inte att nå

### DIFF
--- a/src/components/public/CookieBanner.tsx
+++ b/src/components/public/CookieBanner.tsx
@@ -122,7 +122,14 @@ export function CookieBanner() {
   return (
     <div
       className={cn(
-        'fixed bottom-0 left-0 right-0 z-50 p-4 md:p-6 bg-card border-t shadow-lg animate-fade-in'
+        /* z-40, INTE z-50: allt annat fixerat på den publika ytan ligger på
+           z-50 — headern, mobilmenyns paneler, chattwidgeten, popup-blocken —
+           så ordningen avgjordes av DOM-ordning, och bannern renderas sist.
+           På en telefon lade den sig därför över den meny besökaren just
+           öppnat: halva menyn gick inte att nå förrän man svarat på kakrutan.
+           En panel besökaren själv öppnat ska ligga överst. Bannern syns
+           fortfarande — den ligger kvar över sidans innehåll. */
+        'fixed bottom-0 left-0 right-0 z-40 p-4 md:p-6 bg-card border-t shadow-lg animate-fade-in'
       )}
       role="dialog"
       aria-label={t('cookie.consentLabel', 'Cookie consent')}

--- a/src/lib/__tests__/public-overlay-stacking.guardrails.test.ts
+++ b/src/lib/__tests__/public-overlay-stacking.guardrails.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const read = (p: string) => readFileSync(resolve(__dirname, '../..', p), 'utf8');
+
+/**
+ * Vem ligger över vem på den publika ytan.
+ *
+ * Varje fixerad yta stod på `z-50` — headern, mobilmenyns tre paneler,
+ * chattwidgeten, popup-blocken OCH kakrutan. Med samma nivå avgör DOM-ordning,
+ * och kakrutan renderas sist: på en telefon lade den sig över den meny
+ * besökaren just öppnat, så de nedre grupperna inte gick att nå förrän man
+ * svarat (Resta, 2026-09-10, verifierat på 375 px).
+ *
+ * Regeln är enkel och räcker: det besökaren SJÄLV öppnat ligger överst,
+ * passiva band under. Vakten pinnar just den ordningen — den räknar inte upp
+ * varje yta, den läser de två som krockade.
+ */
+describe('publika överlagers ordning', () => {
+  it('kakrutan ligger UNDER mobilmenyn', () => {
+    const banner = read('components/public/CookieBanner.tsx');
+    const bannerZ = banner.match(/fixed bottom-0 left-0 right-0 (z-\[?\d+\]?)/)?.[1];
+    expect(bannerZ, 'hittade inte kakrutans z-klass').toBeTruthy();
+    expect(
+      bannerZ,
+      'kakrutan får inte ligga på samma nivå som menyn — då avgör DOM-ordning och bannern vinner',
+    ).toBe('z-40');
+  });
+
+  it('mobilmenyns paneler ligger kvar på z-50', () => {
+    const nav = read('components/public/PublicNavigation.tsx');
+    const panels = nav.match(/fixed inset-0 top-0 left-0 z-50|fixed inset-y-0 right-0 z-50/g) ?? [];
+    expect(panels.length, 'mobilpanelerna ska ligga över kakrutan').toBe(2);
+  });
+});


### PR DESCRIPTION
Hittat när jag provkörde mega-menyn på telefon (375 px) på Resta, efter #512.

## Felet
Varje fixerad yta på den publika sajten står på `z-50` — headern, mobilmenyns tre paneler, chattwidgeten, popup-blocken **och kakrutan**. Med samma nivå avgör DOM-ordning, och bannern renderas sist. Den lade sig alltså över den meny besökaren just öppnat: grupperna "Köp", "Upplev & bo" och "Om gården" gick inte att nå förrän man svarat på kakrutan.

## Fixen
Bannern till `z-40`. Den ligger kvar över sidans innehåll, men under det besökaren själv öppnat. En vakt pinnar de två ytor som krockade.

## Kvar att avgöra
Det finns **ingen nivåskala** för publika överlager. Tolv ytor delar `z-50` och ordningen dem emellan är en slump. En namngiven skala vore rätt, men den rör varje kunds sajt och är ett designbeslut, inte en rättelse — därför inte med här.

🤖 Generated with [Claude Code](https://claude.com/claude-code)