### PR TITLE
feat(projects): uppgiften får en ansvarig — fältet fanns överallt utom i gränssnittet

### DIFF
--- a/src/components/admin/projects/TaskEditDialog.tsx
+++ b/src/components/admin/projects/TaskEditDialog.tsx
@@ -4,6 +4,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import { useAssignablePeople } from "@/hooks/useAssignablePeople";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -38,6 +40,9 @@ import { cn } from "@/lib/utils";
  * (Gmail-style: list left, the open task right). One component, two frames,
  * so the two never drift apart.
  */
+/** Radix Select cannot hold an empty value, so "nobody" needs a name. */
+const UNASSIGNED = "__unassigned__";
+
 export function TaskDetail({
   task,
   projectId,
@@ -59,6 +64,7 @@ export function TaskDetail({
   // Finansiering). Titles from other projects carry the project name.
   const { data: allTasks } = useAllProjectTasks();
   const { data: projects } = useProjects();
+  const { data: people = [] } = useAssignablePeople(projectId);
   const { data: deps } = useTaskDependencies(task.id, projectId);
   const depMut = useManageDependency();
   const { data: comments = [] } = useTaskComments(task.id);
@@ -70,6 +76,9 @@ export function TaskDetail({
   const [startDate, setStartDate] = useState<string>((task as any).start_date ?? "");
   const [dueDate, setDueDate] = useState<string>(task.due_date ?? "");
   const [estHours, setEstHours] = useState<string>(task.estimated_hours != null ? String(task.estimated_hours) : "");
+  // UNASSIGNED is a real choice, so it needs a value the Select can hold —
+  // an empty string is how Radix says "nothing selected", not "nobody".
+  const [assignedTo, setAssignedTo] = useState<string>(task.assigned_to ?? UNASSIGNED);
   const [checklist, setChecklist] = useState<ChecklistItem[]>(Array.isArray((task as any).checklist) ? ((task as any).checklist as ChecklistItem[]) : []);
   const [newItem, setNewItem] = useState("");
   const [pickDep, setPickDep] = useState<string>("");
@@ -98,6 +107,7 @@ export function TaskDetail({
         start_date: startDate || null,
         due_date: dueDate || null,
         estimated_hours: estHours ? Number(estHours) : null,
+        assigned_to: assignedTo === UNASSIGNED ? null : assignedTo,
         checklist,
       } as any,
       { onSuccess: () => { if (variant === "dialog") onClose(); else toast.success("Saved"); } },
@@ -199,6 +209,25 @@ export function TaskDetail({
                 <Label>Est. hours</Label>
                 <Input type="number" step="0.25" min="0" value={estHours} onChange={(e) => setEstHours(e.target.value)} />
               </div>
+            </div>
+            <div>
+              {/* The column, the skill parameter, the "Mine" filter and the
+                  capacity report all waited on this value; no screen ever set
+                  it. Optic ran 62 tasks with nobody on any of them. */}
+              <Label>Assignee</Label>
+              <Select value={assignedTo} onValueChange={setAssignedTo}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Unassigned" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={UNASSIGNED}>Unassigned</SelectItem>
+                  {people.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>
+                      {p.name}{p.isMember ? " · on this project" : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
             <div>

--- a/src/components/admin/projects/TasksView.tsx
+++ b/src/components/admin/projects/TasksView.tsx
@@ -6,6 +6,7 @@ import { LensToggle } from "@/components/admin/LensToggle";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useAssignablePeople } from "@/hooks/useAssignablePeople";
 import { AlertTriangle, CalendarDays, PanelRightClose, PanelRightOpen } from "lucide-react";
 import { useAllProjectTasks, type Project } from "@/hooks/useProjects";
 import { TaskDetail, TaskEditDialog } from "@/components/admin/projects/TaskEditDialog";
@@ -86,6 +87,10 @@ export function TasksView({
     [projects]
   );
   const today = new Date().toISOString().slice(0, 10);
+  // Namn på den som fått uppgiften. Listan är instansens personer; ingen
+  // projektfiltrering här, eftersom raderna korsar projekt.
+  const { data: people = [] } = useAssignablePeople();
+  const nameOf = new Map(people.map((x) => [x.id, x.name] as const));
 
   // "Mine" means what Magnus decided it should mean (2026-08-29): assigned to
   // me, PLUS unassigned work in projects I own. The strict reading — only what
@@ -168,7 +173,12 @@ export function TasksView({
                   <span className={cn("block truncate text-sm font-medium", DONE.has(t.status) && "line-through text-muted-foreground")}>
                     {t.title}
                   </span>
-                  <span className="block truncate text-xs text-muted-foreground">{p.name}</span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {p.name}
+                    {/* Vem som äger arbetet syns i listan — annars måste man
+                        öppna varje uppgift för att veta om någon har den. */}
+                    {t.assigned_to && nameOf.get(t.assigned_to) ? ` · ${nameOf.get(t.assigned_to)}` : ""}
+                  </span>
                 </span>
                 <Badge variant="outline" className="hidden sm:inline-flex capitalize">{t.status.replace(/_/g, " ")}</Badge>
                 {t.priority === "high" && <Badge variant="secondary" className="hidden sm:inline-flex">high</Badge>}

--- a/src/hooks/useAssignablePeople.ts
+++ b/src/hooks/useAssignablePeople.ts
@@ -1,0 +1,69 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { logger } from '@/lib/logger';
+
+export interface AssignablePerson {
+  id: string;
+  name: string;
+  email: string | null;
+  /** True when the person is a member of the project being edited. */
+  isMember: boolean;
+}
+
+/**
+ * Who a task can be given to.
+ *
+ * `project_tasks.assigned_to` existed in the schema, was read by the task
+ * list's "Mine" filter, was a parameter on `manage_project_task`, and was the
+ * whole basis of `resource_capacity_report` — but no screen ever set it. On
+ * optic that left 62 of 62 tasks unassigned, the capacity report answering with
+ * an empty list, and FlowPilot asking "who is driving this?" in a comment
+ * thread because the data could not say (2026-09-10).
+ *
+ * Members of the project come first: on a staffed project they are the likely
+ * answer. Everyone else on the instance follows, because a small team often
+ * staffs nothing and would otherwise see an empty picker — the failure this
+ * hook exists to end.
+ */
+export function useAssignablePeople(projectId?: string) {
+  return useQuery({
+    queryKey: ['assignable-people', projectId ?? 'all'],
+    queryFn: async (): Promise<AssignablePerson[]> => {
+      const { data: profiles, error } = await supabase
+        .from('profiles')
+        .select('id, full_name, email')
+        .order('full_name', { ascending: true });
+      if (error) throw error;
+
+      let memberIds = new Set<string>();
+      if (projectId) {
+        // A project with no members is the normal case, not an error — the list
+        // simply falls back to everyone. An UNREADABLE members table is a
+        // different thing, and swallowing it would silently drop the ordering
+        // with no way to tell the two apart. Degrade, but say so: the picker
+        // still works, just unsorted by membership.
+        const { data: members, error: memberErr } = await supabase
+          .from('project_members')
+          .select('user_id')
+          .eq('project_id', projectId);
+        if (memberErr) {
+          logger.warn('[assignable-people] project members unreadable — listing everyone unsorted', memberErr);
+        }
+        memberIds = new Set((members ?? []).map((m) => m.user_id).filter(Boolean) as string[]);
+      }
+
+      const people: AssignablePerson[] = (profiles ?? []).map((p) => ({
+        id: p.id,
+        name: (p.full_name || p.email || 'Unnamed').trim(),
+        email: p.email ?? null,
+        isMember: memberIds.has(p.id),
+      }));
+
+      return people.sort((a, b) => {
+        if (a.isMember !== b.isMember) return a.isMember ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}


### PR DESCRIPTION
`project_tasks.assigned_to` fanns i schemat, lästes av uppgiftslistans **"Mine"**-filter, var en parameter på `manage_project_task` och var **hela grunden** för `resource_capacity_report`. Men ingen skärm satte det någonsin.

Följden på optic, avläst i dag: **62 av 62 uppgifter utan ansvarig**, noll projektmedlemskap, kapacitetsrapporten svarar med tom lista — och FlowPilot skriver "vem driver uppföljningen?" i en kommentarstråd därför att datan inte kan säga det. Frågan var riktad åt vårt håll.

## Vad som ändras
- Personväljare i uppgiftsdialogen. Samma komponent i popup- och delad vy, eftersom `TaskDetail` delas av båda.
- Projektets medlemmar överst, instansens övriga personer under. Ett litet team bemannar ofta inga projekt, och skulle annars mötas av en tom lista — exakt det tomrum fältet finns för att avsluta.
- "Unassigned" är ett riktigt val och skriver `null`.
- Uppgiftslistan visar namnet bredvid projektnamnet, annars måste man öppna varje uppgift för att se om någon äger den.

## Inte med
**Massomtilldelning.** Peter har lagt upp 61 av 62 uppgifter, men skaparen är inte ansvarig — två kolumner, två betydelser. Att låta systemet gissa vore samma felklass som kodens "Blog" i #513.

## Noterat under bygget
Vakten om svalda läsningar fällde hooken direkt: ett oläsbart `project_members` blev tyst "inga medlemmar". Nu loggas det och listan degraderar till osorterad.

## Verifierat
tsc, ratchet 3544 (fältet är typat, inte castat), hela batteriet nere på samma fem miljöberoende fel som ren main.

**Inte okulärbesiktigad** — admin ligger bakom inloggning och jag hanterar inga lösenord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)