### PR TITLE
fix(chat): chatten hängde på sitt eget kvitto — varje svar dog vid 150 s

### DIFF
--- a/src/lib/__tests__/chat-stream-no-write-before-return.guardrails.test.ts
+++ b/src/lib/__tests__/chat-stream-no-write-before-return.guardrails.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Chatten hängde på sitt eget kvitto (#510 → fix 2026-09-11).
+ *
+ * En TransformStream föds med mottryck PÅ: den första write() släpps först
+ * när läsarsidan dras, och den dras först när Response har RETURNERATS. Ett
+ * `await writer.write()` före returen väntar alltså på en läsare som inte kan
+ * finnas än. Varje chatt på varje instans hängde i exakt 150 s — körtidens
+ * väggklocka — och dog som WORKER_RESOURCE_LIMIT, som låter som minne och inte
+ * är det. Inget loggades: processen dödades före catch-blocket.
+ *
+ * Två vakter. Mekanismen bevisas i kod (så nästa person inte behöver tro på
+ * kommentaren), och FORMEN pinnas i källan: mellan att strömmen skapas och att
+ * svaret returneras får ingen skrivning inväntas utanför pumpen.
+ */
+describe('chattens utström', () => {
+  it('mekanismen: en inväntad första skrivning blockerar tills någon läser', async () => {
+    const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+    const writer = writable.getWriter();
+    const write = writer.write(new TextEncoder().encode('data: {}\n\n'));
+    const beforeReader = await Promise.race([
+      write.then(() => 'resolved'),
+      new Promise<string>((r) => setTimeout(() => r('blocked'), 150)),
+    ]);
+    expect(beforeReader, 'skrivningen får INTE släppas innan någon läser — annars vore buggen omöjlig').toBe('blocked');
+    // …och släpps i samma stund som en läsare finns (det Response ger).
+    const reader = readable.getReader();
+    const [chunk] = await Promise.all([reader.read(), write]);
+    expect(chunk.value?.length).toBeGreaterThan(0);
+  });
+
+  it('formen: ingen inväntad skrivning mellan att strömmen skapas och att svaret returneras', () => {
+    const src = readFileSync(
+      resolve(__dirname, '../../../supabase/functions/chat-completion/index.ts'),
+      'utf8',
+    );
+    const start = src.indexOf('new TransformStream<Uint8Array, Uint8Array>()');
+    const pump = src.indexOf('(async () => {', start);
+    expect(start, 'hittade inte utströmmen').toBeGreaterThan(-1);
+    expect(pump, 'hittade inte pumpen efter strömmen').toBeGreaterThan(start);
+    // Kommentarer är inte kod: förklaringen på plats nämner själva mönstret,
+    // och en vakt som läser kommentarer som kod skulle fälla sin egen rättelse.
+    const between = src.slice(start, pump)
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '');
+    expect(
+      /await\s+writer\.write\(/.test(between),
+      'en `await writer.write()` före pumpen väntar på en läsare som inte finns än — det är hängningen från #510',
+    ).toBe(false);
+  });
+});

--- a/supabase/functions/chat-completion/index.ts
+++ b/supabase/functions/chat-completion/index.ts
@@ -1089,9 +1089,14 @@ serve(async (req) => {
       // Open an output pipe — client starts receiving immediately
       const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
       const writer = writable.getWriter();
-      // First frame out: the grounding receipt (only on the first iteration —
-      // later iterations continue the same answer).
-      if (iteration === 0) await writer.write(new TextEncoder().encode(groundingFrame(receipt)));
+      // The grounding receipt is written INSIDE the pump below, never here. A
+      // TransformStream is born with backpressure on: the first write() only
+      // resolves once the readable side is pulled, and it is pulled only after
+      // this function has RETURNED the Response. An `await writer.write()`
+      // before that return therefore waits for a reader that cannot exist yet.
+      // That deadlock (#510) hung every chat on every instance for exactly
+      // 150 s — the runtime's wall-clock limit — and surfaced as
+      // WORKER_RESOURCE_LIMIT, which reads like memory and is not.
 
       // Track token usage from upstream SSE so this branch also logs to ai_usage_logs.
       let pTok = 0, cTok = 0, tTok = 0;
@@ -1121,6 +1126,11 @@ serve(async (req) => {
 
       // Process stream in background without blocking the Response
       (async () => {
+        // First frame out: the grounding receipt (only on the first iteration —
+        // later iterations continue the same answer). Safe HERE: by the time
+        // this write is serviced the Response has been returned and a reader
+        // pulls; writes are queued in order, so the frame still leads.
+        if (iteration === 0) await writer.write(new TextEncoder().encode(groundingFrame(receipt)));
         const reader = upstream.body!.getReader();
         const decoder = new TextDecoder();
         let buf = '';

--- a/supabase/seed/instance-manifest.json
+++ b/supabase/seed/instance-manifest.json
@@ -2373,7 +2373,7 @@
         "automation-dispatcher": "sha256:8c04d415561f35764d0c72e7765f618497ee96a48f637f640730b805592015a7",
         "blog-rss": "sha256:dd57f6386804f1e0a4b8e0db3cdb83abc386c5790a677c7fdfe145067ae51be6",
         "browser-fetch": "sha256:762a956222c98ae99b4a361bec94c3d31fcbde6c0d96512755bd50caefa6d652",
-        "chat-completion": "sha256:391c70b2d91cc58423073ee8a9e19a278016a900dd2905a73769153a98abd7a8",
+        "chat-completion": "sha256:14c698663a2a6ad4acfc0b80c57a0088c3356188a0e1ad31082a8085ab6b0e3d",
         "chat-stt": "sha256:b67dd50ab6cad26f061b911a366607620aca8647977b2be8d4331b2ec51c4aa6",
         "check-secrets": "sha256:e3b8a4da10f01358def2a012f7f5ed417c3896beefcdcd5f1e8bb2463aaa320a",
         "comms-send": "sha256:39dc9fde197bf59a92ae372f96263fe368238b212ad5674b299736ec1052d6b6",


### PR DESCRIPTION
Sedan #510 svarar ingen publik chatt på någon instans. Varje anrop hänger i **exakt 150 sekunder** (körtidens väggklocka) och dör som `WORKER_RESOURCE_LIMIT` — ett fel som låter som minne och inte är det. Inget loggas: processen dödas före catch-blocket. Briefingar och FlowPilot går som vanligt, för de tar inte den här vägen.

## Orsaken är en rad
Kvittot skrevs med `await writer.write()` **innan** `return new Response(readable)`. En `TransformStream` föds med mottryck på: den första skrivningen släpps först när läsarsidan dras, och den dras först när `Response` har returnerats. Skrivningen väntade på en läsare som inte kunde finnas än.

Reproducerat i tio rader utan Deno:
```
före läsare: STILL WAITING after 2s — deadlock: nobody reads yet
efter läsare: skrivningen släpptes, läste 10 bytes
```

## Fixen
Skrivningen flyttas in i pumpen, som redan skriver med en läsare på plats. Skrivningar köas i ordning, så kvittot leder fortfarande strömmen.

## Vakter
Mekanismen bevisas i kod (så nästa person inte behöver tro på kommentaren), och formen pinnas i källan: ingen inväntad skrivning mellan att strömmen skapas och att pumpen startar. Kommentarer stripas före skanning — första versionen fällde sin egen förklaring. **Negativtestad mot main.**

## Verifierat
tsc, ratchet 3544, hela batteriet på samma fem miljöberoende fel som main. `deno check`: 7 fel före, 7 efter — inte mina.

## Deploy
**Nu, inte i natt.** Nordbrygg och sandbox får den av upstreams integration vid merge — jag verifierar chatten live där först. Forkarna behöver en sync utanför schemat; Magnus avgör.

🤖 Generated with [Claude Code](https://claude.com/claude-code)