### PR TITLE
feat(knowledge): kunskapsluckan blir en arbetskö — och live-frågan räknas som en grund

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ const PurchaseOrdersPage = lazy(() => import("./pages/admin/PurchaseOrdersPage")
 const ManufacturingPage = lazy(() => import("./pages/admin/ManufacturingPage"));
 const SlaMonitorPage = lazy(() => import("./pages/admin/SlaMonitorPage"));
 const KnowledgeBaseAdminPage = lazy(() => import("./pages/admin/KnowledgeBasePage"));
+const KnowledgeGapsPage = lazy(() => import("./pages/admin/KnowledgeGapsPage"));
 const AnalyticsDashboardPage = lazy(() => import("./pages/admin/AnalyticsDashboardPage"));
 const BookingsPage = lazy(() => import("./pages/admin/BookingsPage"));
 const ProfilePage = lazy(() => import("./pages/admin/ProfilePage"));
@@ -387,6 +388,7 @@ const router = createBrowserRouter([
       { path: "/admin/integrations", element: <IntegrationsStatusPage /> },
       { path: "/admin/webhooks", element: <Navigate to="/admin/developer" replace /> },
       { path: "/admin/knowledge-base", element: <KnowledgeBaseAdminPage /> },
+      { path: "/admin/knowledge-base/gaps", element: <KnowledgeGapsPage /> },
       { path: "/admin/knowledge-base/new", element: <KbArticleEditorPage /> },
       { path: "/admin/knowledge-base/:id", element: <KbArticleEditorPage /> },
       { path: "/admin/flowpilot", element: <CopilotPage /> },

--- a/src/hooks/useKnowledgeGaps.ts
+++ b/src/hooks/useKnowledgeGaps.ts
@@ -1,0 +1,72 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * The knowledge gap report — what the assistant could NOT answer.
+ *
+ * The point of the loop: an agent must not invent. Only the owner knows whether
+ * dogs are allowed in the café, so a question with nothing behind it should end
+ * in "I don't know" — correct behaviour, and the strongest possible signal that
+ * a knowledge base article is missing. This report is that signal, and the KB
+ * article's Q&A shape means the visitor's own wording becomes the question.
+ *
+ * The engine is `knowledge_gap_report` (SQL). It pairs each visitor question
+ * with the next assistant answer and reads that answer's grounding receipt.
+ */
+export interface ChatGap {
+  at: string;
+  question: string;
+  state: 'ungrounded' | 'unknown' | 'unanswered';
+  conversation_id: string | null;
+  /** How the answer got its knowledge, when it had any. */
+  mode: 'retrieval' | 'fulltext' | 'skill' | 'none' | null;
+}
+
+export interface EmailGap {
+  at: string;
+  subject: string | null;
+  recipient: string | null;
+  needs_person: boolean | null;
+  thread_id: string | null;
+  state: 'ungrounded' | 'unknown' | 'grounded';
+}
+
+export interface KnowledgeGapReport {
+  success: boolean;
+  since: string;
+  days: number;
+  chat: {
+    questions: number;
+    grounded: number;
+    ungrounded: number;
+    unknown: number;
+    unanswered: number;
+    top_sources: Array<{ title: string; table: string; hits: number }>;
+    gaps: ChatGap[];
+  };
+  email: {
+    drafts: number;
+    needs_person: number;
+    ungrounded: number;
+    unknown: number;
+    gaps: EmailGap[];
+  };
+  kb: { articles: number; published: number; in_chat: number; never_cited: number };
+  reading_guide: string;
+}
+
+export function useKnowledgeGaps(days = 14, limit = 50) {
+  return useQuery({
+    queryKey: ['knowledge-gaps', days, limit],
+    queryFn: async (): Promise<KnowledgeGapReport> => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- RPC added after the generated types
+      const { data, error } = await supabase.rpc('knowledge_gap_report' as any, {
+        p_days: days,
+        p_limit: limit,
+      });
+      if (error) throw error;
+      return data as unknown as KnowledgeGapReport;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/lib/__tests__/grounding-receipt.test.ts
+++ b/src/lib/__tests__/grounding-receipt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { groundingReceipt, groundingFrame, readGroundingFrame } from '../../../supabase/functions/_shared/retrieval/receipt';
+import { groundingReceipt, groundingFrame, readGroundingFrame, withSkills } from '../../../supabase/functions/_shared/retrieval/receipt';
 
 describe('grounding receipt', () => {
   it('dedupes chunks per entity, keeps the best score first, caps at 8, and links what it can', () => {
@@ -33,5 +33,52 @@ describe('grounding receipt', () => {
     expect(readGroundingFrame(parsed)).toEqual(r);
     expect(readGroundingFrame({ choices: [{ delta: { content: 'hi' } }] })).toBeNull();
     expect(readGroundingFrame(null)).toBeNull();
+  });
+});
+
+/**
+ * Live-frågan är också en grund.
+ *
+ * Strukturerade tabeller indexeras med flit inte — de ändras varje timme, deras
+ * värde är relationen, och deras synlighet är per ANVÄNDARE (optic: 7 av 10
+ * projekt är private), inte per publiceringstillstånd. Ett projektsvar kommer
+ * därför ur en skill som frågar databasen i stunden. Utan ett eget läge
+ * rapporterade kvittot `none`, och kunskapslucke-rapporten räknade ett korrekt,
+ * färskt svar som en lucka — måttet pekade alltså ut rätt beteende som fel.
+ */
+describe('svar ur en skill', () => {
+  const chunk = { sourceTable: 'kb_articles', entityId: 'a1', title: 'Öppettider', score: 0.9 };
+
+  it('utan annan grund blir svaret ett skill-svar, och räknas som grundat', () => {
+    const r = withSkills(groundingReceipt([], 'none'), ['project_portfolio_brief']);
+    expect(r.mode).toBe('skill');
+    expect(r.grounded).toBe(true);
+    expect(r.sources.map((s) => s.title)).toEqual(['project_portfolio_brief']);
+  });
+
+  it('hämtning som redan grundat svaret behåller sitt läge — skillen läggs till', () => {
+    const r = withSkills(groundingReceipt([chunk], 'retrieval'), ['get_project_schedule']);
+    expect(r.mode).toBe('retrieval');
+    expect(r.sources.map((s) => s.title)).toContain('Öppettider');
+    expect(r.sources.map((s) => s.title)).toContain('get_project_schedule');
+  });
+
+  it('inga verktyg = kvittot rörs inte', () => {
+    const before = groundingReceipt([], 'none');
+    expect(withSkills(before, [])).toEqual(before);
+    expect(withSkills(before, ['', '  '])).toEqual(before);
+  });
+
+  it('samma skill två gånger räknas en gång', () => {
+    const r = withSkills(groundingReceipt([], 'none'), ['browse_blog', 'browse_blog']);
+    expect(r.sources).toHaveLength(1);
+  });
+
+  it('ett skill-svar överlever rundturen genom SSE-ramen', () => {
+    const r = withSkills(groundingReceipt([], 'none'), ['timesheet_summary']);
+    const frame = groundingFrame(r);
+    const parsed = readGroundingFrame(JSON.parse(frame.replace(/^data: /, '').trim()));
+    expect(parsed?.mode).toBe('skill');
+    expect(parsed?.grounded).toBe(true);
   });
 });

--- a/src/pages/admin/KbArticleEditorPage.tsx
+++ b/src/pages/admin/KbArticleEditorPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { ArrowLeft, Save, Eye, EyeOff, Sparkles, Loader2, Bold, Italic, List, ListOrdered, Quote, Heading2, Heading3, Globe, Lock } from "lucide-react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
@@ -40,7 +40,12 @@ import { slugify } from '@/lib/slugify';
 export default function KbArticleEditorPage() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const isNew = !id || id === "new";
+  /* Kommer man hit från "Unanswered questions" bär adressen besökarens EGNA
+     formulering. En KB-artikel är en fråga och ett svar, så frågan flyttas in
+     ordagrant — den som skriver ska svara, inte formulera om. */
+  const askedQuestion = isNew ? (searchParams.get("question") || "").trim() : "";
 
   const { data: categories, isLoading: categoriesLoading } = useKbCategories();
   const { data: article, isLoading: articleLoading } = useKbArticle(isNew ? "" : id || "");
@@ -73,6 +78,14 @@ export default function KbArticleEditorPage() {
   });
 
   // Load existing article
+  // Förifyll EN gång när frågan kommer med i adressen.
+  useEffect(() => {
+    if (!askedQuestion) return;
+    setFormData((prev) => (prev.question || prev.title
+      ? prev
+      : { ...prev, question: askedQuestion, title: askedQuestion.slice(0, 120) }));
+  }, [askedQuestion]);
+
   useEffect(() => {
     if (article && editor) {
       setFormData({

--- a/src/pages/admin/KnowledgeBasePage.tsx
+++ b/src/pages/admin/KnowledgeBasePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import { Plus, Folder, FileText, Search, MoreHorizontal, Pencil, Trash2, Check, X, AlertTriangle, ThumbsUp, ThumbsDown, Globe, Lock, Languages } from "lucide-react";
+import { Plus, Folder, FileText, Search, MoreHorizontal, Pencil, Trash2, Check, X, AlertTriangle, ThumbsUp, ThumbsDown, Globe, Lock, Languages, HelpCircle } from "lucide-react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useWorkingLanguage } from "@/hooks/useWorkingLanguage";
@@ -162,6 +162,13 @@ export default function KnowledgeBasePage() {
           <Button variant="outline" onClick={() => setCategoryDialogOpen(true)}>
             <Folder className="h-4 w-4 mr-2" />
             New Category
+          </Button>
+          <Button variant="outline" asChild>
+            {/* Där Anna arbetar systematiskt: vad chatten INTE kunde svara på. */}
+            <Link to="/admin/knowledge-base/gaps">
+              <HelpCircle className="mr-2 h-4 w-4" />
+              Unanswered questions
+            </Link>
           </Button>
           <Button asChild>
             <Link to="/admin/knowledge-base/new">

--- a/src/pages/admin/KnowledgeGapsPage.tsx
+++ b/src/pages/admin/KnowledgeGapsPage.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowLeft, PenLine } from 'lucide-react';
+
+import { AdminLayout } from '@/components/admin/AdminLayout';
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
+import { AdminPageContainer } from '@/components/admin/AdminPageContainer';
+import { StatCardCompact } from '@/components/admin/StatCard';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useKnowledgeGaps, type ChatGap } from '@/hooks/useKnowledgeGaps';
+
+/** What each state means, in the words a person writing articles needs. */
+const STATE_COPY: Record<ChatGap['state'], { label: string; hint: string }> = {
+  ungrounded: {
+    label: 'No source',
+    hint: 'The assistant answered without anything behind it. This is the queue that matters.',
+  },
+  unanswered: {
+    label: 'No answer',
+    hint: 'The visitor asked and the conversation ended before an answer was given.',
+  },
+  unknown: {
+    label: 'Before receipts',
+    hint: 'Answered before answers recorded their sources. Not evidence either way.',
+  },
+};
+
+function formatWhen(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+    + ' ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
+export default function KnowledgeGapsPage() {
+  const [days, setDays] = useState(14);
+  const { data, isLoading, error } = useKnowledgeGaps(days);
+
+  const chatGaps = data?.chat.gaps ?? [];
+  // "No source" first: those are the ones an article actually closes.
+  const ordered = [...chatGaps].sort((a, b) => {
+    const rank = (g: ChatGap) => (g.state === 'ungrounded' ? 0 : g.state === 'unanswered' ? 1 : 2);
+    return rank(a) - rank(b);
+  });
+
+  return (
+    <AdminLayout>
+      <AdminPageContainer>
+        <AdminPageHeader
+          title="Unanswered questions"
+          description="What visitors asked that the assistant had nothing for. Each one is an article waiting to be written."
+        >
+          <ToggleGroup
+            type="single"
+            value={String(days)}
+            onValueChange={(v) => v && setDays(Number(v))}
+            variant="outline"
+            size="sm"
+          >
+            <ToggleGroupItem value="7">7 days</ToggleGroupItem>
+            <ToggleGroupItem value="14">14 days</ToggleGroupItem>
+            <ToggleGroupItem value="30">30 days</ToggleGroupItem>
+          </ToggleGroup>
+          <Button variant="outline" asChild>
+            <Link to="/admin/knowledge-base">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Articles
+            </Link>
+          </Button>
+        </AdminPageHeader>
+
+        {error && (
+          <Card className="mb-6 border-destructive">
+            <CardContent className="pt-6 text-sm text-destructive">
+              Could not read the report: {error instanceof Error ? error.message : String(error)}
+            </CardContent>
+          </Card>
+        )}
+
+        {isLoading ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-6">
+            {[0, 1, 2, 3].map((i) => <Skeleton key={i} className="h-20" />)}
+          </div>
+        ) : data ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-6">
+            <StatCardCompact label="Questions asked" value={data.chat.questions} />
+            <StatCardCompact label="Answered from a source" value={data.chat.grounded} variant="success" />
+            <StatCardCompact label="No source" value={data.chat.ungrounded} variant="warning" />
+            <StatCardCompact label="Email drafts needing a person" value={data.email.needs_person} />
+          </div>
+        ) : null}
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Questions to answer</CardTitle>
+            <CardDescription>
+              An assistant must not invent. When a question has no source, saying so is the right
+              behaviour — and it is how you learn what to write. Writing the article turns the next
+              visitor&rsquo;s answer into a grounded one.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-3">
+                {[0, 1, 2].map((i) => <Skeleton key={i} className="h-14 w-full" />)}
+              </div>
+            ) : ordered.length === 0 ? (
+              <div className="py-10 text-center">
+                <p className="text-sm text-muted-foreground">
+                  Nothing unanswered in the last {days} days. Every question the assistant was asked
+                  rested on something.
+                </p>
+              </div>
+            ) : (
+              <ul className="divide-y">
+                {ordered.map((gap) => (
+                  <li key={`${gap.conversation_id}-${gap.at}`} className="flex flex-col gap-2 py-3 sm:flex-row sm:items-start sm:gap-4">
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium break-words">{gap.question}</p>
+                      <div className="mt-1 flex flex-wrap items-center gap-2">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Badge variant={gap.state === 'ungrounded' ? 'default' : 'secondary'}>
+                              {STATE_COPY[gap.state]?.label ?? gap.state}
+                            </Badge>
+                          </TooltipTrigger>
+                          <TooltipContent className="max-w-xs">
+                            {STATE_COPY[gap.state]?.hint}
+                          </TooltipContent>
+                        </Tooltip>
+                        <span className="text-xs text-muted-foreground">{formatWhen(gap.at)}</span>
+                      </div>
+                    </div>
+                    <Button size="sm" variant="outline" asChild className="shrink-0">
+                      {/* The visitor's own wording becomes the article's question —
+                          a KB article is a question and an answer, so the loop
+                          closes literally. */}
+                      <Link to={`/admin/knowledge-base/new?question=${encodeURIComponent(gap.question)}`}>
+                        <PenLine className="mr-2 h-4 w-4" />
+                        Write article
+                      </Link>
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+
+        {data && data.kb.never_cited > 0 && (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>Articles no answer has used</CardTitle>
+              <CardDescription>
+                {data.kb.never_cited} of {data.kb.in_chat} chat-enabled articles were named by no
+                answer in this window. Usually the article&rsquo;s question is phrased differently
+                from how people ask it — a reason to rewrite the question, not to delete the article.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        )}
+      </AdminPageContainer>
+    </AdminLayout>
+  );
+}

--- a/supabase/functions/_shared/retrieval/receipt.ts
+++ b/supabase/functions/_shared/retrieval/receipt.ts
@@ -35,8 +35,17 @@ export interface GroundingSource {
 export interface GroundingReceipt {
   /** True when at least one retrieved chunk was in the prompt. */
   grounded: boolean;
-  /** How the knowledge got into the prompt. */
-  mode: 'retrieval' | 'fulltext' | 'none';
+  /**
+   * How the knowledge got into the prompt.
+   *
+   * `skill` is a LIVE QUERY: the answer came from a skill that read the
+   * database in the moment (a project brief, an order lookup), not from the
+   * index. Structured tables are deliberately not indexed — they change hourly,
+   * their value is relational, and their visibility is per user, not per
+   * publication state. Without this mode such an answer reported `none`, and
+   * the knowledge-gap report counted a correct, fresh answer as a gap.
+   */
+  mode: 'retrieval' | 'fulltext' | 'none' | 'skill';
   chunk_count: number;
   /** One entry per distinct entity, best score first, at most 8. */
   sources: GroundingSource[];
@@ -73,7 +82,31 @@ export function groundingReceipt(
     });
   }
   const sources = [...byEntity.values()].sort((a, b) => b.score - a.score).slice(0, 8).map((x) => x.source);
-  return { grounded: mode === 'fulltext' ? true : (chunks.length > 0 && mode !== 'none'), mode, chunk_count: chunks.length, sources };
+  const groundedWithoutChunks = mode === 'fulltext' || mode === 'skill';
+  return { grounded: groundedWithoutChunks ? true : (chunks.length > 0 && mode !== 'none'), mode, chunk_count: chunks.length, sources };
+}
+
+/**
+ * The answer rests on skills that queried the database in the moment.
+ *
+ * Called when the model has run tools: the names ARE the provenance, the same
+ * way a chunk's title is. Nothing is guessed from the answer's prose — the
+ * pipeline declares what it did, which is the same contract the mail rail uses
+ * when it says an answer needs a person.
+ */
+export function withSkills(receipt: GroundingReceipt, skillNames: string[]): GroundingReceipt {
+  const names = [...new Set(skillNames.filter((n) => typeof n === 'string' && n.trim()))];
+  if (names.length === 0) return receipt;
+  const skillSources: GroundingSource[] = names.slice(0, 8).map((name) => ({
+    table: 'agent_skills', id: name, title: name,
+  }));
+  // Retrieval that already grounded the answer keeps its mode — the chunks are
+  // still what it was built on; the skills are added provenance. Only an answer
+  // with nothing else behind it becomes a skill answer.
+  if (receipt.mode === 'none') {
+    return { grounded: true, mode: 'skill', chunk_count: 0, sources: skillSources };
+  }
+  return { ...receipt, sources: [...receipt.sources, ...skillSources].slice(0, 8) };
 }
 
 /** The SSE frame the stream begins with. Existing clients ignore it (no delta). */

--- a/supabase/functions/chat-completion/index.ts
+++ b/supabase/functions/chat-completion/index.ts
@@ -3,7 +3,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { getServiceClient, getAnonClient } from '../_shared/supabase-clients.ts';
 import { loadBusinessIdentityBlock } from '../_shared/domains/business-identity-block.ts';
 import { retrieve, renderContext } from '../_shared/retrieval/index.ts';
-import { groundingReceipt, groundingFrame, withLeadingFrame, type GroundingReceipt } from '../_shared/retrieval/receipt.ts';
+import { groundingReceipt, groundingFrame, withLeadingFrame, withSkills, type GroundingReceipt } from '../_shared/retrieval/receipt.ts';
 import { embedQuery } from '../_shared/retrieval/embedder.ts';
 import { resolveAuthenticatedCustomer, buildCustomerContext, resolveCompanyMembership, buildCompanyContext } from '../_shared/customer-context.ts';
 import {
@@ -1213,6 +1213,14 @@ serve(async (req) => {
                     }
                     msgs.push({ role: 'tool', tool_call_id: tc.id, content: result });
                   }
+
+                  // The receipt goes out BEFORE the model has decided anything,
+                  // so a skill answer would have reported "no source" — and the
+                  // gap report would count a correct, fresh answer as a lucka.
+                  // Now that the tools have run, send an updated receipt naming
+                  // them; the client keeps the LAST frame it sees.
+                  receipt = withSkills(receipt, Object.values(tcMap).map((t) => t.name));
+                  await writer.write(new TextEncoder().encode(groundingFrame(receipt)));
 
                   // Recurse: pipe next iteration into same output stream
                   const nextResp = await streamIteration(msgs, iteration + 1);

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2355,7 +2355,7 @@
     },
     "edge_functions": {
       "count": 77,
-      "shared_hash": "sha256:253fb6cffc7e9f89a859e92de83391246b96bcc388191153f5b59aa2cae831c8",
+      "shared_hash": "sha256:f0382f5e1c232bb238b2783af6f7a3a177867b09b9bb008d95e1b5a07bc7dc7d",
       "functions": {
         "a2a": "sha256:0f4de74f6b9d1ac7c4b77af4bfcf1cb3ab47d56b3cfde9d62ec27071ae3551c2",
         "agent-card": "sha256:9486e3f1a5360c2d0fcfb032e24760eb337757878c51f4eeac4adf786432cddb",
@@ -2365,7 +2365,7 @@
         "automation-dispatcher": "sha256:8c04d415561f35764d0c72e7765f618497ee96a48f637f640730b805592015a7",
         "blog-rss": "sha256:dd57f6386804f1e0a4b8e0db3cdb83abc386c5790a677c7fdfe145067ae51be6",
         "browser-fetch": "sha256:762a956222c98ae99b4a361bec94c3d31fcbde6c0d96512755bd50caefa6d652",
-        "chat-completion": "sha256:e049f58b6862a2033c42af6c00f8023c810fd6c893fb76fcdb84d24c48da2972",
+        "chat-completion": "sha256:391c70b2d91cc58423073ee8a9e19a278016a900dd2905a73769153a98abd7a8",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
         "comms-send": "sha256:39dc9fde197bf59a92ae372f96263fe368238b212ad5674b299736ec1052d6b6",


### PR DESCRIPTION
Två delar av samma loop. En agent får inte hitta på: bara caféägaren vet om hundar får vara där. En fråga utan underlag ska sluta i "det vet jag inte", och just det är den starkaste signalen om att en artikel saknas.

## 1. Live-frågan är också en grund
Kvittot kände bara `retrieval`, `fulltext` och `none`. Ett svar ur en **skill** (projektbrief, orderuppslag) blev därför `none` = ogrundat, och lucke-rapporten räknade ett korrekt, färskt svar som en lucka. Måttet pekade ut rätt beteende som fel.

Nytt läge `skill` plus `withSkills()`, som lägger skill-namnen som proveniens. Hämtning som redan grundat svaret behåller sitt läge och får skillen tillagd. Ramen skickas om efter att verktygen kört, eftersom den första går ut innan modellen bestämt något; klienten behåller den sista den ser.

Varför projekt inte indexeras alls: de ändras varje timme, deras värde är relationen, och synligheten är **per användare** (optic har 7 av 10 projekt `private`), inte per publiceringstillstånd. Indexet är det delade informationsområdet; projekt nås genom skills där modulmatrisen redan vaktar.

## 2. Kön där arbetet görs
Ny sida `/admin/knowledge-base/gaps`: vad besökare frågat som assistenten inte hade något för, "utan källa" först. Knappen **Write article** bär besökarens egna formulering till redigeraren, som förifyller frågefältet. En KB-artikel är en fråga och ett svar, så loopen sluts ordagrant — den som skriver ska svara, inte formulera om.

Sidan ligger i kunskapsbasen, inte i AI chat-modulen. Chattmodulen handlar om *hur* assistenten låter; det här om vad verksamheten *vet*.

## Verifierat
Rapportens fältform matchar hookens kontrakt exakt, avläst mot Restas riktiga data, som redan har en verklig lucka: "hur mycket kostar griskött", obesvarad. tsc, ratchet 3544, hela batteriet nere på samma fem miljöberoende fel som ren main.

**Inte okulärbesiktigad:** admin-sidan ligger bakom inloggning och jag hanterar inga lösenord. Rendering och layout är alltså oprövade i webbläsare.

Kräver deploy av `chat-completion`; forkarna tar den på nattsyncen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)