### PR TITLE
feat(hr): den anställda kopplas till sitt konto — ledet som aldrig satt ihop

### DIFF
--- a/src/components/admin/hr/EmployeeList.tsx
+++ b/src/components/admin/hr/EmployeeList.tsx
@@ -8,6 +8,7 @@ import { differenceInDays } from "date-fns";
 import { usePlatformFormat } from "@/hooks/usePlatformFormat";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { OnboardingPanel } from "./OnboardingPanel";
+import { useAssignablePeople } from "@/hooks/useAssignablePeople";
 
 const STATUS_COLORS: Record<string, string> = {
   active: "bg-green-100 text-green-800",
@@ -24,6 +25,11 @@ function isRecentHire(startDate: string | null): boolean {
 export function EmployeeList({ employees }: { employees: Employee[] }) {
   const [expanded, setExpanded] = useState<string | null>(null);
   const update = useUpdateEmployee();
+  /* Kontot personen loggar in med. Tidrapporteringen hänger på employees,
+     medan uppgifter och kapacitet hänger på kontot — utan den här länken går
+     timmar och arbete inte att lägga bredvid varandra, och kapacitetsrapporten
+     namngav alla "Unknown" (#519). */
+  const { data: people = [] } = useAssignablePeople();
   const { formatDate } = usePlatformFormat();
 
   if (!employees.length) {
@@ -31,6 +37,26 @@ export function EmployeeList({ employees }: { employees: Employee[] }) {
   }
 
   const nameById = new Map(employees.map((e) => [e.id, e.name]));
+  const accountName = new Map(people.map((p) => [p.id, p.name] as const));
+  /* Kontot är unikt per anställd i databasen (partiellt unikt index), så ett
+     redan taget konto visas men går inte att välja — annars möts man av ett
+     databasfel i stället för ett svar. E-postmatchningen är ett FÖRSLAG, inte
+     en automatisk koppling: en gissning som skriver sig själv är samma klass
+     som kodens "Blog" (#513). Människan bekräftar. */
+  const takenBy = new Map(
+    employees.filter((e) => e.user_id).map((e) => [e.user_id as string, e.name] as const),
+  );
+  const accountsFor = (emp: Employee) => {
+    const mail = (emp.email ?? "").trim().toLowerCase();
+    return people
+      .map((p) => ({
+        id: p.id,
+        name: p.name,
+        matchesEmail: !!mail && (p.email ?? "").trim().toLowerCase() === mail,
+        takenBy: takenBy.get(p.id) && takenBy.get(p.id) !== emp.name ? takenBy.get(p.id)! : null,
+      }))
+      .sort((a, b) => (a.matchesEmail === b.matchesEmail ? 0 : a.matchesEmail ? -1 : 1));
+  };
 
   return (
     <Table>
@@ -41,6 +67,7 @@ export function EmployeeList({ employees }: { employees: Employee[] }) {
           <TableHead>Title</TableHead>
           <TableHead>Department</TableHead>
           <TableHead>Manager</TableHead>
+          <TableHead>Account</TableHead>
           <TableHead>Type</TableHead>
           <TableHead>Start Date</TableHead>
           <TableHead>Onboarding</TableHead>
@@ -93,6 +120,30 @@ export function EmployeeList({ employees }: { employees: Employee[] }) {
                     </SelectContent>
                   </Select>
                 </TableCell>
+                <TableCell onClick={(e) => e.stopPropagation()}>
+                  <Select
+                    value={emp.user_id ?? "none"}
+                    onValueChange={(v) =>
+                      update.mutate({ id: emp.id, user_id: v === "none" ? null : v })
+                    }
+                  >
+                    <SelectTrigger className="h-8 w-[190px]">
+                      <SelectValue>
+                        {emp.user_id ? accountName.get(emp.user_id) ?? "Unknown account" : "Not linked"}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">Not linked</SelectItem>
+                      {accountsFor(emp).map((a) => (
+                        <SelectItem key={a.id} value={a.id} disabled={a.takenBy !== null}>
+                          {a.name}
+                          {a.matchesEmail ? " · same email" : ""}
+                          {a.takenBy ? ` · already ${a.takenBy}` : ""}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </TableCell>
                 <TableCell className="capitalize">{emp.employment_type.replace("_", " ")}</TableCell>
                 <TableCell>{emp.start_date ? formatDate(emp.start_date, { year: "numeric", month: "short", day: "numeric" }) : "—"}</TableCell>
                 <TableCell>
@@ -110,7 +161,8 @@ export function EmployeeList({ employees }: { employees: Employee[] }) {
               </TableRow>
               {isOpen && (
                 <TableRow key={`${emp.id}-detail`}>
-                  <TableCell colSpan={9} className="bg-muted/30">
+                  {/* Följer antalet kolumner: 9 rubriker + chevronkolumnen. */}
+                  <TableCell colSpan={10} className="bg-muted/30">
                     <div className="p-4">
                       <OnboardingPanel employeeId={emp.id} startDate={emp.start_date} />
                     </div>

--- a/src/hooks/useEmployees.ts
+++ b/src/hooks/useEmployees.ts
@@ -17,6 +17,16 @@ export type Employee = {
   emergency_contact: Record<string, unknown> | null;
   notes: string | null;
   manager_id: string | null;
+  /**
+   * The login account this person uses.
+   *
+   * The join nobody could make: time_entries hangs off employees, while task
+   * assignment and the capacity report hang off the account. Without this link
+   * a person's hours and their work cannot be put side by side — and the
+   * capacity report named everyone "Unknown" (#519). Unique where set: two
+   * employees must not claim one account.
+   */
+  user_id: string | null;
   personal_number: string | null;
   birth_date: string | null;
   created_at: string;

--- a/src/lib/__tests__/employee-list-columns.guardrails.test.ts
+++ b/src/lib/__tests__/employee-list-columns.guardrails.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Den utfällda raden måste spänna över alla kolumner.
+ *
+ * En ny kolumn läggs till i rubrikraden och i cellraden — colSpan:et längre ned
+ * glöms, och den utfällda panelen slutar en kolumn för tidigt. Det syns bara
+ * som en tom ruta i kanten, alltså precis den sorts fel ingen rapporterar.
+ * Vakten räknar rubrikerna i stället för att lita på minnet.
+ */
+describe('personallistans kolumner', () => {
+  it('colSpan matchar antalet kolumner', () => {
+    const src = readFileSync(
+      resolve(__dirname, '../../components/admin/hr/EmployeeList.tsx'),
+      'utf8',
+    );
+    const heads = src.match(/<TableHead[\s>]/g) ?? [];
+    const span = src.match(/colSpan=\{(\d+)\}/);
+    expect(heads.length, 'hittade inga kolumnrubriker').toBeGreaterThan(3);
+    expect(span, 'hittade inget colSpan').not.toBeNull();
+    expect(
+      Number(span![1]),
+      `colSpan är ${span![1]} men tabellen har ${heads.length} kolumner`,
+    ).toBe(heads.length);
+  });
+});


### PR DESCRIPTION
Tidrapporteringen hänger på `employees`, medan uppgiftstilldelning och kapacitetsrapporten hänger på **inloggningskontot**. Utan en länk går en persons timmar och en persons arbete inte att lägga bredvid varandra.

Kolumnen `employees.user_id` fanns — med ett partiellt unikt index och allt — men ingen skärm satte den. Optic: 1 anställd, 0 kopplade. Resta: 0 anställda. Samma tomma led som fick kapacitetsrapporten att svara "Unknown" i #519.

## Vad som ändras
- Personallistan får kolumnen **Account**, samma inline-väljare som chefsfältet redan använder.
- Kontot vars e-post matchar den anställdas ligger överst och märks `· same email`. Det är ett **förslag**, aldrig en automatisk koppling — en gissning som skriver sig själv är samma klass som kodens "Blog" i #513. Människan bekräftar.
- Ett konto som redan tillhör någon annan visas men går inte att välja, och säger vems det är. Utan det hade databasens unika index gett ett rått fel i stället för ett svar.

## Vakt
Den utfällda raden måste spänna över alla kolumner. Jag lade till en kolumn och `colSpan` låg kvar på nio — ett fel som bara syns som en tom ruta i kanten, alltså ett ingen rapporterar. Vakten räknar rubrikerna, och jag negativtestade den: `colSpan är 9 men tabellen har 10 kolumner`.

## Verifierat
tsc, ratchet 3544, hela batteriet nere på samma fem miljöberoende fel som ren main. **Inte okulärbesiktigad** — admin ligger bakom inloggning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)