### PR TITLE
feat(projects): beroendeväljaren skalar — eget projekt först, andra bakom en rad eller en sökning

### DIFF
--- a/src/components/admin/projects/DependencyPicker.tsx
+++ b/src/components/admin/projects/DependencyPicker.tsx
@@ -1,0 +1,141 @@
+import { useMemo, useState } from "react";
+import { Check, ChevronsUpDown, FolderOpen } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+
+export interface PickableTask {
+  id: string;
+  title: string;
+  project_id: string;
+  status: string;
+}
+
+interface DependencyPickerProps {
+  /** The task being edited — never offered to itself. */
+  taskId: string;
+  projectId: string;
+  /** Every active project's tasks; the picker does the narrowing. */
+  tasks: PickableTask[];
+  projects: Array<{ id: string; name: string }>;
+  /** Already-linked prerequisites — offered nowhere, not greyed out. */
+  excludeIds: Set<string>;
+  onPick: (taskId: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Which task does this one wait for?
+ *
+ * A dependency may cross projects (since 2026-09-08), so the candidates are
+ * every open task on the instance. A flat <select> over that was 60 rows on
+ * optic with eleven projects, and cross-project links there are the
+ * exception: eight dependencies, none crossing. So the list must not pay for
+ * the exception every time.
+ *
+ * Own project is what opens. Other projects sit behind ONE row until asked
+ * for — or until the person types, because typing is asking. Done tasks stay
+ * hidden behind a toggle: waiting on something already finished is rarely the
+ * intent. What cannot be picked (self, existing links) is absent, not greyed.
+ */
+export function DependencyPicker({ taskId, projectId, tasks, projects, excludeIds, onPick, disabled }: DependencyPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [othersOpen, setOthersOpen] = useState(false);
+  const [showDone, setShowDone] = useState(false);
+
+  const nameOf = useMemo(() => new Map(projects.map((p) => [p.id, p.name] as const)), [projects]);
+  const searching = query.trim().length > 0;
+
+  const { own, others } = useMemo(() => {
+    const pickable = tasks.filter((t) => t.id !== taskId && !excludeIds.has(t.id) && (showDone || t.status !== "done"));
+    const own = pickable.filter((t) => t.project_id === projectId).sort((a, b) => a.title.localeCompare(b.title));
+    const byProject = new Map<string, PickableTask[]>();
+    for (const t of pickable) {
+      if (t.project_id === projectId) continue;
+      byProject.set(t.project_id, [...(byProject.get(t.project_id) ?? []), t]);
+    }
+    const others = [...byProject.entries()]
+      .map(([pid, list]) => ({ id: pid, name: nameOf.get(pid) ?? "…", tasks: list.sort((a, b) => a.title.localeCompare(b.title)) }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    return { own, others };
+  }, [tasks, taskId, excludeIds, showDone, projectId, nameOf]);
+
+  const otherCount = others.reduce((n, p) => n + p.tasks.length, 0);
+  const pick = (id: string) => { onPick(id); setOpen(false); setQuery(""); };
+
+  return (
+    <Popover open={open} onOpenChange={(next) => { setOpen(next); if (!next) { setQuery(""); setOthersOpen(false); } }}>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="outline" size="sm" role="combobox" aria-expanded={open} disabled={disabled}
+          className="h-8 w-full justify-between font-normal text-muted-foreground">
+          Pick a task this one waits for…
+          <ChevronsUpDown className="ml-2 h-3.5 w-3.5 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] min-w-[20rem] p-0" align="start">
+        {/* Search matches task title AND project name: "kyc" finds SBB-KYC
+            wherever it lives, "ekonomi" opens that whole project. The value
+            string is what cmdk filters on. */}
+        <Command filter={(value, search) => (value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0)}>
+          <CommandInput placeholder="Search tasks or projects…" value={query} onValueChange={setQuery} />
+          <CommandList className="max-h-72">
+            <CommandEmpty>No task matches.</CommandEmpty>
+
+            <CommandGroup heading={nameOf.get(projectId) ?? "This project"}>
+              {own.length === 0 && (
+                <div className="px-2 py-1.5 text-xs text-muted-foreground">Nothing else open in this project.</div>
+              )}
+              {own.map((t) => (
+                <CommandItem key={t.id} value={`${t.title} ${nameOf.get(projectId) ?? ""}`} onSelect={() => pick(t.id)}>
+                  <span className="truncate">{t.title}</span>
+                  <StatusMark status={t.status} />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+
+            {otherCount > 0 && (
+              <>
+                <CommandSeparator />
+                {!othersOpen && !searching ? (
+                  // One row stands for every other project until asked for.
+                  <CommandGroup>
+                    <CommandItem value="__other_projects__" onSelect={() => setOthersOpen(true)} className="text-muted-foreground">
+                      <FolderOpen className="mr-2 h-3.5 w-3.5" />
+                      Other projects ({others.length} projects, {otherCount} tasks)
+                    </CommandItem>
+                  </CommandGroup>
+                ) : (
+                  others.map((p) => (
+                    <CommandGroup key={p.id} heading={p.name}>
+                      {p.tasks.map((t) => (
+                        <CommandItem key={t.id} value={`${t.title} ${p.name}`} onSelect={() => pick(t.id)}>
+                          <span className="truncate">{t.title}</span>
+                          <StatusMark status={t.status} />
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  ))
+                )}
+              </>
+            )}
+          </CommandList>
+          <div className="flex items-center justify-between border-t px-2 py-1.5 text-xs text-muted-foreground">
+            <span>{showDone ? "Showing finished tasks" : "Finished tasks hidden"}</span>
+            <button type="button" className="underline-offset-2 hover:underline" onClick={() => setShowDone((v) => !v)}>
+              {showDone ? "Hide" : "Show"}
+            </button>
+          </div>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function StatusMark({ status }: { status: string }) {
+  if (status === "done") return <Check className="ml-auto h-3.5 w-3.5 text-muted-foreground" aria-label="Done" />;
+  if (status === "in_progress") return <Badge variant="outline" className={cn("ml-auto text-[10px]")}>in progress</Badge>;
+  return null;
+}

--- a/src/components/admin/projects/TaskEditDialog.tsx
+++ b/src/components/admin/projects/TaskEditDialog.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { useAssignablePeople } from "@/hooks/useAssignablePeople";
+import { DependencyPicker } from "./DependencyPicker";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -81,7 +82,6 @@ export function TaskDetail({
   const [assignedTo, setAssignedTo] = useState<string>(task.assigned_to ?? UNASSIGNED);
   const [checklist, setChecklist] = useState<ChecklistItem[]>(Array.isArray((task as any).checklist) ? ((task as any).checklist as ChecklistItem[]) : []);
   const [newItem, setNewItem] = useState("");
-  const [pickDep, setPickDep] = useState<string>("");
   const [note, setNote] = useState("");
   const [noteKind, setNoteKind] = useState<"comment" | "question" | "decision">("comment");
 
@@ -89,9 +89,6 @@ export function TaskDetail({
   const projectName = new Map((projects ?? []).map((p) => [p.id, p.name] as const));
   const labelFor = (t: { title: string; project_id: string }) =>
     t.project_id === projectId ? t.title : `${projectName.get(t.project_id) ?? "…"} · ${t.title}`;
-  const candidates = (allTasks ?? [])
-    .filter((t) => t.id !== task.id && !depSet.has(t.id))
-    .sort((a, b) => (a.project_id === projectId ? 0 : 1) - (b.project_id === projectId ? 0 : 1) || a.title.localeCompare(b.title));
   const byId = new Map((allTasks ?? []).map((t) => [t.id, t] as const));
   const blocking = blockedBy(deps, new Map((allTasks ?? []).map((t) => [t.id, t.status] as const)));
   const progress = checklistProgress(checklist);
@@ -118,14 +115,6 @@ export function TaskDetail({
   const persistChecklist = (next: ChecklistItem[]) => {
     setChecklist(next);
     update.mutate({ id: task.id, project_id: projectId, checklist: next } as any);
-  };
-
-  const addDep = () => {
-    if (!pickDep) return;
-    depMut.mutate(
-      { action: "add", task_id: task.id, depends_on_task_id: pickDep, project_id: projectId },
-      { onSuccess: () => setPickDep("") },
-    );
   };
 
   const postNote = async () => {
@@ -271,13 +260,17 @@ export function TaskDetail({
                   );
                 })}
               </div>
-              <div className="flex gap-2">
-                <select value={pickDep} onChange={(e) => setPickDep(e.target.value)} className="h-8 min-w-0 flex-1 rounded-md border bg-background px-2 text-sm">
-                  <option value="">Pick a task this one waits for…</option>
-                  {candidates.map((t) => <option key={t.id} value={t.id}>{labelFor(t)}</option>)}
-                </select>
-                <Button type="button" size="sm" variant="outline" className="h-8" onClick={addDep} disabled={!pickDep || depMut.isPending}>Add</Button>
-              </div>
+              {/* Picking IS adding — one step, no separate button. Own project
+                  first; other projects behind one row or a search. */}
+              <DependencyPicker
+                taskId={task.id}
+                projectId={projectId}
+                tasks={(allTasks ?? []).map((t) => ({ id: t.id, title: t.title, project_id: t.project_id, status: t.status }))}
+                projects={(projects ?? []).map((p) => ({ id: p.id, name: p.name }))}
+                excludeIds={depSet}
+                disabled={depMut.isPending}
+                onPick={(id) => depMut.mutate({ action: "add", task_id: task.id, depends_on_task_id: id, project_id: projectId })}
+              />
             </div>
 
             <div className="flex justify-end gap-2 pt-2">


### PR DESCRIPTION
Ett beroende får korsa projekt sedan 09-08, så kandidaterna är varje öppen uppgift på instansen. En platt `<select>` över det var **60 rader** på optic med elva projekt. Och korsande beroenden är där undantaget: åtta beroenden, noll som korsar. Listan ska inte betala för undantaget varje gång.

## Ny `DependencyPicker`
Popover + Command, samma primitiv som kommandopaletten.

- **Det egna projektet öppnas** — sällan mer än tio, femton rader.
- **Andra projekt bakom en rad**, "Other projects (n projekt, m uppgifter)", tills man ber om dem — eller tills man skriver, för att skriva är att be.
- **Sökningen träffar titel och projektnamn**: "kyc" hittar SBB-KYC var den än ligger, "ekonomi" visar hela det projektet.
- **Avslutade göms** bakom en växel: att vänta på något redan klart är sällan avsikten.
- **Det som inte kan väljas är frånvarande**, inte utgråat.
- **Att välja är att lägga till** — knappen "Add" och mellantillståndet försvinner.

Regeln bakom (cykel- och självkantsvägran, modulgrinden) rörs inte; bara ytan.

tsc, ratchet 3544, batteriet på samma fem miljöberoende fel som main. **Ej okulärbesiktigad** — admin bakom inloggning. Peter är rätt person att titta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)